### PR TITLE
Empty package for `package:cli_config`

### DIFF
--- a/.github/ISSUE_TEMPLATE/cli_config.md
+++ b/.github/ISSUE_TEMPLATE/cli_config.md
@@ -1,0 +1,5 @@
+---
+name: "package:cli_config"
+about: "Create a bug or file a feature request against package:cli_config."
+labels: "package:cli_config"
+---

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,9 @@
-# Configuration for .github/workflows/pull_request_label.yml. 
+# Configuration for .github/workflows/pull_request_label.yml.
 
 'type-infra':
   - '.github/**'
 
+'package:cli_config':
+  - 'pkgs/cli_config/**'
 'package:unified_analytics':
   - 'pkgs/unified_analytics/**'

--- a/.github/workflows/cli_config.yml
+++ b/.github/workflows/cli_config.yml
@@ -1,0 +1,44 @@
+name: package:cli_config
+permissions: read-all
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/cli_config.yml"
+      - "pkgs/cli_config/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/cli_config.yml"
+      - "pkgs/cli_config/**"
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkgs/cli_config
+    strategy:
+      matrix:
+        sdk: [stable, dev] # {pkgs.versions}
+        include:
+          - sdk: stable
+            run-tests: true
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
+        with:
+          sdk: ${{matrix.sdk}}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+        if: ${{matrix.run-tests}}
+
+      - run: dart test
+        if: ${{matrix.run-tests}}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,5 @@
 # for code within the repository
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+/pkgs/cli_config/ @dcharkes @HosseinYousefi
 /pkgs/unified_analytics/ @eliasyishak

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,4 @@
 # for code within the repository
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-/pkgs/cli_config/ @dcharkes @HosseinYousefi
 /pkgs/unified_analytics/ @eliasyishak

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ don't naturally belong to other topic monorepos (like
 
 | Package | Description | Version |
 | --- | --- | --- |
-| [cli_config](pkgs/cli_config/) | A package to take config values from configuration files, CLI arguments, and environment variables. |
+| [cli_config](pkgs/cli_config/) | A package to take config values from configuration files, CLI arguments, and environment variables. | |
 | [unified_analytics](pkgs/unified_analytics/) | A package for logging analytics for all Dart and Flutter related tooling to Google Analytics. | [![pub package](https://img.shields.io/pub/v/unified_analytics.svg)](https://pub.dev/packages/unified_analytics) |
 
 ## Publishing automation

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ don't naturally belong to other topic monorepos (like
 
 | Package | Description | Version |
 | --- | --- | --- |
+| [cli_config](pkgs/cli_config/) | A package to take config values from configuration files, CLI arguments, and environment variables. |
 | [unified_analytics](pkgs/unified_analytics/) | A package for logging analytics for all Dart and Flutter related tooling to Google Analytics. | [![pub package](https://img.shields.io/pub/v/unified_analytics.svg)](https://pub.dev/packages/unified_analytics) |
 
 ## Publishing automation

--- a/pkgs/cli_config/.gitignore
+++ b/pkgs/cli_config/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/pkgs/cli_config/CHANGELOG.md
+++ b/pkgs/cli_config/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial version.

--- a/pkgs/cli_config/CHANGELOG.md
+++ b/pkgs/cli_config/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0
+## 0.1.0-dev
 
 - Initial version.

--- a/pkgs/cli_config/LICENSE
+++ b/pkgs/cli_config/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2023, the Dart project authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkgs/cli_config/README.md
+++ b/pkgs/cli_config/README.md
@@ -1,0 +1,1 @@
+A library to take config values from configuration files, CLI arguments, and environment variables.

--- a/pkgs/cli_config/analysis_options.yaml
+++ b/pkgs/cli_config/analysis_options.yaml
@@ -1,0 +1,22 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-raw-types: true
+    strict-inference: true
+
+linter:
+  rules:
+    - always_declare_return_types
+    - avoid_dynamic_calls
+    - camel_case_types
+    - depend_on_referenced_packages
+    - directives_ordering
+    - prefer_const_declarations
+    - prefer_expression_function_bodies
+    - prefer_final_in_for_each
+    - prefer_final_locals
+    - prefer_relative_imports
+    - prefer_single_quotes
+    - sort_pub_dependencies
+    - unawaited_futures

--- a/pkgs/cli_config/lib/cli_config.dart
+++ b/pkgs/cli_config/lib/cli_config.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A library to take config values from configuration files, CLI arguments,
+/// and environment variables.
+library cli_config;

--- a/pkgs/cli_config/pubspec.yaml
+++ b/pkgs/cli_config/pubspec.yaml
@@ -1,8 +1,8 @@
 name: cli_config
 description: A library to take config values from configuration files, CLI arguments, and environment variables.
-version: 0.1.0
+version: 0.1.0-dev
 
-repository: https://github.com/dcharkes/config
+repository: https://github.com/dart-lang/tools/tree/main/pkgs/cli_config
 
 environment:
   sdk: ">=2.19.3 <4.0.0"

--- a/pkgs/cli_config/pubspec.yaml
+++ b/pkgs/cli_config/pubspec.yaml
@@ -1,0 +1,16 @@
+name: cli_config
+description: A library to take config values from configuration files, CLI arguments, and environment variables.
+version: 0.1.0
+
+repository: https://github.com/dcharkes/config
+
+environment:
+  sdk: ">=2.19.3 <4.0.0"
+
+dependencies:
+  args: ^2.4.0
+  yaml: ^3.1.1
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.21.0

--- a/pkgs/cli_config/test/cli_config_test.dart
+++ b/pkgs/cli_config/test/cli_config_test.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main() {}

--- a/pkgs/cli_config/test/cli_config_test.dart
+++ b/pkgs/cli_config/test/cli_config_test.dart
@@ -2,4 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-void main() {}
+import 'package:test/test.dart';
+
+void main() {
+  test('dummy test', () {
+    expect(42, 42);
+  });
+}


### PR DESCRIPTION
Sets up the directory structure for `package:cli_config`.

The package contains no Dart code yet, this will be added later.