### PR TITLE
Adding more information to `LogFileStats` + minor updates to tests

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.1-dev
+## 0.1.1
 
 - Bumping intl package to 0.18.0 to fix version solving issue with flutter_tools
 - LogFileStats includes more information about how many events are persisted and total count of how many times each event was sent

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.1-dev
 
 - Bumping intl package to 0.18.0 to fix version solving issue with flutter_tools
+- LogFileStats includes more information about how many events are persisted and total count of how many times each event was sent
 
 ## 0.1.0
 

--- a/pkgs/unified_analytics/USAGE_GUIDE.md
+++ b/pkgs/unified_analytics/USAGE_GUIDE.md
@@ -143,18 +143,24 @@ print(analytics.logFileStats());
 
 // Prints out the below
 // {
-//     "startDateTime": "2023-02-08 15:07:10.293728",
-//     "endDateTime": "2023-02-08 15:07:10.299678",
-//     "sessionCount": 1,
+//     "startDateTime": "2023-02-22 15:23:24.410921",
+//     "minsFromStartDateTime": 18858,
+//     "endDateTime": "2023-03-02 17:24:59.206405",
+//     "minsFromEndDateTime": 7217,
+//     "sessionCount": 5,
 //     "flutterChannelCount": 1,
-//     "toolCount": 1
+//     "toolCount": 1,
+//     "recordCount": 18
 // }
 ```
 
 Explanation of the each key above
 
 - startDateTime: the earliest event that was sent
+- minsFromStartDateTime: the number of minutes elapsed since the earliest message
 - endDateTime: the latest, most recent event that was sent
+- minsFromEndDateTime: the number of minutes elapsed since the latest message
 - sessionCount: count of sessions; sessions have a minimum time of 30 minutes
 - flutterChannelCount: count of flutter channels (can be 0 if developer is a Dart dev only)
 - toolCount: count of the Dart and Flutter tools sending analytics
+- recordCount: count of the total number of events in the log file

--- a/pkgs/unified_analytics/USAGE_GUIDE.md
+++ b/pkgs/unified_analytics/USAGE_GUIDE.md
@@ -144,13 +144,18 @@ print(analytics.logFileStats());
 // Prints out the below
 // {
 //     "startDateTime": "2023-02-22 15:23:24.410921",
-//     "minsFromStartDateTime": 18858,
-//     "endDateTime": "2023-03-02 17:24:59.206405",
-//     "minsFromEndDateTime": 7217,
-//     "sessionCount": 5,
-//     "flutterChannelCount": 1,
+//     "minsFromStartDateTime": 20319,
+//     "endDateTime": "2023-03-08 15:46:36.318211",
+//     "minsFromEndDateTime": 136,
+//     "sessionCount": 7,
+//     "flutterChannelCount": 2,
 //     "toolCount": 1,
-//     "recordCount": 18
+//     "recordCount": 23,
+//     "eventCount": {
+//         "hot_reload_time": 16,
+//         "analytics_collection_enabled": 7,
+//         ... scales up with number of events
+//     }
 // }
 ```
 
@@ -164,3 +169,4 @@ Explanation of the each key above
 - flutterChannelCount: count of flutter channels (can be 0 if developer is a Dart dev only)
 - toolCount: count of the Dart and Flutter tools sending analytics
 - recordCount: count of the total number of events in the log file
+- eventCount: counts each unique event and how many times they occurred in the log file

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -246,7 +246,15 @@ class AnalyticsImpl implements Analytics {
     required DashEvent eventName,
     Map<String, Object?> eventData = const {},
   }) {
-    if (!telemetryEnabled) return null;
+
+    // Checking the [telemetryEnabled] boolean reflects what the
+    // config file reflects
+    // 
+    // Checking the [_showMessage] boolean indicates if this the first
+    // time the tool is using analytics or if there has been an update
+    // the messaging found in constants.dart - in both cases, analytics
+    // will not be sent until the second time the tool is used
+    if (!telemetryEnabled || _showMessage) return null;
 
     // Construct the body of the request
     final Map<String, Object?> body = generateRequestBody(
@@ -311,7 +319,7 @@ class TestAnalytics extends AnalyticsImpl {
     required DashEvent eventName,
     Map<String, Object?> eventData = const {},
   }) {
-    if (!telemetryEnabled) return null;
+    if (!telemetryEnabled || _showMessage) return null;
 
     // Calling the [generateRequestBody] method will ensure that the
     // session file is getting updated without actually making any

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -246,10 +246,9 @@ class AnalyticsImpl implements Analytics {
     required DashEvent eventName,
     Map<String, Object?> eventData = const {},
   }) {
-
     // Checking the [telemetryEnabled] boolean reflects what the
     // config file reflects
-    // 
+    //
     // Checking the [_showMessage] boolean indicates if this the first
     // time the tool is using analytics or if there has been an update
     // the messaging found in constants.dart - in both cases, analytics

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -70,7 +70,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dash-analytics.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '0.1.1-dev';
+const String kPackageVersion = '0.1.1';
 
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/log_handler.dart
+++ b/pkgs/unified_analytics/lib/src/log_handler.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
@@ -16,13 +17,13 @@ class LogFileStats {
   /// The oldest timestamp in the log file
   final DateTime startDateTime;
 
-  /// Number of minutes from [startDateTime] to [DateTime.now()]
+  /// Number of minutes from [startDateTime] to [clock.now()]
   final int minsFromStartDateTime;
 
   /// The latest timestamp in the log file
   final DateTime endDateTime;
 
-  /// Number of minutes from [endDateTime] to [DateTime.now()]
+  /// Number of minutes from [endDateTime] to [clock.now()]
   final int minsFromEndDateTime;
 
   /// The number of unique session ids found in the log file
@@ -136,9 +137,9 @@ class LogHandler {
 
     return LogFileStats(
       startDateTime: startDateTime,
-      minsFromStartDateTime: DateTime.now().difference(startDateTime).inMinutes,
+      minsFromStartDateTime: clock.now().difference(startDateTime).inMinutes,
       endDateTime: endDateTime,
-      minsFromEndDateTime: DateTime.now().difference(endDateTime).inMinutes,
+      minsFromEndDateTime: clock.now().difference(endDateTime).inMinutes,
       sessionCount: counter['sessions']!.length,
       flutterChannelCount: counter['flutter_channel']!.length,
       toolCount: counter['tool']!.length,

--- a/pkgs/unified_analytics/lib/src/log_handler.dart
+++ b/pkgs/unified_analytics/lib/src/log_handler.dart
@@ -16,8 +16,14 @@ class LogFileStats {
   /// The oldest timestamp in the log file
   final DateTime startDateTime;
 
+  /// Number of minutes from [startDateTime] to [DateTime.now()]
+  final int minsFromStartDateTime;
+
   /// The latest timestamp in the log file
   final DateTime endDateTime;
+
+  /// Number of minutes from [endDateTime] to [DateTime.now()]
+  final int minsFromEndDateTime;
 
   /// The number of unique session ids found in the log file
   final int sessionCount;
@@ -28,22 +34,31 @@ class LogFileStats {
   /// The number of unique tools found in the log file
   final int toolCount;
 
+  /// Total number of records in the log file
+  final int recordCount;
+
   /// Contains the data from the [LogHandler.logFileStats] method
   const LogFileStats({
     required this.startDateTime,
+    required this.minsFromStartDateTime,
     required this.endDateTime,
+    required this.minsFromEndDateTime,
     required this.sessionCount,
     required this.flutterChannelCount,
     required this.toolCount,
+    required this.recordCount,
   });
 
   @override
   String toString() => jsonEncode(<String, Object?>{
         'startDateTime': startDateTime.toString(),
+        'minsFromStartDateTime': minsFromStartDateTime,
         'endDateTime': endDateTime.toString(),
+        'minsFromEndDateTime': minsFromEndDateTime,
         'sessionCount': sessionCount,
         'flutterChannelCount': flutterChannelCount,
         'toolCount': toolCount,
+        'recordCount': recordCount,
       });
 }
 
@@ -105,10 +120,13 @@ class LogHandler {
 
     return LogFileStats(
       startDateTime: startDateTime,
+      minsFromStartDateTime: DateTime.now().difference(startDateTime).inMinutes,
       endDateTime: endDateTime,
+      minsFromEndDateTime: DateTime.now().difference(endDateTime).inMinutes,
       sessionCount: counter['sessions']!.length,
       flutterChannelCount: counter['flutter_channel']!.length,
       toolCount: counter['tool']!.length,
+      recordCount: records.length,
     );
   }
 

--- a/pkgs/unified_analytics/lib/src/log_handler.dart
+++ b/pkgs/unified_analytics/lib/src/log_handler.dart
@@ -135,11 +135,13 @@ class LogHandler {
       eventCount[record.eventName] = eventCount[record.eventName]! + 1;
     }
 
+    final DateTime now = clock.now();
+
     return LogFileStats(
       startDateTime: startDateTime,
-      minsFromStartDateTime: clock.now().difference(startDateTime).inMinutes,
+      minsFromStartDateTime: now.difference(startDateTime).inMinutes,
       endDateTime: endDateTime,
-      minsFromEndDateTime: clock.now().difference(endDateTime).inMinutes,
+      minsFromEndDateTime: now.difference(endDateTime).inMinutes,
       sessionCount: counter['sessions']!.length,
       flutterChannelCount: counter['flutter_channel']!.length,
       toolCount: counter['tool']!.length,

--- a/pkgs/unified_analytics/lib/src/log_handler.dart
+++ b/pkgs/unified_analytics/lib/src/log_handler.dart
@@ -234,7 +234,7 @@ class LogItem {
   ///             "value": "flutter-tools"
   ///         },
   ///         "local_time": {
-  ///             "value": "2023-01-31 14:32:14.592898"
+  ///             "value": "2023-01-31 14:32:14.592898 -0500"
   ///         }
   ///     }
   /// }
@@ -294,7 +294,7 @@ class LogItem {
       }
 
       // Parse the local time from the string extracted
-      final DateTime localTime = DateTime.parse(localTimeString!);
+      final DateTime localTime = DateTime.parse(localTimeString!).toLocal();
 
       return LogItem(
         eventName: eventName,

--- a/pkgs/unified_analytics/lib/src/user_property.dart
+++ b/pkgs/unified_analytics/lib/src/user_property.dart
@@ -8,6 +8,7 @@ import 'package:clock/clock.dart';
 
 import 'constants.dart';
 import 'session.dart';
+import 'utils.dart';
 
 class UserProperty {
   final Session session;
@@ -58,6 +59,6 @@ class UserProperty {
         'dart_version': dartVersion,
         'analytics_pkg_version': kPackageVersion,
         'tool': tool,
-        'local_time': '${clock.now()}',
+        'local_time': formatDateTime(clock.now()),
       };
 }

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -41,7 +41,7 @@ String formatDateTime(DateTime t) {
 ///     "flutter_version": { "value": "Flutter 3.6.0-7.0.pre.47" },
 ///     "dart_version": { "value": "Dart 2.19.0" },
 ///     "tool": { "value": "flutter-tools" },
-///     "local_time": { "value": "2023-01-11 14:53:31.471816" }
+///     "local_time": { "value": "2023-01-11 14:53:31.471816 -0500" }
 ///   }
 /// }
 /// ```

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -10,6 +10,21 @@ import 'package:file/file.dart';
 import 'enums.dart';
 import 'user_property.dart';
 
+/// Format time as 'yyyy-MM-dd HH:mm:ss Z' where Z is the difference between the
+/// timezone of t and UTC formatted according to RFC 822.
+String formatDateTime(DateTime t) {
+  final String sign = t.timeZoneOffset.isNegative ? '-' : '+';
+  final Duration tzOffset = t.timeZoneOffset.abs();
+  final int hoursOffset = tzOffset.inHours;
+  final int minutesOffset =
+      tzOffset.inMinutes - (Duration.minutesPerHour * hoursOffset);
+  assert(hoursOffset < 24);
+  assert(minutesOffset < 60);
+
+  String twoDigits(int n) => (n >= 10) ? '$n' : '0$n';
+  return '$t $sign${twoDigits(hoursOffset)}${twoDigits(minutesOffset)}';
+}
+
 /// Construct the Map that will be converted to json for the
 /// body of the request
 ///

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 0.1.1-dev
+version: 0.1.1
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -138,6 +138,38 @@ void main() {
             'The config file should have the same message from the constants file');
   });
 
+  test('First time analytics run will not send events, second time will', () {
+    // Send an event with the first analytics class; this should result
+    // in no logs in the log file which keeps track of all the events
+    // that have been sent
+    analytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    analytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+
+    // Create a new instance of the analytics class with the SAME tool
+    // to simulate that the same tool is running for the second time
+    final Analytics secondAnalytics = Analytics.test(
+      tool: initialToolName,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    secondAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+
+    expect(logFile.readAsLinesSync().length, 1,
+        reason: 'The second analytics instance should have logged an event');
+  });
+
   test('Toggling telemetry boolean through Analytics class api', () async {
     expect(analytics.telemetryEnabled, true,
         reason: 'Telemetry should be enabled by default '

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -848,7 +848,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
         '"flutter_version":{"value":"Flutter 3.6.0-7.0.pre.47"},'
         '"dart_version":{"value":"Dart 2.19.0"},'
         // '"tool":{"value":"flutter-tools"},'  NEEDS REMAIN REMOVED
-        '"local_time":{"value":"2023-01-31 14:32:14.592898"}}}';
+        '"local_time":{"value":"2023-01-31 14:32:14.592898 -0500"}}}';
 
     logFile.writeAsStringSync(malformedLog);
     final LogFileStats? query = analytics.logFileStats();

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -838,7 +838,8 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
             'The query should be null because the `local_time` value is malformed');
   });
 
-  test('Check that the constant kPackageVersion matches pubspec version', () {
+  test('Version is the same in the change log, pubspec, and constants.dart',
+      () {
     // Parse the contents of the pubspec.yaml
     final String pubspecYamlString = io.File('pubspec.yaml').readAsStringSync();
 
@@ -851,6 +852,13 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
             'constants.dart need to match\n'
             'Pubspec: $version && constants.dart: $kPackageVersion\n\n'
             'Make sure both are the same');
+
+    // Parse the contents of the change log file
+    final String changeLogFirstLineString =
+        io.File('CHANGELOG.md').readAsLinesSync().first;
+    expect(changeLogFirstLineString.substring(3), kPackageVersion,
+        reason: 'The CHANGELOG.md file needs the first line to '
+            'be the same version as the pubspec and constants.dart');
   });
 
   test('Null values for flutter parameters is reflected properly in log file',

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -905,9 +905,9 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
 
   test('Null values for flutter parameters is reflected properly in log file',
       () {
-        // Use a for loop two initialize the second analytics instance
-        // twice to account for no events being sent on the first instance
-        // run for a given tool
+    // Use a for loop two initialize the second analytics instance
+    // twice to account for no events being sent on the first instance
+    // run for a given tool
     Analytics? secondAnalytics;
     for (int i = 0; i < 2; i++) {
       secondAnalytics = Analytics.test(

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -870,7 +870,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
         '"flutter_version":{"value":"Flutter 3.6.0-7.0.pre.47"},'
         '"dart_version":{"value":"Dart 2.19.0"},'
         '"tool":{"value":"flutter-tools"},'
-        '"local_time":{"value":"2023-xx-31 14:32:14.592898"}}}'; // PURPOSEFULLY MALFORMED
+        '"local_time":{"value":"2023-xx-31 14:32:14.592898 -0500"}}}'; // PURPOSEFULLY MALFORMED
 
     logFile.writeAsStringSync(malformedLog);
     final LogFileStats? query = analytics.logFileStats();

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -732,8 +732,6 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
           eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
 
       final LogFileStats secondQuery = analytics.logFileStats()!;
-      expect(secondQuery.sessionCount, 2,
-          reason: 'There should be 2 sessions after the second event');
 
       // Construct the expected response for the second query
       //


### PR DESCRIPTION
This update will include more information for the stats returns from the log file. The following keys have been added

`minsFromStartDateTime` – how many minutes have elapsed since the oldest log item
`minsFromEndDateTime` – how many minutes have elapsed since the earliest log item
`recordCount` – total count of records in the log file
`eventCount` – a map object that has each event sent as the key and a count of how many times that event was sent

```dart
{
    "startDateTime": "2023-02-22 15:23:24.410921",
    "minsFromStartDateTime": 20339,  // NEW
    "endDateTime": "2023-03-08 15:46:36.318211",
    "minsFromEndDateTime": 156,  // NEW
    "sessionCount": 7,
    "flutterChannelCount": 2,
    "toolCount": 1,
    "recordCount": 23,  // NEW
    "eventCount": {  // NEW
        "hot_reload_time": 16,
        "analytics_collection_enabled": 7
    }
}
```

This will help with survey conditions that involve the presence of an event, count exceeding N for an event being called, etc.

Included in this PR also has `local_time` in the body of the request to include the timezone offset so that the local time can be used for querying if desired

```
"local_time": {
  "value": "2023-01-31 14:32:14.592898 -0500"
}
```