### PR TITLE
add some clarification to the top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ## Overview
 
-This repository is home to tooling related Dart packages.
+This repository is home to tooling related Dart packages. Generally, this means
+packages published through the
+[tools.dart.dev](https://pub.dev/publishers/tools.dart.dev) publisher that
+don't naturally belong to other topic monorepos (like
+[dart-lang/build](https://github.com/dart-lang/build),
+[dart-lang/test](https://github.com/dart-lang/test), or
+[dart-lang/shelf](https://github.com/dart-lang/shelf)).
 
 ## Packages
 

--- a/pkgs/dash_analytics/README.md
+++ b/pkgs/dash_analytics/README.md
@@ -1,12 +1,15 @@
 [![package:dash_analytics](https://github.com/dart-lang/tools/actions/workflows/dash_analytics.yml/badge.svg)](https://github.com/dart-lang/tools/actions/workflows/dash_analytics.yml)
 
-## What's This?
+## What's this?
 
-This package is intended to be used on Dash (Flutter, Dart, etc.) related tooling only.
-It provides APIs to send events to Google Analytics using the Measurement Protocol.
+This package is intended to be used on Dash (Flutter, Dart, etc.) related
+tooling only. It provides APIs to send events to Google Analytics using the
+Measurement Protocol.
 
-This is not intended to be general purpose or consumed by the community. It is responsible for toggling analytics collection for Dash related tooling on each developer's machine.
+This is not intended to be general purpose or consumed by the community. It is
+responsible for toggling analytics collection for Dash related tooling on each
+developer's machine.
 
-## Using This Package As A Dash Tool
+## Using this package
 
-Refer to the [guide](USAGE_GUIDE.md).
+Refer to the [usage guide](USAGE_GUIDE.md).


### PR DESCRIPTION
- add some clarification to the top-level readme (mostly that this is intended to host tools.dart.dev packages)
