### PR TITLE
Analytics development constructor

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3-dev
+
+- Creating a new analytics constructor to point to a test instance of Google Analytics for developers
+
 ## 0.1.2
 
 - Implemented fake Google Analytics Client for `Analytics.test(...)` constructor; marked with visible for testing annotation

--- a/pkgs/unified_analytics/USAGE_GUIDE.md
+++ b/pkgs/unified_analytics/USAGE_GUIDE.md
@@ -17,12 +17,10 @@ import 'unified_analytics/unified_analytics.dart';
 
 // Constants that should be resolved by the client using package
 final DashTool tool = DashTool.flutterTools; // Restricted to enum provided by package
-final String measurementId = 'xxxxxxxxxxxx'; // To be provided to client
-final String apiSecret = 'xxxxxxxxxxxx'; // To be provided to client
 
 // Values that need to be provided by the client that may
 // need to be calculated
-final String branch = ...;
+final String channel = ...;
 final String flutterVersion = ...;
 final String dartVersion = ...;
 
@@ -30,10 +28,8 @@ final String dartVersion = ...;
 // preferably outside of the [main] method
 final Analytics analytics = Analytics(
   tool: tool,
-  measurementId: measurementId,
-  apiSecret: apiSecret,
-  branch: branch,
-  flutterVersion: flutterVersion,
+  flutterChannel: channel,  // Optional; only if easy to determine
+  flutterVersion: flutterVersion,  // Optional; only if easy to determine
   dartVersion: dartVersion,
 );
 
@@ -129,12 +125,11 @@ print('This user's status: ${analytics.telemetryEnabled}');  // true if opted-in
 ## Developing Within `package:unified_analytics`
 
 When contributing to this package, if the developer needs to verify that
-events have been sent, the following credentials should be used in
-`lib/src/constants.dart` to point to a separate Google Analytics endpoint
+events have been sent, the developer should the use development constructor
+so that the events being sent are not going into the production instance
 
 ```dart
-const String kGoogleAnalyticsApiSecret = '4yT8__oER3Cd84dtx6r-_A';
-const String kGoogleAnalyticsMeasurementId = 'G-N1NXG28J5B';
+final Analytics analytics = Analytics.development(...);
 ```
 
 Reach out to maintainers to get access to the test Google Analytics endpoint.

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -54,8 +54,54 @@ abstract class Analytics {
     return AnalyticsImpl(
       tool: tool.label,
       homeDirectory: getHomeDirectory(fs),
-      measurementId: kGoogleAnalyticsMeasurementId,
-      apiSecret: kGoogleAnalyticsApiSecret,
+      flutterChannel: flutterChannel,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      platform: platform,
+      toolsMessage: kToolsMessage,
+      toolsMessageVersion: kToolsMessageVersion,
+      fs: fs,
+      gaClient: gaClient,
+    );
+  }
+
+  /// Factory constructor to return the [AnalyticsImpl] class with
+  /// Google Analytics credentials that point to a test instance and
+  /// not the production instance where live data will be sent
+  factory Analytics.development({
+    required DashTool tool,
+    required String dartVersion,
+    String? flutterChannel,
+    String? flutterVersion,
+  }) {
+    // Create the instance of the file system so clients don't need
+    // resolve on their own
+    const FileSystem fs = LocalFileSystem();
+
+    // Resolve the OS using dart:io
+    final DevicePlatform platform;
+    if (io.Platform.operatingSystem == 'linux') {
+      platform = DevicePlatform.linux;
+    } else if (io.Platform.operatingSystem == 'macos') {
+      platform = DevicePlatform.macos;
+    } else {
+      platform = DevicePlatform.windows;
+    }
+
+    // Credentials defined below for the test Google Analytics instance
+    const String kTestMeasurementId = 'G-N1NXG28J5B';
+    const String kTestApiSecret = '4yT8__oER3Cd84dtx6r-_A';
+
+    // Create the instance of the GA Client which will create
+    // an [http.Client] to send requests
+    final GAClient gaClient = GAClient(
+      measurementId: kTestMeasurementId,
+      apiSecret: kTestApiSecret,
+    );
+
+    return AnalyticsImpl(
+      tool: tool.label,
+      homeDirectory: getHomeDirectory(fs),
       flutterChannel: flutterChannel,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
@@ -86,8 +132,6 @@ abstract class Analytics {
       TestAnalytics(
         tool: tool,
         homeDirectory: homeDirectory,
-        measurementId: measurementId,
-        apiSecret: apiSecret,
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,
@@ -162,8 +206,6 @@ class AnalyticsImpl implements Analytics {
   AnalyticsImpl({
     required String tool,
     required Directory homeDirectory,
-    required String measurementId,
-    required String apiSecret,
     String? flutterChannel,
     String? flutterVersion,
     required String dartVersion,
@@ -307,8 +349,6 @@ class TestAnalytics extends AnalyticsImpl {
   TestAnalytics({
     required super.tool,
     required super.homeDirectory,
-    required super.measurementId,
-    required super.apiSecret,
     super.flutterChannel,
     super.flutterVersion,
     required super.dartVersion,

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -70,7 +70,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dash-analytics.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '0.1.2';
+const String kPackageVersion = '0.1.3-dev';
 
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 0.1.2
+version: 0.1.3-dev
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:


### PR DESCRIPTION
Addresses: https://github.com/dart-lang/tools/issues/48

This new constructor will allow other developers using this package to test sending events to a test instance in Google Analytics.

Developers will need to request access to the BigQuery instance to see the data that is being exported