### PR TITLE
Implement fake ga client

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Implemented fake Google Analytics Client for `Analytics.test(...)` constructor
+
 ## 0.1.1
 
 - Bumping intl package to 0.18.0 to fix version solving issue with flutter_tools

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -43,6 +43,13 @@ abstract class Analytics {
       platform = DevicePlatform.windows;
     }
 
+    // Create the instance of the GA Client which will create
+    // an [http.Client] to send requests
+    final GAClient gaClient = GAClient(
+      measurementId: kGoogleAnalyticsMeasurementId,
+      apiSecret: kGoogleAnalyticsApiSecret,
+    );
+
     return AnalyticsImpl(
       tool: tool.label,
       homeDirectory: getHomeDirectory(fs),
@@ -55,6 +62,7 @@ abstract class Analytics {
       toolsMessage: kToolsMessage,
       toolsMessageVersion: kToolsMessageVersion,
       fs: fs,
+      gaClient: gaClient,
     );
   }
 
@@ -90,6 +98,7 @@ abstract class Analytics {
                   ? FileSystemStyle.windows
                   : FileSystemStyle.posix,
             ),
+        gaClient: FakeGAClient(),
       );
 
   /// Returns a map object with all of the tools that have been parsed
@@ -140,7 +149,7 @@ class AnalyticsImpl implements Analytics {
   final FileSystem fs;
   late final ConfigHandler _configHandler;
   late bool _showMessage;
-  late final GAClient _gaClient;
+  final GAClient _gaClient;
   late final String _clientId;
   late final UserProperty userProperty;
   late final LogHandler _logHandler;
@@ -160,7 +169,8 @@ class AnalyticsImpl implements Analytics {
     required this.toolsMessage,
     required int toolsMessageVersion,
     required this.fs,
-  }) {
+    required gaClient,
+  }) : _gaClient = gaClient {
     // This initializer class will let the instance know
     // if it was the first run; if it is, nothing will be sent
     // on the first run
@@ -197,13 +207,6 @@ class AnalyticsImpl implements Analytics {
         .file(p.join(
             homeDirectory.path, kDartToolDirectoryName, kClientIdFileName))
         .readAsStringSync();
-
-    // Create the instance of the GA Client which will create
-    // an [http.Client] to send requests
-    _gaClient = GAClient(
-      measurementId: measurementId,
-      apiSecret: apiSecret,
-    );
 
     // Initialize the user property class that will be attached to
     // each event that is sent to Google Analytics -- it will be responsible
@@ -311,6 +314,7 @@ class TestAnalytics extends AnalyticsImpl {
     required super.toolsMessage,
     required super.toolsMessageVersion,
     required super.fs,
+    required super.gaClient,
   });
 
   @override

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -70,7 +70,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dash-analytics.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '0.1.1';
+const String kPackageVersion = '0.1.2';
 
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/ga_client.dart
+++ b/pkgs/unified_analytics/lib/src/ga_client.dart
@@ -8,6 +8,27 @@ import 'package:http/http.dart' as http;
 
 import 'constants.dart';
 
+class FakeGAClient implements GAClient {
+  @override
+  String get apiSecret => throw UnimplementedError();
+
+  @override
+  String get measurementId => throw UnimplementedError();
+
+  @override
+  String get postUrl => throw UnimplementedError();
+
+  @override
+  http.Client get _client => throw UnimplementedError();
+
+  @override
+  void close() {}
+
+  @override
+  Future<http.Response> sendData(Map<String, Object?> body) =>
+      Future<http.Response>.value(http.Response('', 200));
+}
+
 class GAClient {
   final String measurementId;
   final String apiSecret;

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:


### PR DESCRIPTION
As requested in https://buganizer.corp.google.com/issues/272229439#comment8 – implementing a fake Google Analytics client class to make tests usable.

At the moment, all getters and methods will throw `UnimplementedError` errors when used **except** for `sendData` which will return a future of type `http.Response` with the body set as an empty string with a 200 status code