### PR TITLE
Use version number for incrementing

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Error handling functionality added to prevent malformed session json data from causing a crash
 - Creating a new analytics constructor to point to a test instance of Google Analytics for developers
 - Exposing a new instance method that will need to be invoked when a client has successfully shown the consent message to the user `clientShowedMessage()`
+- Adding and incrementing a tool's version will automatically use the current consent message version instead of incrementing by 1
 
 ## 0.1.2
 

--- a/pkgs/unified_analytics/example/unified_analytics_example.dart
+++ b/pkgs/unified_analytics/example/unified_analytics_example.dart
@@ -20,7 +20,10 @@ void main() {
   DateTime start = DateTime.now();
   print('###### START ###### $start');
 
-  // Automatically assume that the client has shown the message
+  // Confirm to analytics instance that the message was shown;
+  // simplified for this example, tools using this package will
+  // invoke this method after confirming they have showed the
+  // message
   analytics.clientShowedMessage();
 
   print(analytics.telemetryEnabled);

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -212,13 +212,13 @@ class AnalyticsImpl implements Analytics {
   /// This will be switch to true once it has been confirmed by the
   /// client using this package that they have shown this message
   /// to the developer
-  /// 
+  ///
   /// If the tool using this package as already shown the consent message
   /// and it has been added to the config file, it will be set as true
-  /// 
+  ///
   /// It will also be set to true once the tool using this package has
   /// invoked [clientShowedMessage]
-  /// 
+  ///
   /// If this is false, all events will be blocked from being sent
   bool _clientShowedMessage = false;
 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -296,12 +296,18 @@ class AnalyticsImpl implements Analytics {
   @override
   void clientShowedMessage() {
     if (!_configHandler.parsedTools.containsKey(tool.label)) {
-      _configHandler.addTool(tool: tool.label);
+      _configHandler.addTool(
+        tool: tool.label,
+        versionNumber: toolsMessageVersion,
+      );
       _showMessage = true;
     }
     if (_configHandler.parsedTools[tool.label]!.versionNumber <
         toolsMessageVersion) {
-      _configHandler.incrementToolVersion(tool: tool.label);
+      _configHandler.incrementToolVersion(
+        tool: tool.label,
+        newVersionNumber: toolsMessageVersion,
+      );
       _showMessage = true;
     }
     _clientShowedMessage = true;

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -197,12 +197,29 @@ class AnalyticsImpl implements Analytics {
   final DashTool tool;
   final FileSystem fs;
   late final ConfigHandler _configHandler;
-  late bool _showMessage;
   final GAClient _gaClient;
   late final String _clientId;
   late final UserProperty userProperty;
   late final LogHandler _logHandler;
   final int toolsMessageVersion;
+
+  /// Tells the client if they need to show a message to the
+  /// user; this will return true if it is the first time the
+  /// package is being used for a developer or if the consent
+  /// message has been updated by the package
+  late bool _showMessage;
+
+  /// This will be switch to true once it has been confirmed by the
+  /// client using this package that they have shown this message
+  /// to the developer
+  /// 
+  /// If the tool using this package as already shown the consent message
+  /// and it has been added to the config file, it will be set as true
+  /// 
+  /// It will also be set to true once the tool using this package has
+  /// invoked [clientShowedMessage]
+  /// 
+  /// If this is false, all events will be blocked from being sent
   bool _clientShowedMessage = false;
 
   AnalyticsImpl({

--- a/pkgs/unified_analytics/lib/src/config_handler.dart
+++ b/pkgs/unified_analytics/lib/src/config_handler.dart
@@ -85,14 +85,20 @@ class ConfigHandler {
   /// Responsibe for the creation of the configuration line
   /// for the tool being passed in by the user and adding a
   /// [ToolInfo] object
-  void addTool({required String tool}) {
+  void addTool({
+    required String tool,
+    required int versionNumber,
+  }) {
     // Create the new instance of [ToolInfo] to be added
     // to the [parsedTools] map
-    parsedTools[tool] = ToolInfo(lastRun: clock.now(), versionNumber: 1);
+    parsedTools[tool] = ToolInfo(
+      lastRun: clock.now(),
+      versionNumber: versionNumber,
+    );
 
     // New string to be appended to the bottom of the configuration file
     // with a newline character for new tools to be added
-    String newTool = '$tool=$dateStamp,1\n';
+    String newTool = '$tool=$dateStamp,$versionNumber\n';
     if (!configFile.readAsStringSync().endsWith('\n')) {
       newTool = '\n$newTool';
     }
@@ -103,7 +109,10 @@ class ConfigHandler {
   /// Will increment the version number and update the date
   /// in the config file for the provided tool name while
   /// also incrementing the version number in [ToolInfo]
-  void incrementToolVersion({required String tool}) {
+  void incrementToolVersion({
+    required String tool,
+    required int newVersionNumber,
+  }) {
     if (!parsedTools.containsKey(tool)) {
       return;
     }
@@ -122,11 +131,6 @@ class ConfigHandler {
       resetConfig();
       return;
     }
-
-    final RegExpMatch match = matches.first;
-
-    // Extract the groups from the regex match to prep for parsing
-    final int newVersionNumber = int.parse(match.group(3) as String) + 1;
 
     // Construct the new tool line for the config line and replace it
     // in the original config string to prep for writing back out


### PR DESCRIPTION
This PR is related to @jcollins-g comments about not incrementing the version number by 1. In the case the user has not updated for a while they would potentially have to see 4 different messages if they need to go from version 1 to 5.

With this PR, we will automatically use the version number that is passed to the constructor from the `constants.dart` file