### PR TITLE
Update messaging for tools messaging

### DIFF
--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -88,7 +88,16 @@ platform, Flutter framework, and related tools.
 Telemetry is not sent on the very first run.
 To disable reporting of telemetry, run this terminal command:
 
-[dart|flutter] --disable-telemetry.
+flutter config --no-analytics
+  OR
+dart --disable-analytics
+
+To enable reporting of telemetry, run this terminal command:
+
+flutter config --analytics
+  OR
+dart --enable-analytics
+
 If you opt out of telemetry, an opt-out event will be sent, and then no further
 information will be sent. This data is collected in accordance with the
 Google Privacy Policy (https://policies.google.com/privacy).


### PR DESCRIPTION
The messaging has been updated to reflect the correct commands for both `flutter` and `dart` cli tools for enabling and disabling telemetry.

This message can also be shown to users through the `Analytics` getter `toolsMessage`

```dart
abstract class Analytics {

  /// Boolean that lets the client know if they should display the message
  bool get shouldShowMessage;

  /// Returns the message that should be displayed to the users if
  /// [shouldShowMessage] returns true
  String get toolsMessage;
}
```

The updated messaging is below
```
Flutter and Dart related tooling uses Google Analytics to report usage and
diagnostic data along with package dependencies, and crash reporting to
send basic crash reports. This data is used to help improve the Dart
platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter config --no-analytics
  OR
dart --disable-analytics

To enable reporting of telemetry, run this terminal command:

flutter config --analytics
  OR
dart --enable-analytics

If you opt out of telemetry, an opt-out event will be sent, and then no further
information will be sent. This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).
```