### PR TITLE
[cli_config] Make string list and path list consistent

### DIFF
--- a/pkgs/cli_config/lib/src/cli_source.dart
+++ b/pkgs/cli_config/lib/src/cli_source.dart
@@ -36,7 +36,7 @@ class CliSource extends Source {
   }
 
   @override
-  List<String>? stringList(
+  List<String>? optionalStringList(
     String key, {
     String? splitPattern,
   }) {

--- a/pkgs/cli_config/lib/src/environment_source.dart
+++ b/pkgs/cli_config/lib/src/environment_source.dart
@@ -23,7 +23,7 @@ class EnvironmentSource extends Source {
   String? optionalString(String key) => _environment[key];
 
   @override
-  List<String>? stringList(
+  List<String>? optionalStringList(
     String key, {
     String? splitPattern,
   }) {

--- a/pkgs/cli_config/lib/src/file_source.dart
+++ b/pkgs/cli_config/lib/src/file_source.dart
@@ -21,7 +21,7 @@ class FileSource extends Source {
   String? optionalString(String key) => optionalValueOf<String>(key);
 
   @override
-  List<String>? stringList(
+  List<String>? optionalStringList(
     String key, {
     String? splitPattern,
   }) {

--- a/pkgs/cli_config/lib/src/source.dart
+++ b/pkgs/cli_config/lib/src/source.dart
@@ -14,7 +14,7 @@ abstract class Source {
   /// Lookup a nullable string list.
   ///
   /// If provided, [splitPattern] splits config.
-  List<String>? stringList(
+  List<String>? optionalStringList(
     String key, {
     String? splitPattern,
   });
@@ -31,7 +31,7 @@ abstract class Source {
   /// Lookup an optional value of type [T].
   ///
   /// Does not support specialized options such as `splitPattern`. One must
-  /// use the specialized methods such as [stringList] for that.
+  /// use the specialized methods such as [optionalStringList] for that.
   ///
   /// Returns `null` if the source cannot provide a value of type [T].
   T? optionalValueOf<T>(String key) {
@@ -42,7 +42,7 @@ abstract class Source {
       return optionalString(key) as T?;
     }
     if (T == List<String>) {
-      return stringList(key) as T?;
+      return optionalStringList(key) as T?;
     }
     return null;
   }

--- a/pkgs/cli_config/test/cli_config_test.dart
+++ b/pkgs/cli_config/test/cli_config_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 import 'helpers.dart';
 
 void main() {
-  test('stringList', () {
+  test('optionalStringList', () {
     const path1 = 'path/in/cli_arguments/';
     const path2 = 'path/in/cli_arguments_2/';
     const path3 = 'path/in/environment/';
@@ -39,7 +39,7 @@ void main() {
     );
 
     {
-      final result = config.stringList(
+      final result = config.optionalStringList(
         'build.out_dir',
         combineAllConfigs: true,
         splitEnvironmentPattern: ':',
@@ -48,7 +48,7 @@ void main() {
     }
 
     {
-      final result = config.stringList(
+      final result = config.optionalStringList(
         'build.out_dir',
         combineAllConfigs: false,
         splitEnvironmentPattern: ':',
@@ -264,9 +264,9 @@ void main() {
     );
   });
 
-  test('CLI split stringlist', () {
+  test('CLI split optionalStringList', () {
     final config = Config(commandLineDefines: ['key=value;value2']);
-    final value = config.stringList('key', splitCliPattern: ';');
+    final value = config.optionalStringList('key', splitCliPattern: ';');
     expect(value, ['value', 'value2']);
   });
 
@@ -332,15 +332,16 @@ void main() {
     );
   });
 
-  test('environment split stringlist', () {
+  test('environment split optionalStringList', () {
     final config = Config(environment: {'key': 'value;value2'});
-    final value = config.stringList('key', splitEnvironmentPattern: ';');
+    final value =
+        config.optionalStringList('key', splitEnvironmentPattern: ';');
     expect(value, ['value', 'value2']);
   });
 
-  test('environment non split stringlist', () {
+  test('environment non split optionalStringList', () {
     final config = Config(environment: {'key': 'value'});
-    final value = config.stringList('key');
+    final value = config.optionalStringList('key');
     expect(value, ['value']);
   });
 
@@ -457,5 +458,45 @@ void main() {
     expect(config.optionalDouble('nothing'), null);
     expect(() => config.optionalDouble('not_parsable'), throwsFormatException);
     expect(() => config.optionalDouble('not_parsable2'), throwsFormatException);
+  });
+
+  test('stringList and optionalStringList', () {
+    {
+      final config = Config(
+        fileParsed: {},
+      );
+
+      expect(config.optionalStringList('my_list'), null);
+      expect(() => config.stringList('my_list'), throwsFormatException);
+    }
+
+    {
+      final config = Config(
+        fileParsed: {'my_list': <String>[]},
+      );
+
+      expect(config.optionalStringList('my_list'), <String>[]);
+      expect(config.stringList('my_list'), <String>[]);
+    }
+  });
+
+  test('pathList and optionalPathList', () {
+    {
+      final config = Config(
+        fileParsed: {},
+      );
+
+      expect(config.optionalPathList('my_list'), null);
+      expect(() => config.pathList('my_list'), throwsFormatException);
+    }
+
+    {
+      final config = Config(
+        fileParsed: {'my_list': <String>[]},
+      );
+
+      expect(config.optionalPathList('my_list'), <String>[]);
+      expect(config.pathList('my_list'), <String>[]);
+    }
   });
 }


### PR DESCRIPTION
Provide both optional and non-optional accessors for list config variables.

The non-optional accessors require at least one of the sources to provide at least an empty list. (For example JNIgen wants `classes` to be defined, even though it might be an empty list.)