### PR TITLE
dogfood the new version of the setup-dart action

### DIFF
--- a/.github/workflows/unified_analytics.yml
+++ b/.github/workflows/unified_analytics.yml
@@ -29,7 +29,7 @@ jobs:
             run-tests: true
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+      - uses: dart-lang/setup-dart@929ed5f8bae55086c6fac456ba5acb9763c9e3e2
         with:
           sdk: ${{matrix.sdk}}
 


### PR DESCRIPTION
- related to https://github.com/dart-lang/setup-dart/issues/79 - switch this repo to use the `setup-dart` action from head (in order to dogfood the pre-release version of it)
