### PR TITLE
Static method added to retrieve tools onboarded in config file

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Error handling functionality added to prevent malformed session json data from causing a crash
 - Creating a new analytics constructor to point to a test instance of Google Analytics for developers
+- Adding a static method `Analytics.onboardedTools()` to retrieve a list of tools that have already been onboarded into the config file on the developer's machine
 
 ## 0.1.2
 

--- a/pkgs/unified_analytics/USAGE_GUIDE.md
+++ b/pkgs/unified_analytics/USAGE_GUIDE.md
@@ -184,3 +184,28 @@ Explanation of the each key above
 - toolCount: count of the Dart and Flutter tools sending analytics
 - recordCount: count of the total number of events in the log file
 - eventCount: counts each unique event and how many times they occurred in the log file
+
+## Advanced Usage: Identifying Tools in Package Config File
+
+It may be beneficial for some tools using this package to know about other
+tools that have already been onboarded to the package without creating an
+instance of the `Analytics` class (Remember, when creating an instance
+for the first time on a given tool, it will automatically add that tool
+into the package's config file on the developer's machine). In those instances,
+a static method has been exposed on the `Analytics` class that will allow
+each tool to identify which tools have already been added.
+
+This can be particularly useful if a tool using this package is unable to
+display the message informing the user about how to opt-out of telemetry
+collection, but it can share the same permissions as another tool that has
+already shown the message.
+
+```dart
+final List<DashTool> onboardedTools = Analytics.onboardedTools();
+
+// Returns a list of DashTool enums
+// ie. --> [DashTool.flutterTools, DashTool.languageServer]
+```
+
+The returned list can be used to check for the _other_ tool that already
+has shown the message

--- a/pkgs/unified_analytics/example/unified_analytics_example.dart
+++ b/pkgs/unified_analytics/example/unified_analytics_example.dart
@@ -8,8 +8,9 @@ final String measurementId = 'G-N1NXG28J5B';
 final String apiSecret = '4yT8__oER3Cd84dtx6r-_A';
 
 // Globally instantiate the analytics class at the entry
-// point of the tool
-final Analytics analytics = Analytics(
+// point of the tool; the development constructor used here
+// so events sent from here won't go to production
+final Analytics analytics = Analytics.development(
   tool: DashTool.flutterTools,
   flutterChannel: 'ey-test-channel',
   flutterVersion: 'Flutter 3.6.0-7.0.pre.47',

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -103,6 +103,43 @@ abstract class Analytics {
         gaClient: FakeGAClient(),
       );
 
+  /// Returns all [DashTool]s that have been added to the config file
+  static List<DashTool> onboardedTools({
+    FileSystem fs = const LocalFileSystem(),
+  }) {
+    final Directory homeDirectory = getHomeDirectory(fs);
+    final File configFile = fs.file(p.join(
+      homeDirectory.path,
+      kDartToolDirectoryName,
+      kConfigFileName,
+    ));
+
+    // Iterate through the parsed data from the static method
+    // in [ConfigHandler] and match the key to the label for
+    // the corresponding [DashTool] enum value
+    final Map<String, ToolInfo> parsedTools = ConfigHandler.readParsedTools(
+      configString: configFile.readAsStringSync(),
+    );
+
+    // Create a map of each DashTool where the key is
+    // DashTool.label and the value is the enum value
+    final Map<String, DashTool> labelToDashToolMap = {};
+    for (DashTool tool in DashTool.values) {
+      labelToDashToolMap[tool.label] = tool;
+    }
+
+    // Use the two maps above to return a list of DashTools
+    // that have been added to the config file
+    final List<DashTool> results = [];
+    for (String toolLabel in parsedTools.keys) {
+      if (labelToDashToolMap.containsKey(toolLabel)) {
+        results.add(labelToDashToolMap[toolLabel]!);
+      }
+    }
+
+    return results;
+  }
+
   /// Returns a map object with all of the tools that have been parsed
   /// out of the configuration file
   Map<String, ToolInfo> get parsedTools;

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -148,7 +148,7 @@ abstract class Analytics {
       );
 
   /// Returns all [DashTool]s that have been added to the config file
-  /// 
+  ///
   /// By default, it will use the [LocalFileSystem] if [fs] is not provided
   /// and if a specific home directory needs to be passed as an override, it
   /// can be passed in as [homeDirectoryOverride]
@@ -163,6 +163,8 @@ abstract class Analytics {
       kDartToolDirectoryName,
       kConfigFileName,
     ));
+
+    if (!configFile.existsSync()) return [];
 
     // Iterate through the parsed data from the static method
     // in [ConfigHandler] and match the key to the label for

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -104,10 +104,16 @@ abstract class Analytics {
       );
 
   /// Returns all [DashTool]s that have been added to the config file
+  /// 
+  /// By default, it will use the [LocalFileSystem] if [fs] is not provided
+  /// and if a specific home directory needs to be passed as an override, it
+  /// can be passed in as [homeDirectoryOverride]
   static List<DashTool> onboardedTools({
     FileSystem fs = const LocalFileSystem(),
+    Directory? homeDirectoryOverride,
   }) {
-    final Directory homeDirectory = getHomeDirectory(fs);
+    final Directory homeDirectory =
+        homeDirectoryOverride ?? getHomeDirectory(fs);
     final File configFile = fs.file(p.join(
       homeDirectory.path,
       kDartToolDirectoryName,

--- a/pkgs/unified_analytics/lib/src/config_handler.dart
+++ b/pkgs/unified_analytics/lib/src/config_handler.dart
@@ -145,6 +145,33 @@ class ConfigHandler {
     toolInfo.versionNumber = newVersionNumber;
   }
 
+  /// Returns a [Map] object that will have each key be a tool
+  /// that has been added to the config file previously, the value
+  /// will be an instance of [ToolInfo] for that tool
+  static Map<String, ToolInfo> readParsedTools({required String configString}) {
+    // Define a temporary map object that will store the contents
+    // of the config file's stored tools to be used within this
+    // static method
+    final Map<String, ToolInfo> temp = {};
+
+    // Collect the tools logged in the configuration file
+    toolRegex.allMatches(configString).forEach((RegExpMatch element) {
+      // Extract the information relevant for the [ToolInfo] class
+      final String tool = element.group(1) as String;
+      final DateTime lastRun = DateTime.parse(element.group(2) as String);
+      final int versionNumber = int.parse(element.group(3) as String);
+
+      // Initialize an instance of the [ToolInfo] class to store
+      // in the [parsedTools] map object
+      temp[tool] = ToolInfo(
+        lastRun: lastRun,
+        versionNumber: versionNumber,
+      );
+    });
+
+    return temp;
+  }
+
   /// Method responsible for reading in the config file stored on
   /// user's machine and parsing out the following: all the tools that
   /// have been logged in the file, the dates they were last run, and
@@ -159,18 +186,8 @@ class ConfigHandler {
     final String configString = configFile.readAsStringSync();
 
     // Collect the tools logged in the configuration file
-    toolRegex.allMatches(configString).forEach((RegExpMatch element) {
-      // Extract the information relevant for the [ToolInfo] class
-      final String tool = element.group(1) as String;
-      final DateTime lastRun = DateTime.parse(element.group(2) as String);
-      final int versionNumber = int.parse(element.group(3) as String);
-
-      // Initialize an instance of the [ToolInfo] class to store
-      // in the [parsedTools] map object
-      parsedTools[tool] = ToolInfo(
-        lastRun: lastRun,
-        versionNumber: versionNumber,
-      );
+    readParsedTools(configString: configString).forEach((key, value) {
+      parsedTools[key] = value;
     });
 
     // Check for lines signaling that the user has disabled analytics,

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 /// Values for the event name to be sent to Google Analytics
 ///
 /// The [label] for each enum value is what will be logged, the [description]
@@ -85,6 +87,18 @@ enum DashTool {
   languageServer(
     label: 'language_server',
     description: 'The Dart language server for IDE and CLI support.',
+  ),
+
+  // Enum values below to be used within testing only
+  @visibleForTesting
+  testTool(
+    label: 'test_tool',
+    description: 'Tool to be used in tests',
+  ),
+  @visibleForTesting
+  anotherTestTool(
+    label: 'another_test_tool',
+    description: 'Second tool to simulate two tools using package',
   );
 
   final String label;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart';
-
 /// Values for the event name to be sent to Google Analytics
 ///
 /// The [label] for each enum value is what will be logged, the [description]
@@ -87,18 +85,6 @@ enum DashTool {
   languageServer(
     label: 'language_server',
     description: 'The Dart language server for IDE and CLI support.',
-  ),
-
-  // Enum values below to be used within testing only
-  @visibleForTesting
-  testTool(
-    label: 'test_tool',
-    description: 'Tool to be used in tests',
-  ),
-  @visibleForTesting
-  anotherTestTool(
-    label: 'another_test_tool',
-    description: 'Second tool to simulate two tools using package',
   );
 
   final String label;

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:clock/clock.dart';
 import 'package:file/file.dart';
@@ -76,18 +77,24 @@ class Session {
   /// to date incase another tool is also calling this package and
   /// making updates to the session file
   void _refreshSessionData() {
-    try {
+    /// Using a nested function here to reduce verbosity
+    void parseContents() {
       final String sessionFileContents = _sessionFile.readAsStringSync();
       final Map<String, Object?> sessionObj = jsonDecode(sessionFileContents);
       _sessionId = sessionObj['session_id'] as int;
       _lastPing = sessionObj['last_ping'] as int;
+    }
+
+    try {
+      parseContents();
     } on FormatException {
       Initializer.createSessionFile(sessionFile: _sessionFile);
 
-      final String sessionFileContents = _sessionFile.readAsStringSync();
-      final Map<String, Object?> sessionObj = jsonDecode(sessionFileContents);
-      _sessionId = sessionObj['session_id'] as int;
-      _lastPing = sessionObj['last_ping'] as int;
+      parseContents();
+    } on PathNotFoundException {
+      Initializer.createSessionFile(sessionFile: _sessionFile);
+
+      parseContents();
     }
   }
 }

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -1087,4 +1087,12 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
     expect(onboardedTools.contains(DashTool.testTool), true);
     expect(onboardedTools.contains(DashTool.anotherTestTool), true);
   });
+
+  test('Onboarded tools returns empty list when config does not exist', () {
+    configFile.deleteSync();
+    final List<DashTool> onboardedTools =
+        Analytics.onboardedTools(fs: fs, homeDirectoryOverride: home);
+
+    expect(onboardedTools.length, 0);
+  });
 }

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -31,8 +31,8 @@ void main() {
   late UserProperty userProperty;
 
   const String homeDirName = 'home';
-  final String initialToolName = DashTool.testTool.label;
-  final String secondTool = DashTool.anotherTestTool.label;
+  final String initialToolName = DashTool.flutterTools.label;
+  final String secondTool = DashTool.dartTools.label;
   const String measurementId = 'measurementId';
   const String apiSecret = 'apiSecret';
   const int toolsMessageVersion = 1;
@@ -128,14 +128,6 @@ void main() {
         kConfigString.split('\n').length + 1,
         reason: 'The number of lines should equal lines in constant value + 1 '
             'for the initialized tool');
-    expect(
-        Analytics.onboardedTools(
-          fs: fs,
-          homeDirectoryOverride: home,
-        ).contains(DashTool.testTool),
-        true,
-        reason: 'The static method should be able to '
-            'detect the first tool in the config file');
   });
 
   test('Resetting session file when data is malformed', () {

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -31,8 +31,8 @@ void main() {
   late UserProperty userProperty;
 
   const String homeDirName = 'home';
-  const String initialToolName = 'initial_tool';
-  const String secondTool = 'newTool';
+  final String initialToolName = DashTool.testTool.label;
+  final String secondTool = DashTool.anotherTestTool.label;
   const String measurementId = 'measurementId';
   const String apiSecret = 'apiSecret';
   const int toolsMessageVersion = 1;
@@ -128,6 +128,14 @@ void main() {
         kConfigString.split('\n').length + 1,
         reason: 'The number of lines should equal lines in constant value + 1 '
             'for the initialized tool');
+    expect(
+        Analytics.onboardedTools(
+          fs: fs,
+          homeDirectoryOverride: home,
+        ).contains(DashTool.testTool),
+        true,
+        reason: 'The static method should be able to '
+            'detect the first tool in the config file');
   });
 
   test('New tool is successfully added to config file', () {
@@ -1035,5 +1043,30 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
   test('Confirm credentials for GA', () {
     expect(kGoogleAnalyticsApiSecret, 'Ka1jc8tZSzWc_GXMWHfPHA');
     expect(kGoogleAnalyticsMeasurementId, 'G-04BXPVBCWJ');
+  });
+
+  test('Confirm static method for identifying onboarded tools in config', () {
+    final Analytics secondAnalytics = Analytics.test(
+      tool: secondTool,
+      homeDirectory: home,
+      measurementId: 'measurementId',
+      apiSecret: 'apiSecret',
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: 'Flutter 3.6.0-7.0.pre.47',
+      dartVersion: 'Dart 2.19.0',
+      fs: fs,
+      platform: platform,
+    );
+    secondAnalytics.shouldShowMessage;
+
+    final List<DashTool> onboardedTools =
+        Analytics.onboardedTools(fs: fs, homeDirectoryOverride: home);
+
+    expect(onboardedTools.length, 2,
+        reason: 'There should only be two tools in the config');
+    expect(onboardedTools.contains(DashTool.testTool), true);
+    expect(onboardedTools.contains(DashTool.anotherTestTool), true);
   });
 }

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -1076,8 +1076,8 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
 
     expect(onboardedTools.length, 2,
         reason: 'There should only be two tools in the config');
-    expect(onboardedTools.contains(DashTool.testTool), true);
-    expect(onboardedTools.contains(DashTool.anotherTestTool), true);
+    expect(onboardedTools.contains(DashTool.flutterTools), true);
+    expect(onboardedTools.contains(DashTool.dartTools), true);
   });
 
   test('Onboarded tools returns empty list when config does not exist', () {


### PR DESCRIPTION
This PR exposes a static method on the `Analytics` class that will allow the tool using this package to retrieve a list of `DashTool` enums for each tool that has been onboarded into the config file. If there has been no tool added, or the file does not exist, it will return an empty list

This will help other tools that are not able to show a message to the developer get approval to send telemetry simultaneously with other tools. For example, if a user is using the analyzer inside vim, it won't be possible to prompt the user with a message informing them about analytics collection. However, in the case with the analyzer, it is part of the same codebase as the `dart-tool` and when the `dart-tool` displays it messages, it can also approve the analyzer to send messages since they are within the same logical grouping of dart tools.

Usage within production code:
```dart
final List<DashTool> onboardedTools = Analytics.onboardedTools();

// Returns a list of DashTool enums
// ie. --> [DashTool.flutterTools, DashTool.languageServer]
```

Usage within test code where we need to provide a filesystem and point to a different home directory:
```dart
// Setup the filesystem with the home directory
final FileSystemStyle fsStyle =
    io.Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
fs = MemoryFileSystem.test(style: fsStyle);

// Setup the home directory since `MemoryFileSystem.test()` is empty
const String homeDirName = 'home';
final Directory home = fs.directory(homeDirName);
home.createSync();

final List<DashTool> onboardedTools = Analytics.onboardedTools(fs: fs, homeDirectoryOverride: home);
```