### PR TITLE
Disable unapproved files

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Align supported tool list with PDD
 - Exposing a new instance method that will need to be invoked when a client has successfully shown the consent message to the user `clientShowedMessage()`
 - Adding and incrementing a tool's version will automatically use the current consent message version instead of incrementing by 1
-- Default constructor has disabled the usage of local log file and session json file until revisions have landed to the privacy document
 
 ## 0.1.2
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Align supported tool list with PDD
 - Exposing a new instance method that will need to be invoked when a client has successfully shown the consent message to the user `clientShowedMessage()`
 - Adding and incrementing a tool's version will automatically use the current consent message version instead of incrementing by 1
+- Default constructor has disabled the usage of local log file and session json file until revisions have landed to the privacy document
 
 ## 0.1.2
 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -64,6 +64,9 @@ abstract class Analytics {
     );
   }
 
+  /// Prevents the unapproved files for logging and session handling
+  /// from being saved on to the developer's disk until privacy revision
+  /// has landed
   factory Analytics.pddApproved({
     required DashTool tool,
     required String dartVersion,

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -22,56 +22,52 @@ import 'user_property.dart';
 import 'utils.dart';
 
 abstract class Analytics {
-  // TODO: (eliasyishak) enable this once revisions have landed
+  /// The default factory constructor that will return an implementation
+  /// of the [Analytics] abstract class using the [LocalFileSystem]
+  factory Analytics({
+    required DashTool tool,
+    required String dartVersion,
+    String? flutterChannel,
+    String? flutterVersion,
+  }) {
+    // Create the instance of the file system so clients don't need
+    // resolve on their own
+    const FileSystem fs = LocalFileSystem();
 
-  // /// The default factory constructor that will return an implementation
-  // /// of the [Analytics] abstract class using the [LocalFileSystem]
-  // factory Analytics({
-  //   required DashTool tool,
-  //   required String dartVersion,
-  //   String? flutterChannel,
-  //   String? flutterVersion,
-  // }) {
-  //   // Create the instance of the file system so clients don't need
-  //   // resolve on their own
-  //   const FileSystem fs = LocalFileSystem();
+    // Resolve the OS using dart:io
+    final DevicePlatform platform;
+    if (io.Platform.operatingSystem == 'linux') {
+      platform = DevicePlatform.linux;
+    } else if (io.Platform.operatingSystem == 'macos') {
+      platform = DevicePlatform.macos;
+    } else {
+      platform = DevicePlatform.windows;
+    }
 
-  //   // Resolve the OS using dart:io
-  //   final DevicePlatform platform;
-  //   if (io.Platform.operatingSystem == 'linux') {
-  //     platform = DevicePlatform.linux;
-  //   } else if (io.Platform.operatingSystem == 'macos') {
-  //     platform = DevicePlatform.macos;
-  //   } else {
-  //     platform = DevicePlatform.windows;
-  //   }
+    // Create the instance of the GA Client which will create
+    // an [http.Client] to send requests
+    final GAClient gaClient = GAClient(
+      measurementId: kGoogleAnalyticsMeasurementId,
+      apiSecret: kGoogleAnalyticsApiSecret,
+    );
 
-  //   // Create the instance of the GA Client which will create
-  //   // an [http.Client] to send requests
-  //   final GAClient gaClient = GAClient(
-  //     measurementId: kGoogleAnalyticsMeasurementId,
-  //     apiSecret: kGoogleAnalyticsApiSecret,
-  //   );
-
-  //   return AnalyticsImpl(
-  //     tool: tool,
-  //     homeDirectory: getHomeDirectory(fs),
-  //     flutterChannel: flutterChannel,
-  //     flutterVersion: flutterVersion,
-  //     dartVersion: dartVersion,
-  //     platform: platform,
-  //     toolsMessageVersion: kToolsMessageVersion,
-  //     fs: fs,
-  //     gaClient: gaClient,
-  //   );
-  // }
-
-  // TODO: (eliasyishak) remove this constructor when revision lands
+    return AnalyticsImpl(
+      tool: tool,
+      homeDirectory: getHomeDirectory(fs),
+      flutterChannel: flutterChannel,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      platform: platform,
+      toolsMessageVersion: kToolsMessageVersion,
+      fs: fs,
+      gaClient: gaClient,
+    );
+  }
 
   /// Prevents the unapproved files for logging and session handling
   /// from being saved on to the developer's disk until privacy revision
   /// has landed
-  factory Analytics({
+  factory Analytics.pddApproved({
     required DashTool tool,
     required String dartVersion,
     String? flutterChannel,
@@ -116,6 +112,7 @@ abstract class Analytics {
       toolsMessageVersion: kToolsMessageVersion,
       fs: fs,
       gaClient: gaClient,
+      pddFlag: true,
     );
   }
 
@@ -287,6 +284,7 @@ class AnalyticsImpl implements Analytics {
     required this.toolsMessageVersion,
     required this.fs,
     required gaClient,
+    bool pddFlag = false,
   }) : _gaClient = gaClient {
     // This initializer class will let the instance know
     // if it was the first run; if it is, nothing will be sent
@@ -296,6 +294,7 @@ class AnalyticsImpl implements Analytics {
       tool: tool.label,
       homeDirectory: homeDirectory,
       toolsMessageVersion: toolsMessageVersion,
+      pddFlag: pddFlag,
     );
     initializer.run();
     _showMessage = initializer.firstRun;
@@ -333,9 +332,12 @@ class AnalyticsImpl implements Analytics {
 
     // Create the session instance that will be responsible for managing
     // all the sessions across every client tool using this pakage
-    // TODO: (eliasyishak) use real session class once revision lands
-    final Session session = NoopSession();
-    // final Session session = Session(homeDirectory: homeDirectory, fs: fs);
+    final Session session;
+    if (pddFlag) {
+      session = NoopSession();
+    } else {
+      session = Session(homeDirectory: homeDirectory, fs: fs);
+    }
 
     // Initialize the user property class that will be attached to
     // each event that is sent to Google Analytics -- it will be responsible
@@ -351,9 +353,11 @@ class AnalyticsImpl implements Analytics {
     );
 
     // Initialize the log handler to persist events that are being sent
-    // TODO: (eliasyishak) use real session class once revision lands
-    final LogHandler _logHandler = NoopLogHandler();
-    // final LogHandler _logHandler = LogHandler(fs: fs, homeDirectory: homeDirectory);
+    if (pddFlag) {
+      _logHandler = NoopLogHandler();
+    } else {
+      _logHandler = LogHandler(fs: fs, homeDirectory: homeDirectory);
+    }
   }
 
   @override

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -22,52 +22,56 @@ import 'user_property.dart';
 import 'utils.dart';
 
 abstract class Analytics {
-  /// The default factory constructor that will return an implementation
-  /// of the [Analytics] abstract class using the [LocalFileSystem]
-  factory Analytics({
-    required DashTool tool,
-    required String dartVersion,
-    String? flutterChannel,
-    String? flutterVersion,
-  }) {
-    // Create the instance of the file system so clients don't need
-    // resolve on their own
-    const FileSystem fs = LocalFileSystem();
+  // TODO: (eliasyishak) enable this once revisions have landed
 
-    // Resolve the OS using dart:io
-    final DevicePlatform platform;
-    if (io.Platform.operatingSystem == 'linux') {
-      platform = DevicePlatform.linux;
-    } else if (io.Platform.operatingSystem == 'macos') {
-      platform = DevicePlatform.macos;
-    } else {
-      platform = DevicePlatform.windows;
-    }
+  // /// The default factory constructor that will return an implementation
+  // /// of the [Analytics] abstract class using the [LocalFileSystem]
+  // factory Analytics({
+  //   required DashTool tool,
+  //   required String dartVersion,
+  //   String? flutterChannel,
+  //   String? flutterVersion,
+  // }) {
+  //   // Create the instance of the file system so clients don't need
+  //   // resolve on their own
+  //   const FileSystem fs = LocalFileSystem();
 
-    // Create the instance of the GA Client which will create
-    // an [http.Client] to send requests
-    final GAClient gaClient = GAClient(
-      measurementId: kGoogleAnalyticsMeasurementId,
-      apiSecret: kGoogleAnalyticsApiSecret,
-    );
+  //   // Resolve the OS using dart:io
+  //   final DevicePlatform platform;
+  //   if (io.Platform.operatingSystem == 'linux') {
+  //     platform = DevicePlatform.linux;
+  //   } else if (io.Platform.operatingSystem == 'macos') {
+  //     platform = DevicePlatform.macos;
+  //   } else {
+  //     platform = DevicePlatform.windows;
+  //   }
 
-    return AnalyticsImpl(
-      tool: tool,
-      homeDirectory: getHomeDirectory(fs),
-      flutterChannel: flutterChannel,
-      flutterVersion: flutterVersion,
-      dartVersion: dartVersion,
-      platform: platform,
-      toolsMessageVersion: kToolsMessageVersion,
-      fs: fs,
-      gaClient: gaClient,
-    );
-  }
+  //   // Create the instance of the GA Client which will create
+  //   // an [http.Client] to send requests
+  //   final GAClient gaClient = GAClient(
+  //     measurementId: kGoogleAnalyticsMeasurementId,
+  //     apiSecret: kGoogleAnalyticsApiSecret,
+  //   );
+
+  //   return AnalyticsImpl(
+  //     tool: tool,
+  //     homeDirectory: getHomeDirectory(fs),
+  //     flutterChannel: flutterChannel,
+  //     flutterVersion: flutterVersion,
+  //     dartVersion: dartVersion,
+  //     platform: platform,
+  //     toolsMessageVersion: kToolsMessageVersion,
+  //     fs: fs,
+  //     gaClient: gaClient,
+  //   );
+  // }
+
+  // TODO: (eliasyishak) remove this constructor when revision lands
 
   /// Prevents the unapproved files for logging and session handling
   /// from being saved on to the developer's disk until privacy revision
   /// has landed
-  factory Analytics.pddApproved({
+  factory Analytics({
     required DashTool tool,
     required String dartVersion,
     String? flutterChannel,
@@ -112,7 +116,6 @@ abstract class Analytics {
       toolsMessageVersion: kToolsMessageVersion,
       fs: fs,
       gaClient: gaClient,
-      pddFlag: true,
     );
   }
 
@@ -284,7 +287,6 @@ class AnalyticsImpl implements Analytics {
     required this.toolsMessageVersion,
     required this.fs,
     required gaClient,
-    bool pddFlag = false,
   }) : _gaClient = gaClient {
     // This initializer class will let the instance know
     // if it was the first run; if it is, nothing will be sent
@@ -294,7 +296,6 @@ class AnalyticsImpl implements Analytics {
       tool: tool.label,
       homeDirectory: homeDirectory,
       toolsMessageVersion: toolsMessageVersion,
-      pddFlag: pddFlag,
     );
     initializer.run();
     _showMessage = initializer.firstRun;
@@ -332,12 +333,9 @@ class AnalyticsImpl implements Analytics {
 
     // Create the session instance that will be responsible for managing
     // all the sessions across every client tool using this pakage
-    final Session session;
-    if (pddFlag) {
-      session = NoopSession();
-    } else {
-      session = Session(homeDirectory: homeDirectory, fs: fs);
-    }
+    // TODO: (eliasyishak) use real session class once revision lands
+    final Session session = NoopSession();
+    // final Session session = Session(homeDirectory: homeDirectory, fs: fs);
 
     // Initialize the user property class that will be attached to
     // each event that is sent to Google Analytics -- it will be responsible
@@ -353,11 +351,9 @@ class AnalyticsImpl implements Analytics {
     );
 
     // Initialize the log handler to persist events that are being sent
-    if (pddFlag) {
-      _logHandler = NoopLogHandler();
-    } else {
-      _logHandler = LogHandler(fs: fs, homeDirectory: homeDirectory);
-    }
+    // TODO: (eliasyishak) use real session class once revision lands
+    final LogHandler _logHandler = NoopLogHandler();
+    // final LogHandler _logHandler = LogHandler(fs: fs, homeDirectory: homeDirectory);
   }
 
   @override

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -350,7 +350,11 @@ class AnalyticsImpl implements Analytics {
     );
 
     // Initialize the log handler to persist events that are being sent
-    _logHandler = LogHandler(fs: fs, homeDirectory: homeDirectory);
+    if (pddFlag) {
+      _logHandler = NoopLogHandler();
+    } else {
+      _logHandler = LogHandler(fs: fs, homeDirectory: homeDirectory);
+    }
   }
 
   @override

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -22,52 +22,57 @@ import 'user_property.dart';
 import 'utils.dart';
 
 abstract class Analytics {
-  /// The default factory constructor that will return an implementation
-  /// of the [Analytics] abstract class using the [LocalFileSystem]
-  factory Analytics({
-    required DashTool tool,
-    required String dartVersion,
-    String? flutterChannel,
-    String? flutterVersion,
-  }) {
-    // Create the instance of the file system so clients don't need
-    // resolve on their own
-    const FileSystem fs = LocalFileSystem();
+  // TODO: (eliasyishak) enable again once revision has landed;
+  //  also remove all instances of [pddFlag]
 
-    // Resolve the OS using dart:io
-    final DevicePlatform platform;
-    if (io.Platform.operatingSystem == 'linux') {
-      platform = DevicePlatform.linux;
-    } else if (io.Platform.operatingSystem == 'macos') {
-      platform = DevicePlatform.macos;
-    } else {
-      platform = DevicePlatform.windows;
-    }
+  // /// The default factory constructor that will return an implementation
+  // /// of the [Analytics] abstract class using the [LocalFileSystem]
+  // factory Analytics({
+  //   required DashTool tool,
+  //   required String dartVersion,
+  //   String? flutterChannel,
+  //   String? flutterVersion,
+  // }) {
+  //   // Create the instance of the file system so clients don't need
+  //   // resolve on their own
+  //   const FileSystem fs = LocalFileSystem();
 
-    // Create the instance of the GA Client which will create
-    // an [http.Client] to send requests
-    final GAClient gaClient = GAClient(
-      measurementId: kGoogleAnalyticsMeasurementId,
-      apiSecret: kGoogleAnalyticsApiSecret,
-    );
+  //   // Resolve the OS using dart:io
+  //   final DevicePlatform platform;
+  //   if (io.Platform.operatingSystem == 'linux') {
+  //     platform = DevicePlatform.linux;
+  //   } else if (io.Platform.operatingSystem == 'macos') {
+  //     platform = DevicePlatform.macos;
+  //   } else {
+  //     platform = DevicePlatform.windows;
+  //   }
 
-    return AnalyticsImpl(
-      tool: tool,
-      homeDirectory: getHomeDirectory(fs),
-      flutterChannel: flutterChannel,
-      flutterVersion: flutterVersion,
-      dartVersion: dartVersion,
-      platform: platform,
-      toolsMessageVersion: kToolsMessageVersion,
-      fs: fs,
-      gaClient: gaClient,
-    );
-  }
+  //   // Create the instance of the GA Client which will create
+  //   // an [http.Client] to send requests
+  //   final GAClient gaClient = GAClient(
+  //     measurementId: kGoogleAnalyticsMeasurementId,
+  //     apiSecret: kGoogleAnalyticsApiSecret,
+  //   );
+
+  //   return AnalyticsImpl(
+  //     tool: tool,
+  //     homeDirectory: getHomeDirectory(fs),
+  //     flutterChannel: flutterChannel,
+  //     flutterVersion: flutterVersion,
+  //     dartVersion: dartVersion,
+  //     platform: platform,
+  //     toolsMessageVersion: kToolsMessageVersion,
+  //     fs: fs,
+  //     gaClient: gaClient,
+  //   );
+  // }
+
+  // TODO: (eliasyishak) remove this contructor once revision has landed
 
   /// Prevents the unapproved files for logging and session handling
   /// from being saved on to the developer's disk until privacy revision
   /// has landed
-  factory Analytics.pddApproved({
+  factory Analytics({
     required DashTool tool,
     required String dartVersion,
     String? flutterChannel,

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -18,7 +18,6 @@ class Initializer {
   final Directory homeDirectory;
   final int toolsMessageVersion;
   bool firstRun = false;
-  final bool pddFlag;
 
   /// Responsibe for the initialization of the files
   /// necessary for analytics reporting
@@ -34,7 +33,6 @@ class Initializer {
     required this.tool,
     required this.homeDirectory,
     required this.toolsMessageVersion,
-    required this.pddFlag,
   });
 
   /// Get a string representation of the current date in the following format
@@ -114,17 +112,19 @@ class Initializer {
     }
 
     // Begin initialization checks for the session file
-    final File sessionFile = fs.file(
-        p.join(homeDirectory.path, kDartToolDirectoryName, kSessionFileName));
-    if (!sessionFile.existsSync() && !pddFlag) {
-      createSessionFile(sessionFile: sessionFile);
-    }
+    // TODO: (eliasyishak) enable again once revision lands
+    // final File sessionFile = fs.file(
+    //     p.join(homeDirectory.path, kDartToolDirectoryName, kSessionFileName));
+    // if (!sessionFile.existsSync()) {
+    //   createSessionFile(sessionFile: sessionFile);
+    // }
 
     // Begin initialization checks for the log file to persist events locally
-    final File logFile = fs
-        .file(p.join(homeDirectory.path, kDartToolDirectoryName, kLogFileName));
-    if (!logFile.existsSync() && !pddFlag) {
-      createLogFile(logFile: logFile);
-    }
+    // TODO: (eliasyishak) enable again once revision lands
+    // final File logFile = fs
+    //     .file(p.join(homeDirectory.path, kDartToolDirectoryName, kLogFileName));
+    // if (!logFile.existsSync()) {
+    //   createLogFile(logFile: logFile);
+    // }
   }
 }

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -18,6 +18,7 @@ class Initializer {
   final Directory homeDirectory;
   final int toolsMessageVersion;
   bool firstRun = false;
+  final bool pddFlag;
 
   /// Responsibe for the initialization of the files
   /// necessary for analytics reporting
@@ -33,6 +34,7 @@ class Initializer {
     required this.tool,
     required this.homeDirectory,
     required this.toolsMessageVersion,
+    required this.pddFlag,
   });
 
   /// Get a string representation of the current date in the following format
@@ -114,14 +116,14 @@ class Initializer {
     // Begin initialization checks for the session file
     final File sessionFile = fs.file(
         p.join(homeDirectory.path, kDartToolDirectoryName, kSessionFileName));
-    if (!sessionFile.existsSync()) {
+    if (!sessionFile.existsSync() && !pddFlag) {
       createSessionFile(sessionFile: sessionFile);
     }
 
     // Begin initialization checks for the log file to persist events locally
     final File logFile = fs
         .file(p.join(homeDirectory.path, kDartToolDirectoryName, kLogFileName));
-    if (!logFile.existsSync()) {
+    if (!logFile.existsSync() && !pddFlag) {
       createLogFile(logFile: logFile);
     }
   }

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -18,6 +18,7 @@ class Initializer {
   final Directory homeDirectory;
   final int toolsMessageVersion;
   bool firstRun = false;
+  final bool pddFlag;
 
   /// Responsibe for the initialization of the files
   /// necessary for analytics reporting
@@ -33,6 +34,7 @@ class Initializer {
     required this.tool,
     required this.homeDirectory,
     required this.toolsMessageVersion,
+    required this.pddFlag,
   });
 
   /// Get a string representation of the current date in the following format
@@ -112,19 +114,17 @@ class Initializer {
     }
 
     // Begin initialization checks for the session file
-    // TODO: (eliasyishak) enable again once revision lands
-    // final File sessionFile = fs.file(
-    //     p.join(homeDirectory.path, kDartToolDirectoryName, kSessionFileName));
-    // if (!sessionFile.existsSync()) {
-    //   createSessionFile(sessionFile: sessionFile);
-    // }
+    final File sessionFile = fs.file(
+        p.join(homeDirectory.path, kDartToolDirectoryName, kSessionFileName));
+    if (!sessionFile.existsSync() && !pddFlag) {
+      createSessionFile(sessionFile: sessionFile);
+    }
 
     // Begin initialization checks for the log file to persist events locally
-    // TODO: (eliasyishak) enable again once revision lands
-    // final File logFile = fs
-    //     .file(p.join(homeDirectory.path, kDartToolDirectoryName, kLogFileName));
-    // if (!logFile.existsSync()) {
-    //   createLogFile(logFile: logFile);
-    // }
+    final File logFile = fs
+        .file(p.join(homeDirectory.path, kDartToolDirectoryName, kLogFileName));
+    if (!logFile.existsSync() && !pddFlag) {
+      createLogFile(logFile: logFile);
+    }
   }
 }

--- a/pkgs/unified_analytics/lib/src/log_handler.dart
+++ b/pkgs/unified_analytics/lib/src/log_handler.dart
@@ -313,3 +313,20 @@ class LogItem {
     }
   }
 }
+
+class NoopLogHandler implements LogHandler {
+  @override
+  FileSystem get fs => throw UnimplementedError();
+
+  @override
+  Directory get homeDirectory => throw UnimplementedError();
+
+  @override
+  File get logFile => throw UnimplementedError();
+
+  @override
+  LogFileStats? logFileStats() => null;
+
+  @override
+  void save({required Map<String, Object?> data}) {}
+}

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -127,8 +127,8 @@ class NoopSession implements Session {
   }
 
   @override
-  set _lastPing(int __lastPing) {}
+  set _lastPing(int lastPing) {}
 
   @override
-  set _sessionId(int __sessionId) {}
+  set _sessionId(int sessionId) {}
 }

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -104,7 +104,7 @@ class NoopSession implements Session {
   final int _lastPing = 0;
 
   @override
-  final int _sessionId = 0;
+  final int _sessionId = DateTime.now().millisecondsSinceEpoch;
 
   @override
   void _refreshSessionData() {}

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -98,3 +98,37 @@ class Session {
     }
   }
 }
+
+class NoopSession implements Session {
+  @override
+  final int _lastPing = 0;
+
+  @override
+  final int _sessionId = 0;
+
+  @override
+  void _refreshSessionData() {}
+
+  @override
+  File get _sessionFile => throw UnimplementedError();
+
+  @override
+  FileSystem get fs => throw UnimplementedError();
+
+  @override
+  int getSessionId() => _sessionId;
+
+  @override
+  Directory get homeDirectory => throw UnimplementedError();
+
+  @override
+  String toJson() {
+    throw UnimplementedError();
+  }
+
+  @override
+  set _lastPing(int __lastPing) {}
+
+  @override
+  set _sessionId(int __sessionId) {}
+}

--- a/pkgs/unified_analytics/test/pdd_approved_test.dart
+++ b/pkgs/unified_analytics/test/pdd_approved_test.dart
@@ -42,15 +42,15 @@ void main() {
       homeOverride: home,
     );
     initializationAnalytics.clientShowedMessage();
+
+    // The main analytics instance that will be used for the
+    // tests after having the tool onboarded
     analytics = Analytics.pddApproved(
       tool: initialTool,
       dartVersion: dartVersion,
       fsOverride: fs,
       homeOverride: home,
     );
-
-    // The main analytics instance that will be used for the
-    // tests after having the tool onboarded
 
     // The 3 files that should have been generated
     clientIdFile = home

--- a/pkgs/unified_analytics/test/pdd_approved_test.dart
+++ b/pkgs/unified_analytics/test/pdd_approved_test.dart
@@ -35,7 +35,7 @@ void main() {
     dartToolDirectory = home.childDirectory(kDartToolDirectoryName);
 
     // Create the initial analytics instance that will onboard the tool
-    initializationAnalytics = Analytics(
+    initializationAnalytics = Analytics.pddApproved(
       tool: initialTool,
       dartVersion: dartVersion,
       fsOverride: fs,
@@ -45,7 +45,7 @@ void main() {
 
     // The main analytics instance that will be used for the
     // tests after having the tool onboarded
-    analytics = Analytics(
+    analytics = Analytics.pddApproved(
       tool: initialTool,
       dartVersion: dartVersion,
       fsOverride: fs,

--- a/pkgs/unified_analytics/test/pdd_approved_test.dart
+++ b/pkgs/unified_analytics/test/pdd_approved_test.dart
@@ -75,9 +75,9 @@ void main() {
         reason: 'The session handling has been disabled');
     expect(configFile.existsSync(), true,
         reason: 'The $kConfigFileName was not found');
-    expect(logFile.existsSync(), true,
-        reason: 'The $kLogFileName file was not found');
-    expect(dartToolDirectory.listSync().length, equals(4),
+    expect(logFile.existsSync(), false,
+        reason: 'The log file has been disabled');
+    expect(dartToolDirectory.listSync().length, equals(2),
         reason:
             'There should only be 4 files in the $kDartToolDirectoryName directory');
     expect(initializationAnalytics.shouldShowMessage, true,
@@ -86,5 +86,11 @@ void main() {
         kConfigString.split('\n').length + 1,
         reason: 'The number of lines should equal lines in constant value + 1 '
             'for the initialized tool');
+  });
+
+  test('Sending events does not cause any errors', () async {
+    await expectLater(
+        () => analytics.sendEvent(eventName: DashEvent.hotReloadTime),
+        returnsNormally);
   });
 }

--- a/pkgs/unified_analytics/test/pdd_approved_test.dart
+++ b/pkgs/unified_analytics/test/pdd_approved_test.dart
@@ -9,7 +9,6 @@ import 'package:file/memory.dart';
 import 'package:test/test.dart';
 
 import 'package:unified_analytics/src/constants.dart';
-import 'package:unified_analytics/src/user_property.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
@@ -22,7 +21,6 @@ void main() {
   late File sessionFile;
   late File configFile;
   late File logFile;
-  late UserProperty userProperty;
 
   const String homeDirName = 'home';
   const DashTool initialTool = DashTool.flutterTool;

--- a/pkgs/unified_analytics/test/pdd_approved_test.dart
+++ b/pkgs/unified_analytics/test/pdd_approved_test.dart
@@ -35,7 +35,7 @@ void main() {
     dartToolDirectory = home.childDirectory(kDartToolDirectoryName);
 
     // Create the initial analytics instance that will onboard the tool
-    initializationAnalytics = Analytics.pddApproved(
+    initializationAnalytics = Analytics(
       tool: initialTool,
       dartVersion: dartVersion,
       fsOverride: fs,
@@ -45,7 +45,7 @@ void main() {
 
     // The main analytics instance that will be used for the
     // tests after having the tool onboarded
-    analytics = Analytics.pddApproved(
+    analytics = Analytics(
       tool: initialTool,
       dartVersion: dartVersion,
       fsOverride: fs,

--- a/pkgs/unified_analytics/test/pdd_approved_test.dart
+++ b/pkgs/unified_analytics/test/pdd_approved_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:test/test.dart';
+
+import 'package:unified_analytics/src/constants.dart';
+import 'package:unified_analytics/src/user_property.dart';
+import 'package:unified_analytics/unified_analytics.dart';
+
+void main() {
+  late FileSystem fs;
+  late Directory home;
+  late Directory dartToolDirectory;
+  late Analytics initializationAnalytics;
+  late Analytics analytics;
+  late File clientIdFile;
+  late File sessionFile;
+  late File configFile;
+  late File logFile;
+  late UserProperty userProperty;
+
+  const String homeDirName = 'home';
+  const DashTool initialTool = DashTool.flutterTool;
+  const String dartVersion = 'dartVersion';
+
+  setUp(() {
+    // Setup the filesystem with the home directory
+    final FileSystemStyle fsStyle =
+        io.Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
+    fs = MemoryFileSystem.test(style: fsStyle);
+    home = fs.directory(homeDirName);
+    dartToolDirectory = home.childDirectory(kDartToolDirectoryName);
+
+    // Create the initial analytics instance that will onboard the tool
+    initializationAnalytics = Analytics.pddApproved(
+      tool: initialTool,
+      dartVersion: dartVersion,
+      fsOverride: fs,
+      homeOverride: home,
+    );
+    initializationAnalytics.clientShowedMessage();
+    analytics = Analytics.pddApproved(
+      tool: initialTool,
+      dartVersion: dartVersion,
+      fsOverride: fs,
+      homeOverride: home,
+    );
+
+    // The main analytics instance that will be used for the
+    // tests after having the tool onboarded
+
+    // The 3 files that should have been generated
+    clientIdFile = home
+        .childDirectory(kDartToolDirectoryName)
+        .childFile(kClientIdFileName);
+    sessionFile =
+        home.childDirectory(kDartToolDirectoryName).childFile(kSessionFileName);
+    configFile =
+        home.childDirectory(kDartToolDirectoryName).childFile(kConfigFileName);
+    logFile =
+        home.childDirectory(kDartToolDirectoryName).childFile(kLogFileName);
+  });
+
+  test('Initializer properly sets up on first run', () {
+    expect(dartToolDirectory.existsSync(), true,
+        reason: 'The directory should have been created');
+    expect(clientIdFile.existsSync(), true,
+        reason: 'The $kClientIdFileName file was not found');
+    expect(sessionFile.existsSync(), false,
+        reason: 'The session handling has been disabled');
+    expect(configFile.existsSync(), true,
+        reason: 'The $kConfigFileName was not found');
+    expect(logFile.existsSync(), true,
+        reason: 'The $kLogFileName file was not found');
+    expect(dartToolDirectory.listSync().length, equals(4),
+        reason:
+            'There should only be 4 files in the $kDartToolDirectoryName directory');
+    expect(initializationAnalytics.shouldShowMessage, true,
+        reason: 'For the first run, analytics should default to being enabled');
+    expect(configFile.readAsLinesSync().length,
+        kConfigString.split('\n').length + 1,
+        reason: 'The number of lines should equal lines in constant value + 1 '
+            'for the initialized tool');
+  });
+}

--- a/pkgs/unified_analytics/test/pdd_approved_test.dart
+++ b/pkgs/unified_analytics/test/pdd_approved_test.dart
@@ -77,9 +77,9 @@ void main() {
         reason: 'The log file has been disabled');
     expect(dartToolDirectory.listSync().length, equals(2),
         reason:
-            'There should only be 4 files in the $kDartToolDirectoryName directory');
+            'There should only be 2 files in the $kDartToolDirectoryName directory');
     expect(initializationAnalytics.shouldShowMessage, true,
-        reason: 'For the first run, analytics should default to being enabled');
+        reason: 'For the first run, the message should be shown');
     expect(configFile.readAsLinesSync().length,
         kConfigString.split('\n').length + 1,
         reason: 'The number of lines should equal lines in constant value + 1 '

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -125,7 +125,7 @@ void main() {
         reason:
             'There should only be 4 files in the $kDartToolDirectoryName directory');
     expect(initializationAnalytics.shouldShowMessage, true,
-        reason: 'For the first run, analytics should default to being enabled');
+        reason: 'For the first run, the message should be shown');
     expect(configFile.readAsLinesSync().length,
         kConfigString.split('\n').length + 1,
         reason: 'The number of lines should equal lines in constant value + 1 '


### PR DESCRIPTION
This PR will disable the creation of the two files that have yet to be approved in the privacy document
1. `dart-flutter-telemetry-session.json` 
2. `dart-flutter-telemetry.log`

Without the session json file, there will be no session data being sent to the Google Analytics backend. A session in this sense is at minimum 30 minutes, but if the user is active for a full hour, then the session will get extended. This requires persistence of state.

Without the log file, we simply won't be saving the data that is sent to Google Analytics on the user's machine. This blocks a feature necessary for sending user surveys based on a user's historical activity.

This PR introduces only a new constructor `Analytics.pddApproved(...)` so to make it easy to switch back to default constructor once the revision to the privacy document has landed