### PR TITLE
Update Dart sdk constraint in pubspec

### DIFF
--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -8,7 +8,7 @@ version: 0.1.0-dev
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
   clock: ^1.1.1


### PR DESCRIPTION
Updating as hinted in the `dart pub publish --dry-run`

```
Resolving dependencies... 
  _fe_analyzer_shared 54.0.0 (55.0.0 available)
  analyzer 5.6.0 (5.7.1 available)
  intl 0.17.0 (0.18.0 available)
Got dependencies!
Publishing unified_analytics 0.1.0-dev to https://pub.dev:
├── CHANGELOG.md (<1 KB)
├── LICENSE (1 KB)
├── README.md (<1 KB)
├── USAGE_GUIDE.md (5 KB)
├── analysis_options.yaml (1 KB)
├── coverage_runner.sh (<1 KB)
├── example
│   └── unified_analytics_example.dart (1 KB)
├── lib
│   ├── src
│   │   ├── analytics.dart (10 KB)
│   │   ├── config_handler.dart (7 KB)
│   │   ├── constants.dart (3 KB)
│   │   ├── enums.dart (2 KB)
│   │   ├── ga_client.dart (1 KB)
│   │   ├── initializer.dart (4 KB)
│   │   ├── log_handler.dart (8 KB)
│   │   ├── session.dart (3 KB)
│   │   ├── user_property.dart (2 KB)
│   │   └── utils.dart (3 KB)
│   └── unified_analytics.dart (<1 KB)
├── pubspec.yaml (<1 KB)
└── test
    └── unified_analytics_test.dart (36 KB)
Validating package... (1.3s)
Package validation found the following hint:
* The declared SDK constraint is '>=2.19.0 <3.0.0', this is interpreted as '>=2.19.0 <4.0.0'.
  
  Consider updating the SDK constraint to:
  
  environment:
    sdk: '>=2.19.0 <4.0.0'
  

Package has 0 warnings and 1 hint..
The server may enforce additional checks.
```