### PR TITLE
Align to PDD

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Error handling functionality added to prevent malformed session json data from causing a crash
 - Creating a new analytics constructor to point to a test instance of Google Analytics for developers
-- Exposing static method to retrieve the consent message without having to initialize the `Analytics`
+- Exposing a new instance method that will need to be invoked when a client has successfully shown the consent message to the user `clientShowedMessage()`
 
 ## 0.1.2
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Error handling functionality added to prevent malformed session json data from causing a crash
 - Creating a new analytics constructor to point to a test instance of Google Analytics for developers
+- Exposing static method to retrieve the consent message without having to initialize the `Analytics`
 
 ## 0.1.2
 

--- a/pkgs/unified_analytics/USAGE_GUIDE.md
+++ b/pkgs/unified_analytics/USAGE_GUIDE.md
@@ -94,17 +94,29 @@ of the tool using this package to display the proper Analytics messaging
 and inform them on how to Opt-Out of Analytics collection if they wish. The
 package will expose APIs that will make it easy to configure Opt-In status.
 
+For this use case, it is best to use the `Analytics` static method `getConsentMessage`
+which requires passing in the `DashTool` currently using this package
+
+Passing in the `DashTool` is necessary so that the message can include which
+tool is seeking consent
+
 ```dart
-// Begin by initializing the class
-final Analytics analytics = Analytics(...);
+final String consentMessage = Analytics.getConsentMessage(tool: DashTool.flutterTools);
 
-// This should be performed every time the tool starts up
-if (analytics.shouldShowMessage) {
-
-  // How each tool displays the message will be unique,
-  // print statement used for trivial usage example
-  print(analytics.toolsMessage);
-}
+/// Printing out the consent message above returns the below
+///
+/// The flutter_tools uses Google Analytics to report usage and diagnostic data
+/// along with package dependencies, and crash reporting to send basic crash reports.
+/// This data is used to help improve the Dart platform, Flutter framework, and related tools.
+/// 
+/// Telemetry is not sent on the very first run.
+/// To disable reporting of telemetry, run this terminal command:
+/// 
+/// [dart|flutter] --disable-telemetry.
+/// If you opt out of telemetry, an opt-out event will be sent,
+/// and then no further information will be sent.
+/// This data is collected in accordance with the
+/// Google Privacy Policy (https://policies.google.com/privacy).
 ```
 
 ## Checking User Opt-In Status

--- a/pkgs/unified_analytics/USAGE_GUIDE.md
+++ b/pkgs/unified_analytics/USAGE_GUIDE.md
@@ -8,7 +8,7 @@ initialize with the required parameters
 
 **IMPORTANT**: It is best practice to close the http client connection when finished
 sending events, otherwise, you may notice that the dart process hangs on exit. The example below
-shows how to handle closing the connection via `analytics.close()` method
+shows how to handle closing the connection via `analytics.close()` method.
 
 [Link to documentation for http client's close method](https://pub.dev/documentation/http/latest/http/Client-class.html)
 
@@ -72,7 +72,7 @@ void main() {
 It will be important for each tool to expose a trivial method to
 disabling or enabling analytics collection. Based on how the user interacts
 with the tool, this can be done through the CLI, IDE, etc. The tool will
-then pass a boolean to an API exposed by the package as shown below
+then pass a boolean to an API exposed by the package as shown below.
 
 ```dart
 // Begin by initializing the class
@@ -86,7 +86,7 @@ final bool status = false;
 analytics.setTelemetry(status);
 ```
 
-## Informing Users About Analytics Opt-In Status
+## Displaying Consent Message to Users
 
 When a user first uses any tool with this package enabled, they
 will be enrolled into Analytics collection. It will be the responsiblity
@@ -95,13 +95,15 @@ and inform them on how to Opt-Out of Analytics collection if they wish. The
 package will expose APIs that will make it easy to configure Opt-In status.
 
 For this use case, it is best to use the `Analytics` static method `getConsentMessage`
-which requires passing in the `DashTool` currently using this package
+which requires passing in the `DashTool` currently using this package.
 
 Passing in the `DashTool` is necessary so that the message can include which
-tool is seeking consent
+tool is seeking consent.
 
 ```dart
-final String consentMessage = Analytics.getConsentMessage(tool: DashTool.flutterTools);
+final String consentMessage = Analytics.getConsentMessage(
+  tool: DashTool.flutterTools
+);
 
 /// Printing out the consent message above returns the below
 ///
@@ -123,7 +125,7 @@ final String consentMessage = Analytics.getConsentMessage(tool: DashTool.flutter
 
 Some tools may need to know if the user has opted in for Analytics
 collection in order to enable additional functionality. The example below
-shows how to check the status
+shows how to check the status.
 
 ```dart
 // Begin by initializing the class
@@ -134,11 +136,43 @@ final Analytics analytics = Analytics(...);
 print('This user's status: ${analytics.telemetryEnabled}');  // true if opted-in
 ```
 
+## Checking for New Versions of Consent Message
+
+In the event that the package consent messaging needs has been updated, an
+API has been exposed on an instance of `Analytics` that will notify the tool
+using this package whether to display the message again.
+
+```dart
+// Begin by initializing the class
+//
+// This is assuming that the tool has already been onboarded
+// and that the user has already seen the previous version of
+// the consent message
+final Analytics analytics = Analytics(...);
+
+
+// Check the instance's method on if it should show
+// a message
+if (analytics.shouldShowMessage) {
+
+  // Use the static method to return the latest consent message
+  final String newConsentMessage = Analytics.getConsentMessage(
+    tool: DashTool.flutterTools
+  );
+
+  // Using print statement to simulate a client showing the message
+  print(newConsentMessage);
+}
+```
+
+It is important to note events will not be sent if there is a new version of
+the consent message.
+
 ## Developing Within `package:unified_analytics`
 
 When contributing to this package, if the developer needs to verify that
 events have been sent, the developer should the use development constructor
-so that the events being sent are not going into the production instance
+so that the events being sent are not going into the production instance.
 
 ```dart
 final Analytics analytics = Analytics.development(...);
@@ -156,7 +190,7 @@ shows that the user has not been active for N number of days, a tool that
 works within an IDE can prompt the user with a survey to understand why their
 level of activity has dropped.
 
-The snippet below shows how to invoke the query and a sample response
+The snippet below shows how to invoke the query and a sample response.
 
 ```dart
 // Begin by initializing the class

--- a/pkgs/unified_analytics/USAGE_GUIDE.md
+++ b/pkgs/unified_analytics/USAGE_GUIDE.md
@@ -38,6 +38,26 @@ void main() {
     DateTime start = DateTime.now();
     int count = 0;
 
+    // Each client using this package will have it's own
+    // method to show the message but the below is a trivial
+    // example of how to properly initialize the analytics instance
+    if (analytics.shouldShowMessage) {
+      
+      // Simulates displaying the message, this will vary from
+      // client to client; ie. stdout, popup in IDE, etc.
+      print(analytics.getConsentMessage);
+
+      // After receiving confirmation that the message has been
+      // displayed, invoking the below method will successfully
+      // onboard the tool into the config file and allow for
+      // events to be sent on the next creation of the analytics
+      // instance
+      //
+      // The rest of the example below assumes that the tool has
+      // already been onboarded in a previous run
+      analytics.clientShowedMessage();
+    }
+
     // Example of long running process
     for (int i = 0; i < 2000; i++) {
         count += i;
@@ -107,7 +127,7 @@ final String consentMessage = Analytics.getConsentMessage(
 
 /// Printing out the consent message above returns the below
 ///
-/// The flutter_tools uses Google Analytics to report usage and diagnostic data
+/// The flutter tools uses Google Analytics to report usage and diagnostic data
 /// along with package dependencies, and crash reporting to send basic crash reports.
 /// This data is used to help improve the Dart platform, Flutter framework, and related tools.
 /// 
@@ -151,17 +171,24 @@ using this package whether to display the message again.
 final Analytics analytics = Analytics(...);
 
 
-// Check the instance's method on if it should show
-// a message
+// Much like the first example, if there is a new version of
+// the tools message that needs to be shown, use the same work
+// workflow
 if (analytics.shouldShowMessage) {
+  
+  // Simulates displaying the message, this will vary from
+  // client to client; ie. stdout, popup in IDE, etc.
+  print(analytics.getConsentMessage);
 
-  // Use the static method to return the latest consent message
-  final String newConsentMessage = Analytics.getConsentMessage(
-    tool: DashTool.flutterTools
-  );
-
-  // Using print statement to simulate a client showing the message
-  print(newConsentMessage);
+  // After receiving confirmation that the message has been
+  // displayed, invoking the below method will successfully
+  // onboard the tool into the config file and allow for
+  // events to be sent on the next creation of the analytics
+  // instance
+  //
+  // The rest of the example below assumes that the tool has
+  // already been onboarded in a previous run
+  analytics.clientShowedMessage();
 }
 ```
 

--- a/pkgs/unified_analytics/example/unified_analytics_example.dart
+++ b/pkgs/unified_analytics/example/unified_analytics_example.dart
@@ -20,6 +20,9 @@ void main() {
   DateTime start = DateTime.now();
   print('###### START ###### $start');
 
+  // Automatically assume that the client has shown the message
+  analytics.clientShowedMessage();
+
   print(analytics.telemetryEnabled);
   // [eventData] is an optional map to add relevant data
   // for the [eventName] being sent

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -238,8 +238,14 @@ class AnalyticsImpl implements Analytics {
     // If the tool has already been added to the config file
     // we can assume that the client has successfully shown
     // the consent message
+    //
+    // Additionally, if the tool does not exist in the config
+    // file but the config file already exists, prompt with
+    // message again
     if (_configHandler.parsedTools.containsKey(tool.label)) {
       _clientShowedMessage = true;
+    } else {
+      _showMessage = true;
     }
 
     // Check if the tool has already been onboarded, and if it

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -249,7 +249,8 @@ class AnalyticsImpl implements Analytics {
       _configHandler.addTool(tool: tool.label);
       _showMessage = true;
     }
-    if (_configHandler.parsedTools[tool.label]!.versionNumber < toolsMessageVersion) {
+    if (_configHandler.parsedTools[tool.label]!.versionNumber <
+        toolsMessageVersion) {
       _configHandler.incrementToolVersion(tool: tool.label);
       _showMessage = true;
     }

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -203,6 +203,7 @@ class AnalyticsImpl implements Analytics {
   late final UserProperty userProperty;
   late final LogHandler _logHandler;
   final int toolsMessageVersion;
+  bool _clientShowedMessage = false;
 
   AnalyticsImpl({
     required this.tool,
@@ -284,6 +285,7 @@ class AnalyticsImpl implements Analytics {
       _configHandler.incrementToolVersion(tool: tool.label);
       _showMessage = true;
     }
+    _clientShowedMessage = true;
   }
 
   @override
@@ -304,7 +306,10 @@ class AnalyticsImpl implements Analytics {
     // time the tool is using analytics or if there has been an update
     // the messaging found in constants.dart - in both cases, analytics
     // will not be sent until the second time the tool is used
-    if (!telemetryEnabled || _showMessage) return null;
+    //
+    // Additionally, if the client has not invoked `clientShowedMessage`,
+    // then no events shall be sent
+    if (!telemetryEnabled || _showMessage || !_clientShowedMessage) return null;
 
     // Construct the body of the request
     final Map<String, Object?> body = generateRequestBody(
@@ -367,7 +372,7 @@ class TestAnalytics extends AnalyticsImpl {
     required DashEvent eventName,
     Map<String, Object?> eventData = const {},
   }) {
-    if (!telemetryEnabled || _showMessage) return null;
+    if (!telemetryEnabled || _showMessage || !_clientShowedMessage) return null;
 
     // Calling the [generateRequestBody] method will ensure that the
     // session file is getting updated without actually making any

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -238,22 +238,19 @@ class AnalyticsImpl implements Analytics {
     // If the tool has already been added to the config file
     // we can assume that the client has successfully shown
     // the consent message
-    //
-    // Additionally, if the tool does not exist in the config
-    // file but the config file already exists, prompt with
-    // message again
     if (_configHandler.parsedTools.containsKey(tool.label)) {
       _clientShowedMessage = true;
-    } else {
-      _showMessage = true;
     }
 
     // Check if the tool has already been onboarded, and if it
     // has, check if the latest message version is greater to
     // prompt the client to show a message
-    if (_configHandler.parsedTools.containsKey(tool.label) &&
-        _configHandler.parsedTools[tool.label]!.versionNumber <
-            toolsMessageVersion) {
+    // 
+    // If the tool has not been added to the config file, then
+    // we will show the message as well
+    final int currentVersion =
+        _configHandler.parsedTools[tool.label]?.versionNumber ?? -1;
+    if (currentVersion < toolsMessageVersion) {
       _showMessage = true;
     }
 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -52,7 +52,7 @@ abstract class Analytics {
     );
 
     return AnalyticsImpl(
-      tool: tool.label,
+      tool: tool,
       homeDirectory: getHomeDirectory(fs),
       flutterChannel: flutterChannel,
       flutterVersion: flutterVersion,
@@ -100,7 +100,7 @@ abstract class Analytics {
     );
 
     return AnalyticsImpl(
-      tool: tool.label,
+      tool: tool,
       homeDirectory: getHomeDirectory(fs),
       flutterChannel: flutterChannel,
       flutterVersion: flutterVersion,
@@ -117,7 +117,7 @@ abstract class Analytics {
   /// [MemoryFileSystem] to use for testing
   @visibleForTesting
   factory Analytics.test({
-    required String tool,
+    required DashTool tool,
     required Directory homeDirectory,
     required String measurementId,
     required String apiSecret,
@@ -161,6 +161,11 @@ abstract class Analytics {
   /// [shouldShowMessage] returns true
   String get toolsMessage;
 
+  /// Static method to use before initializing the [Analytics] class
+  /// to display the consent message to the user
+  static String getConsentMessage({required DashTool tool}) =>
+      kToolsMessage.replaceAll('[tool name]', tool.label);
+
   /// Returns a map representation of the [UserProperty] for the [Analytics] instance
   ///
   /// This is what will get sent to Google Analytics with every request
@@ -192,6 +197,7 @@ abstract class Analytics {
 }
 
 class AnalyticsImpl implements Analytics {
+  final DashTool tool;
   final FileSystem fs;
   late final ConfigHandler _configHandler;
   late bool _showMessage;
@@ -204,7 +210,7 @@ class AnalyticsImpl implements Analytics {
   final String toolsMessage;
 
   AnalyticsImpl({
-    required String tool,
+    required this.tool,
     required Directory homeDirectory,
     String? flutterChannel,
     String? flutterVersion,
@@ -220,7 +226,7 @@ class AnalyticsImpl implements Analytics {
     // on the first run
     final Initializer initializer = Initializer(
       fs: fs,
-      tool: tool,
+      tool: tool.label,
       homeDirectory: homeDirectory,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -239,12 +245,12 @@ class AnalyticsImpl implements Analytics {
     // tool message and version have been updated from what
     // is in the current file; if there is a new message version
     // make the necessary updates
-    if (!_configHandler.parsedTools.containsKey(tool)) {
-      _configHandler.addTool(tool: tool);
+    if (!_configHandler.parsedTools.containsKey(tool.label)) {
+      _configHandler.addTool(tool: tool.label);
       _showMessage = true;
     }
-    if (_configHandler.parsedTools[tool]!.versionNumber < toolsMessageVersion) {
-      _configHandler.incrementToolVersion(tool: tool);
+    if (_configHandler.parsedTools[tool.label]!.versionNumber < toolsMessageVersion) {
+      _configHandler.incrementToolVersion(tool: tool.label);
       _showMessage = true;
     }
     _clientId = fs
@@ -262,7 +268,7 @@ class AnalyticsImpl implements Analytics {
       host: platform.label,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
-      tool: tool,
+      tool: tool.label,
     );
 
     // Initialize the log handler to persist events that are being sent

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -235,6 +235,15 @@ class AnalyticsImpl implements Analytics {
       initializer: initializer,
     );
 
+    // Check if the tool has already been onboarded, and if it
+    // has, check if the latest message version is greater to
+    // prompt the client to show a message
+    if (_configHandler.parsedTools.containsKey(tool.label) &&
+        _configHandler.parsedTools[tool.label]!.versionNumber <
+            toolsMessageVersion) {
+      _showMessage = true;
+    }
+
     _clientId = fs
         .file(p.join(
             homeDirectory.path, kDartToolDirectoryName, kClientIdFileName))

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -58,7 +58,6 @@ abstract class Analytics {
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
       platform: platform,
-      toolsMessage: kToolsMessage,
       toolsMessageVersion: kToolsMessageVersion,
       fs: fs,
       gaClient: gaClient,
@@ -106,7 +105,6 @@ abstract class Analytics {
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
       platform: platform,
-      toolsMessage: kToolsMessage,
       toolsMessageVersion: kToolsMessageVersion,
       fs: fs,
       gaClient: gaClient,
@@ -134,7 +132,6 @@ abstract class Analytics {
         homeDirectory: homeDirectory,
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
-        toolsMessage: toolsMessage,
         flutterVersion: flutterVersion,
         dartVersion: dartVersion,
         platform: platform,
@@ -156,10 +153,6 @@ abstract class Analytics {
 
   /// Boolean indicating whether or not telemetry is enabled
   bool get telemetryEnabled;
-
-  /// Returns the message that should be displayed to the users if
-  /// [shouldShowMessage] returns true
-  String get toolsMessage;
 
   /// Static method to use before initializing the [Analytics] class
   /// to display the consent message to the user
@@ -206,9 +199,6 @@ class AnalyticsImpl implements Analytics {
   late final UserProperty userProperty;
   late final LogHandler _logHandler;
 
-  @override
-  final String toolsMessage;
-
   AnalyticsImpl({
     required this.tool,
     required Directory homeDirectory,
@@ -216,7 +206,6 @@ class AnalyticsImpl implements Analytics {
     String? flutterVersion,
     required String dartVersion,
     required DevicePlatform platform,
-    required this.toolsMessage,
     required int toolsMessageVersion,
     required this.fs,
     required gaClient,
@@ -229,7 +218,6 @@ class AnalyticsImpl implements Analytics {
       tool: tool.label,
       homeDirectory: homeDirectory,
       toolsMessageVersion: toolsMessageVersion,
-      toolsMessage: toolsMessage,
     );
     initializer.run();
     _showMessage = initializer.firstRun;
@@ -360,7 +348,6 @@ class TestAnalytics extends AnalyticsImpl {
     super.flutterVersion,
     required super.dartVersion,
     required super.platform,
-    required super.toolsMessage,
     required super.toolsMessageVersion,
     required super.fs,
     required super.gaClient,

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -235,6 +235,13 @@ class AnalyticsImpl implements Analytics {
       initializer: initializer,
     );
 
+    // If the tool has already been added to the config file
+    // we can assume that the client has successfully shown
+    // the consent message
+    if (_configHandler.parsedTools.containsKey(tool.label)) {
+      _clientShowedMessage = true;
+    }
+
     // Check if the tool has already been onboarded, and if it
     // has, check if the latest message version is greater to
     // prompt the client to show a message

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -144,6 +144,10 @@ abstract class Analytics {
         gaClient: FakeGAClient(),
       );
 
+  /// Retrieves the consent message to prompt users with on first
+  /// run or when the message has been updated
+  String get getConsentMessage;
+
   /// Returns a map object with all of the tools that have been parsed
   /// out of the configuration file
   Map<String, ToolInfo> get parsedTools;
@@ -153,11 +157,6 @@ abstract class Analytics {
 
   /// Boolean indicating whether or not telemetry is enabled
   bool get telemetryEnabled;
-
-  /// Static method to use before initializing the [Analytics] class
-  /// to display the consent message to the user
-  static String getConsentMessage({required DashTool tool}) =>
-      kToolsMessage.replaceAll('[tool name]', tool.label);
 
   /// Returns a map representation of the [UserProperty] for the [Analytics] instance
   ///
@@ -263,6 +262,10 @@ class AnalyticsImpl implements Analytics {
     // Initialize the log handler to persist events that are being sent
     _logHandler = LogHandler(fs: fs, homeDirectory: homeDirectory);
   }
+
+  @override
+  String get getConsentMessage =>
+      kToolsMessage.replaceAll('[tool name]', tool.label.replaceAll('_', ' '));
 
   @override
   Map<String, ToolInfo> get parsedTools => _configHandler.parsedTools;

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -245,7 +245,7 @@ class AnalyticsImpl implements Analytics {
     // Check if the tool has already been onboarded, and if it
     // has, check if the latest message version is greater to
     // prompt the client to show a message
-    // 
+    //
     // If the tool has not been added to the config file, then
     // we will show the message as well
     final int currentVersion =

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -10,7 +10,7 @@ const String kAnalyticsUrl = 'https://www.google-analytics.com/mp/collect';
 const String kClientIdFileName = 'CLIENT_ID';
 
 /// Name for the file where telemetry status and tools data will be stored
-const String kConfigFileName = 'dash-analytics.config';
+const String kConfigFileName = 'dart-flutter-telemetry.config';
 
 /// The string that will provide the boilerplate for the configuration file
 /// stored on the user's machine
@@ -53,7 +53,7 @@ reporting=1
 
 /// Name of the directory where all of the files necessary for this package
 /// will be located
-const String kDartToolDirectoryName = '.dart';
+const String kDartToolDirectoryName = '.dart-tool';
 
 /// The API secret associated with the GA4 instance's Measurement Protocol
 const String kGoogleAnalyticsApiSecret = 'Ka1jc8tZSzWc_GXMWHfPHA';
@@ -67,7 +67,7 @@ const String kGoogleAnalyticsMeasurementId = 'G-04BXPVBCWJ';
 const int kLogFileLength = 2500;
 
 /// Filename for the log file to persist sent events on user's machine
-const String kLogFileName = 'dash-analytics.log';
+const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
 const String kPackageVersion = '0.1.3-dev';
@@ -76,36 +76,21 @@ const String kPackageVersion = '0.1.3-dev';
 const int kSessionDurationMinutes = 30;
 
 /// Name for the json file where the session details will be stored
-const String kSessionFileName = 'dash-analytics-session.json';
+const String kSessionFileName = 'dart-flutter-telemetry-session.json';
 
 /// The message that should be shown to the user
 const String kToolsMessage = '''
-Flutter and Dart related tooling uses Google Analytics to report usage and
-diagnostic data along with package dependencies, and crash reporting to
-send basic crash reports. This data is used to help improve the Dart
-platform, Flutter framework, and related tools.
+The [tool name] uses Google Analytics to report usage and diagnostic data
+along with package dependencies, and crash reporting to send basic crash reports.
+This data is used to help improve the Dart platform, Flutter framework, and related tools.
 
-Telemetry is not sent on the very first run, but will be sent
-on subsequent runs if not disabled explicitly.
-
+Telemetry is not sent on the very first run.
 To disable reporting of telemetry, run this terminal command:
 
-flutter config --no-analytics
-  OR
-dart --disable-analytics
-
-To enable reporting of telemetry, run this terminal command:
-
-flutter config --analytics
-  OR
-dart --enable-analytics
-
-You can use either the flutter or dart command if both are installed,
-they will set the telemetry status for both tools and any other
-related tooling.
-
-If you opt out of telemetry, an opt-out event will be sent, and then no further
-information will be sent. This data is collected in accordance with the
+[dart|flutter] --disable-telemetry.
+If you opt out of telemetry, an opt-out event will be sent,
+and then no further information will be sent.
+This data is collected in accordance with the
 Google Privacy Policy (https://policies.google.com/privacy).
 ''';
 

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -17,7 +17,6 @@ class Initializer {
   final String tool;
   final Directory homeDirectory;
   final int toolsMessageVersion;
-  final String toolsMessage;
   bool firstRun = false;
 
   /// Responsibe for the initialization of the files
@@ -34,7 +33,6 @@ class Initializer {
     required this.tool,
     required this.homeDirectory,
     required this.toolsMessageVersion,
-    required this.toolsMessage,
   });
 
   /// Get a string representation of the current date in the following format
@@ -57,7 +55,6 @@ class Initializer {
     required File configFile,
     required String dateStamp,
     required String tool,
-    required String toolsMessage,
     required int toolsMessageVersion,
   }) {
     configFile.createSync(recursive: true);
@@ -106,7 +103,6 @@ $tool=$dateStamp,$toolsMessageVersion
         configFile: configFile,
         dateStamp: dateStamp,
         tool: tool,
-        toolsMessage: toolsMessage,
         toolsMessageVersion: toolsMessageVersion,
       );
     }

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -58,10 +58,7 @@ class Initializer {
     required int toolsMessageVersion,
   }) {
     configFile.createSync(recursive: true);
-    configFile.writeAsStringSync('''
-$kConfigString
-$tool=$dateStamp,$toolsMessageVersion
-''');
+    configFile.writeAsStringSync(kConfigString);
   }
 
   /// Creates that log file that will store the record formatted

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -31,8 +31,8 @@ void main() {
   late UserProperty userProperty;
 
   const String homeDirName = 'home';
-  const String initialToolName = 'initial_tool';
-  const String secondTool = 'newTool';
+  const DashTool initialTool = DashTool.flutterTools;
+  const DashTool secondTool = DashTool.dartTools;
   const String measurementId = 'measurementId';
   const String apiSecret = 'apiSecret';
   const int toolsMessageVersion = 1;
@@ -53,7 +53,7 @@ void main() {
     // This is the first analytics instance that will be used to demonstrate
     // that events will not be sent with the first run of analytics
     initializationAnalytics = Analytics.test(
-      tool: initialToolName,
+      tool: initialTool,
       homeDirectory: home,
       measurementId: measurementId,
       apiSecret: apiSecret,
@@ -72,7 +72,7 @@ void main() {
     // This instance should have the same parameters as the one above for
     // [initializationAnalytics]
     analytics = Analytics.test(
-      tool: initialToolName,
+      tool: initialTool,
       homeDirectory: home,
       measurementId: measurementId,
       apiSecret: apiSecret,
@@ -104,11 +104,13 @@ void main() {
       host: platform.label,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
-      tool: initialToolName,
+      tool: initialTool.label,
     );
   });
 
   test('Initializer properly sets up on first run', () {
+    print(Analytics.getConsentMessage(tool: DashTool.dartTools));
+
     expect(dartToolDirectory.existsSync(), true,
         reason: 'The directory should have been created');
     expect(clientIdFile.existsSync(), true,
@@ -167,9 +169,9 @@ void main() {
     expect(secondAnalytics.parsedTools.length, equals(2),
         reason: 'There should be only 2 tools that have '
             'been parsed into the config file');
-    expect(secondAnalytics.parsedTools.containsKey(initialToolName), true,
-        reason: 'The first tool: $initialToolName should be in the map');
-    expect(secondAnalytics.parsedTools.containsKey(secondTool), true,
+    expect(secondAnalytics.parsedTools.containsKey(initialTool.label), true,
+        reason: 'The first tool: ${initialTool.label} should be in the map');
+    expect(secondAnalytics.parsedTools.containsKey(secondTool.label), true,
         reason: 'The second tool: $secondAnalytics should be in the map');
     expect(configFile.readAsStringSync().startsWith(kConfigString), true,
         reason:
@@ -341,7 +343,7 @@ void main() {
   });
 
   test('Incrementing the version for a tool is successful', () {
-    expect(analytics.parsedTools[initialToolName]?.versionNumber,
+    expect(analytics.parsedTools[initialTool.label]?.versionNumber,
         toolsMessageVersion,
         reason: 'On initialization, the first version number should '
             'be what is set in the setup method');
@@ -350,7 +352,7 @@ void main() {
     // the first analytics instance except with a newer version for
     // the tools message and version
     final Analytics secondAnalytics = Analytics.test(
-      tool: initialToolName,
+      tool: initialTool,
       homeDirectory: home,
       measurementId: measurementId,
       apiSecret: apiSecret,
@@ -363,7 +365,7 @@ void main() {
       platform: platform,
     );
 
-    expect(secondAnalytics.parsedTools[initialToolName]?.versionNumber,
+    expect(secondAnalytics.parsedTools[initialTool.label]?.versionNumber,
         toolsMessageVersion + 1,
         reason:
             'The second analytics instance should have incremented the version');
@@ -460,8 +462,8 @@ reporting=1
 # and the value is a date in the form YYYY-MM-DD, a comma, and
 # a number representing the version of the message that was
 # displayed.
-$initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
-$initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
+${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
+${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
 ''');
 
     // Initialize a second analytics class for the same tool as
@@ -471,7 +473,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
     // This second instance should reset the config file when it goes
     // to increment the version in the file
     final Analytics secondAnalytics = Analytics.test(
-      tool: initialToolName,
+      tool: initialTool,
       homeDirectory: home,
       measurementId: measurementId,
       apiSecret: apiSecret,
@@ -486,13 +488,13 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
 
     expect(
       configFile.readAsStringSync().endsWith(
-          '# displayed.\n$initialToolName=${ConfigHandler.dateStamp},${toolsMessageVersion + 1}\n'),
+          '# displayed.\n${initialTool.label}=${ConfigHandler.dateStamp},${toolsMessageVersion + 1}\n'),
       true,
       reason: 'The config file ends with the correctly formatted ending '
           'after removing the duplicate lines for a given tool',
     );
     expect(
-      secondAnalytics.parsedTools[initialToolName]?.versionNumber,
+      secondAnalytics.parsedTools[initialTool.label]?.versionNumber,
       toolsMessageVersion + 1,
       reason: 'The new version should have been incremented',
     );

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -65,6 +65,7 @@ void main() {
       fs: fs,
       platform: platform,
     );
+    initializationAnalytics.clientShowedMessage();
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
@@ -163,6 +164,7 @@ void main() {
       fs: fs,
       platform: platform,
     );
+    secondAnalytics.clientShowedMessage();
 
     expect(secondAnalytics.parsedTools.length, equals(2),
         reason: 'There should be only 2 tools that have '
@@ -257,6 +259,7 @@ void main() {
       fs: fs,
       platform: platform,
     );
+    secondAnalytics.clientShowedMessage();
 
     expect(secondAnalytics.telemetryEnabled, false,
         reason: 'Analytics telemetry should be disabled by the first class '
@@ -280,6 +283,7 @@ void main() {
       fs: fs,
       platform: platform,
     );
+    secondAnalytics.clientShowedMessage();
 
     expect(analytics.telemetryEnabled, true,
         reason: 'Telemetry should be enabled on initialization for '
@@ -333,6 +337,8 @@ void main() {
       fs: fs,
       platform: platform,
     );
+    secondAnalytics.clientShowedMessage();
+
     expect(secondAnalytics.telemetryEnabled, true);
 
     expect(configFile.readAsStringSync().endsWith('\n'), true,
@@ -362,6 +368,7 @@ void main() {
       fs: fs,
       platform: platform,
     );
+    secondAnalytics.clientShowedMessage();
 
     expect(secondAnalytics.parsedTools[initialTool.label]?.versionNumber,
         toolsMessageVersion + 1,
@@ -464,6 +471,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
 ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
 ''');
 
+    print('AFTER EDITTING FILE');
     // Initialize a second analytics class for the same tool as
     // the first analytics instance except with a newer version for
     // the tools message and version
@@ -483,6 +491,32 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
       fs: fs,
       platform: platform,
     );
+    secondAnalytics.clientShowedMessage();
+
+    expect(
+      configFile.readAsStringSync(),
+      kConfigString,
+      reason: 'The config file should have been reset completely '
+          'due to a malformed file that contained two lines for the same tool',
+    );
+
+    // Creating a third instance after the second instance
+    // has reset the config file should include the newly added
+    // tool again with its incremented version number
+    final Analytics thirdAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion + 1,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+    thirdAnalytics.clientShowedMessage();
 
     expect(
       configFile.readAsStringSync().endsWith(
@@ -492,7 +526,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
           'after removing the duplicate lines for a given tool',
     );
     expect(
-      secondAnalytics.parsedTools[initialTool.label]?.versionNumber,
+      thirdAnalytics.parsedTools[initialTool.label]?.versionNumber,
       toolsMessageVersion + 1,
       reason: 'The new version should have been incremented',
     );
@@ -551,6 +585,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
         fs: fs,
         platform: platform,
       );
+      secondAnalytics.clientShowedMessage();
 
       // Read the contents of the session file
       final String sessionFileContents = sessionFile.readAsStringSync();
@@ -630,6 +665,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
         fs: fs,
         platform: platform,
       );
+      secondAnalytics.clientShowedMessage();
 
       // Read the contents of the session file
       final String sessionFileContents = sessionFile.readAsStringSync();
@@ -839,6 +875,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
         fs: fs,
         platform: platform,
       );
+      secondAnalytics.clientShowedMessage();
     }
 
     // Send events with both instances of the classes
@@ -941,6 +978,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
         fs: fs,
         platform: platform,
       );
+      secondAnalytics.clientShowedMessage();
     }
 
     // Send an event and check that the query stats reflects what is expected

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -1054,4 +1054,13 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
     expect(kGoogleAnalyticsApiSecret, 'Ka1jc8tZSzWc_GXMWHfPHA');
     expect(kGoogleAnalyticsMeasurementId, 'G-04BXPVBCWJ');
   });
+
+  test('Consent message is formatted correctly', () {
+    // Retrieve the consent message for flutter tools
+    final String consentMessage =
+        Analytics.getConsentMessage(tool: DashTool.flutterTools);
+
+    expect(consentMessage,
+        kToolsMessage.replaceAll('[tool name]', DashTool.flutterTools.label));
+  });
 }

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -471,7 +471,6 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
 ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
 ''');
 
-    print('AFTER EDITTING FILE');
     // Initialize a second analytics class for the same tool as
     // the first analytics instance except with a newer version for
     // the tools message and version

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -109,8 +109,6 @@ void main() {
   });
 
   test('Initializer properly sets up on first run', () {
-    print(Analytics.getConsentMessage(tool: DashTool.dartTools));
-
     expect(dartToolDirectory.existsSync(), true,
         reason: 'The directory should have been created');
     expect(clientIdFile.existsSync(), true,

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -1057,10 +1057,11 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
 
   test('Consent message is formatted correctly', () {
     // Retrieve the consent message for flutter tools
-    final String consentMessage =
-        Analytics.getConsentMessage(tool: DashTool.flutterTools);
+    final String consentMessage = analytics.getConsentMessage;
 
-    expect(consentMessage,
-        kToolsMessage.replaceAll('[tool name]', DashTool.flutterTools.label));
+    expect(
+        consentMessage,
+        kToolsMessage.replaceAll(
+            '[tool name]', DashTool.flutterTools.label.replaceAll('_', ' ')));
   });
 }

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -85,6 +85,7 @@ void main() {
       fs: fs,
       platform: platform,
     );
+    analytics.clientShowedMessage();
 
     // The 3 files that should have been generated
     clientIdFile = home
@@ -617,6 +618,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
         fs: fs,
         platform: platform,
       );
+      thirdAnalytics.clientShowedMessage();
 
       // Calling the send event method will result in the session file
       // getting updated but because we use the `Analytics.test()` constructor
@@ -700,6 +702,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
         fs: fs,
         platform: platform,
       );
+      thirdAnalytics.clientShowedMessage();
 
       // Calling the send event method will result in the session file
       // getting updated but because we use the `Analytics.test()` constructor

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -22,7 +22,6 @@ void main() {
 
   const String homeDirName = 'home';
   const DashTool initialTool = DashTool.flutterTools;
-  const DashTool secondTool = DashTool.dartTools;
   const String measurementId = 'measurementId';
   const String apiSecret = 'apiSecret';
   const int toolsMessageVersion = 1;

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -11,7 +11,6 @@ import 'package:test/test.dart';
 import 'package:unified_analytics/src/constants.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
-
 void main() {
   late FileSystem fs;
   late Directory home;

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -204,4 +204,56 @@ void main() {
         eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
     expect(logFile.readAsLinesSync().length, 3);
   });
+
+  test('Disable second instance if first one did not show message', () {
+    final Analytics firstAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(firstAnalytics.shouldShowMessage, true);
+
+    final Analytics secondAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(secondAnalytics.shouldShowMessage, true);
+
+    secondAnalytics.clientShowedMessage();
+
+    final Analytics thirdAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(thirdAnalytics.shouldShowMessage, false);
+  });
 }

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -149,7 +149,7 @@ void main() {
       measurementId: measurementId,
       apiSecret: apiSecret,
       flutterChannel: flutterChannel,
-      toolsMessageVersion: toolsMessageVersion + 1,  // Incrementing version
+      toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
@@ -183,7 +183,7 @@ void main() {
       measurementId: measurementId,
       apiSecret: apiSecret,
       flutterChannel: flutterChannel,
-      toolsMessageVersion: toolsMessageVersion + 1,  // Incrementing version
+      toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -1,0 +1,209 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:test/test.dart';
+
+import 'package:unified_analytics/src/constants.dart';
+import 'package:unified_analytics/unified_analytics.dart';
+
+
+void main() {
+  late FileSystem fs;
+  late Directory home;
+  late Directory dartToolDirectory;
+  late File clientIdFile;
+  late File sessionFile;
+  late File configFile;
+  late File logFile;
+
+  const String homeDirName = 'home';
+  const DashTool initialTool = DashTool.flutterTools;
+  const DashTool secondTool = DashTool.dartTools;
+  const String measurementId = 'measurementId';
+  const String apiSecret = 'apiSecret';
+  const int toolsMessageVersion = 1;
+  const String toolsMessage = 'toolsMessage';
+  const String flutterChannel = 'flutterChannel';
+  const String flutterVersion = 'flutterVersion';
+  const String dartVersion = 'dartVersion';
+  const DevicePlatform platform = DevicePlatform.macos;
+
+  setUp(() {
+    // Setup the filesystem with the home directory
+    final FileSystemStyle fsStyle =
+        io.Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
+    fs = MemoryFileSystem.test(style: fsStyle);
+    home = fs.directory(homeDirName);
+    dartToolDirectory = home.childDirectory(kDartToolDirectoryName);
+
+    // The 3 files that should have been generated
+    clientIdFile = home
+        .childDirectory(kDartToolDirectoryName)
+        .childFile(kClientIdFileName);
+    sessionFile =
+        home.childDirectory(kDartToolDirectoryName).childFile(kSessionFileName);
+    configFile =
+        home.childDirectory(kDartToolDirectoryName).childFile(kConfigFileName);
+    logFile =
+        home.childDirectory(kDartToolDirectoryName).childFile(kLogFileName);
+  });
+
+  test('Confirm workflow for checking tools into the config file', () {
+    final Analytics firstAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    // Host of assertions to ensure all required artifacts
+    // are created
+    expect(dartToolDirectory.existsSync(), true,
+        reason: 'The directory should have been created');
+    expect(clientIdFile.existsSync(), true,
+        reason: 'The $kClientIdFileName file was not found');
+    expect(sessionFile.existsSync(), true,
+        reason: 'The $kSessionFileName file was not found');
+    expect(configFile.existsSync(), true,
+        reason: 'The $kConfigFileName was not found');
+    expect(logFile.existsSync(), true,
+        reason: 'The $kLogFileName file was not found');
+    expect(dartToolDirectory.listSync().length, equals(4),
+        reason:
+            'There should only be 4 files in the $kDartToolDirectoryName directory');
+    expect(configFile.readAsStringSync(), kConfigString);
+
+    expect(firstAnalytics.shouldShowMessage, true);
+
+    // Attempting to send a message with this instance should be
+    // blocked because it has not invoked `clientShowedMessage()`
+    // and it is the first run
+    //
+    // Even after invoking the method, it should be prevented from
+    // sending a message because it is the first time the tool was
+    // run in this instance
+    firstAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    expect(logFile.readAsLinesSync().length, 0);
+    firstAnalytics.clientShowedMessage();
+
+    // Attempt to send two events, both should be blocked because it is
+    // part of the first instance
+    firstAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    firstAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    expect(logFile.readAsLinesSync().length, 0);
+
+    // Creating a second analytics instance from the same tool now should
+    // allow for events to be sent only after invoking `clientShowedMessage`
+    final Analytics secondAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(secondAnalytics.shouldShowMessage, false);
+    secondAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    expect(logFile.readAsLinesSync().length, 0,
+        reason: 'Events will be blocked until invoking method '
+            'ensuring client has seen message');
+    secondAnalytics.clientShowedMessage();
+    secondAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    secondAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    expect(logFile.readAsLinesSync().length, 2);
+
+    // Next, we will want to confirm that the message should be showing when
+    // a new analytics instance has been created with a newer version for
+    // message that should be shown
+    //
+    // In this case, it should be treated as a new tool being added for the first
+    // time and all events should be blocked
+
+    // Delete the log file to reset the counter of events sent
+    logFile.deleteSync();
+    final Analytics thirdAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion + 1,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(logFile.existsSync(), true,
+        reason: 'The $kLogFileName file was not found');
+    expect(thirdAnalytics.shouldShowMessage, true,
+        reason: 'New version number should require showing message');
+    thirdAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    expect(logFile.readAsLinesSync().length, 0);
+    thirdAnalytics.clientShowedMessage();
+
+    // Attempt to send two events, both should be blocked because it is
+    // part of the third instance which has a new version for the consent
+    // message which will be treated as a new tool being onboarded
+    thirdAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    thirdAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    expect(logFile.readAsLinesSync().length, 0);
+
+    // The fourth instance of the analytics class with the consent message
+    // version incremented should now be able to send messages
+    final Analytics fourthAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion + 1,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(fourthAnalytics.shouldShowMessage, false);
+    fourthAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    expect(logFile.readAsLinesSync().length, 0,
+        reason: 'Events will be blocked until invoking method '
+            'ensuring client has seen message');
+    fourthAnalytics.clientShowedMessage();
+    fourthAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    fourthAnalytics.sendEvent(
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
+    expect(logFile.readAsLinesSync().length, 2);
+  });
+}

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -106,7 +106,7 @@ void main() {
     expect(logFile.readAsLinesSync().length, 0);
 
     // Creating a second analytics instance from the same tool now should
-    // allow for events to be sent only after invoking `clientShowedMessage`
+    // allow for events to be sent
     final Analytics secondAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
@@ -124,15 +124,15 @@ void main() {
     expect(secondAnalytics.shouldShowMessage, false);
     secondAnalytics.sendEvent(
         eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
-    expect(logFile.readAsLinesSync().length, 0,
+    expect(logFile.readAsLinesSync().length, 1,
         reason: 'Events will be blocked until invoking method '
             'ensuring client has seen message');
-    secondAnalytics.clientShowedMessage();
+
     secondAnalytics.sendEvent(
         eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
     secondAnalytics.sendEvent(
         eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
-    expect(logFile.readAsLinesSync().length, 2);
+    expect(logFile.readAsLinesSync().length, 3);
 
     // Next, we will want to confirm that the message should be showing when
     // a new analytics instance has been created with a newer version for
@@ -149,7 +149,7 @@ void main() {
       measurementId: measurementId,
       apiSecret: apiSecret,
       flutterChannel: flutterChannel,
-      toolsMessageVersion: toolsMessageVersion + 1,
+      toolsMessageVersion: toolsMessageVersion + 1,  // Incrementing version
       toolsMessage: toolsMessage,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
@@ -183,7 +183,7 @@ void main() {
       measurementId: measurementId,
       apiSecret: apiSecret,
       flutterChannel: flutterChannel,
-      toolsMessageVersion: toolsMessageVersion + 1,
+      toolsMessageVersion: toolsMessageVersion + 1,  // Incrementing version
       toolsMessage: toolsMessage,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
@@ -194,14 +194,14 @@ void main() {
     expect(fourthAnalytics.shouldShowMessage, false);
     fourthAnalytics.sendEvent(
         eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
-    expect(logFile.readAsLinesSync().length, 0,
+    expect(logFile.readAsLinesSync().length, 1,
         reason: 'Events will be blocked until invoking method '
             'ensuring client has seen message');
-    fourthAnalytics.clientShowedMessage();
+
     fourthAnalytics.sendEvent(
         eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
     fourthAnalytics.sendEvent(
         eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
-    expect(logFile.readAsLinesSync().length, 2);
+    expect(logFile.readAsLinesSync().length, 3);
   });
 }


### PR DESCRIPTION
As discussed in the meeting, the following have been added to this PR to align with the PDD
1. Constants found in `constants.dart` have been aligned to match the PDD
2. Creation of static method to retrieve the consent message for a given `DashTool` without having to create an instance of `Analytics` – previously, you had to create an instance of the `Analytics` class to retrieve the message

Other various updates that remove unnecessary inputs for the analytics implementation constructor as well + documentation updates