### PR TITLE
contribute publishing automation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,7 +4,7 @@ name: Publish
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   push:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,14 @@
+# A CI configuration to auto-publish pub packages.
+
+name: Publish
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+
+jobs:
+  publish:
+    if: ${{ github.repository_owner == 'dart-lang' }}
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is home to tooling related Dart packages.
 
 | Package | Description | Version |
 | --- | --- | --- |
-| [dash_analytics](pkgs/dash_analytics/) | A package for logging analytics for all dash related tooling to Google Analytics | <!-- [![pub package](https://img.shields.io/pub/v/dash_analytics.svg)](https://pub.dev/packages/dash_analytics) --> |
+| [dash_analytics](pkgs/dash_analytics/) | A package for logging analytics for all dash related tooling to Google Analytics. | <!-- [![pub package](https://img.shields.io/pub/v/dash_analytics.svg)](https://pub.dev/packages/dash_analytics) --> |
 
 ## Publishing automation
 

--- a/pkgs/dash_analytics/CHANGELOG.md
+++ b/pkgs/dash_analytics/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0
+## 0.1.0-dev
 
 - Initial version.

--- a/pkgs/dash_analytics/lib/src/constants.dart
+++ b/pkgs/dash_analytics/lib/src/constants.dart
@@ -62,7 +62,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dash-analytics.log';
 
 /// The current version of the package, should be in line with pubspec version
-const String kPackageVersion = '0.1.0';
+const String kPackageVersion = '0.1.0-dev';
 
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;

--- a/pkgs/dash_analytics/pubspec.yaml
+++ b/pkgs/dash_analytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: dash_analytics
 description: >-
   A package for logging analytics for all dash related tooling to Google
   Analytics.
-version: 0.1.0
+version: 0.1.0-dev
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/dash_analytics
 
 environment:

--- a/pkgs/dash_analytics/pubspec.yaml
+++ b/pkgs/dash_analytics/pubspec.yaml
@@ -2,6 +2,8 @@ name: dash_analytics
 description: >-
   A package for logging analytics for all dash related tooling to Google
   Analytics.
+# When updating this, keep the version consistent with the changelog and the
+# value in lib/src/constants.dart.
 version: 0.1.0-dev
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/dash_analytics
 


### PR DESCRIPTION
- contribute publishing automation
- dial `dash_analytics` back to a pre-release version until we're ready for the first publish
