### PR TITLE
Update to regex to look for underscore delimited labels

### DIFF
--- a/pkgs/dash_analytics/lib/src/config_handler.dart
+++ b/pkgs/dash_analytics/lib/src/config_handler.dart
@@ -19,9 +19,9 @@ const String telemetryFlagPattern = r'^reporting=([0|1]) *$';
 /// from the configuration file
 ///
 /// Example:
-/// flutter-tools=2022-10-26,1
+/// flutter_tools=2022-10-26,1
 const String toolPattern =
-    r'^([A-Za-z0-9]+-*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
+    r'^([A-Za-z0-9]+_*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
 
 class ConfigHandler {
   /// Regex pattern implementation for matching a line in the config file

--- a/pkgs/dash_analytics/lib/src/config_handler.dart
+++ b/pkgs/dash_analytics/lib/src/config_handler.dart
@@ -21,7 +21,7 @@ const String telemetryFlagPattern = r'^reporting=([0|1]) *$';
 /// Example:
 /// flutter_tools=2022-10-26,1
 const String toolPattern =
-    r'^([A-Za-z0-9]+_*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
+    r'^([A-Za-z0-9]+[A-Za-z0-9_]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
 
 class ConfigHandler {
   /// Regex pattern implementation for matching a line in the config file

--- a/pkgs/dash_analytics/test/dash_analytics_test.dart
+++ b/pkgs/dash_analytics/test/dash_analytics_test.dart
@@ -30,7 +30,7 @@ void main() {
   late UserProperty userProperty;
 
   const String homeDirName = 'home';
-  const String initialToolName = 'initialTool';
+  const String initialToolName = 'initial_tool';
   const String secondTool = 'newTool';
   const String measurementId = 'measurementId';
   const String apiSecret = 'apiSecret';
@@ -104,6 +104,10 @@ void main() {
             'There should only be 4 files in the $kDartToolDirectoryName directory');
     expect(analytics.shouldShowMessage, true,
         reason: 'For the first run, analytics should default to being enabled');
+    expect(configFile.readAsLinesSync().length,
+        kConfigString.split('\n').length + 1,
+        reason: 'The number of lines should equal lines in constant value + 1 '
+            'for the initialized tool');
   });
 
   test('New tool is successfully added to config file', () {


### PR DESCRIPTION
We have recently decided to make sure that all tool labels are underscore delimited instead of hyphens. This PR fixes the regex pattern for the tool line in the config file. Sample of what a config file looks like is shown below with one tool initialized

```
# INTRODUCTION
#
# This is the Flutter and Dart telemetry reporting
# configuration file.
#
# Lines starting with a #" are documentation that
# the tools maintain automatically.
#
# All other lines are configuration lines. They have
# the form "name=value". If multiple lines contain
# the same configuration name with different values,
# the parser will default to a conservative value. 

# DISABLING TELEMETRY REPORTING
#
# To disable telemetry reporting, set "reporting" to
# the value "0" and to enable, set to "1":
reporting=1

# NOTIFICATIONS
#
# Each tool records when it last informed the user about
# analytics reporting and the privacy policy.
#
# The following tools have so far read this file:
#
#   dart-tools (Dart CLI developer tool)
#   devtools (DevTools debugging and performance tools)
#   flutter-tools (Flutter CLI developer tool)
#
# For each one, the file may contain a configuration line
# where the name is the code in the list above, e.g. "dart-tool",
# and the value is a date in the form YYYY-MM-DD, a comma, and
# a number representing the version of the message that was
# displayed.
flutter_tools=2023-02-22,1

```