### PR TITLE
Fix windows path resolving

### DIFF
--- a/pkgs/cli_config/lib/src/config.dart
+++ b/pkgs/cli_config/lib/src/config.dart
@@ -477,10 +477,11 @@ class Config {
     required core.bool resolveUri,
     required Uri? baseUri,
   }) {
+    final uri = Source.fileSystemPathToUri(path);
     if (resolveUri && baseUri != null) {
-      return baseUri.resolve(path);
+      return baseUri.resolveUri(uri);
     }
-    return Source.fileSystemPathToUri(path);
+    return uri;
   }
 
   /// Lookup a list of paths in this config.

--- a/pkgs/cli_config/test/cli_config_windows_test.dart
+++ b/pkgs/cli_config/test/cli_config_windows_test.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('windows')
+library;
+
+import 'package:cli_config/cli_config.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('path resolving windows', () {
+    const path = 'C:\\foo\\bar\\';
+    final workingDirectory = Uri.parse('file:///C:/baz/baf/');
+
+    final config = Config(
+      commandLineDefines: ['key=$path'],
+      workingDirectory: workingDirectory,
+    );
+    final value = config.path('key', resolveUri: true);
+    expect(value.toFilePath(), path);
+  });
+}


### PR DESCRIPTION
Apparently windows path resolving requires slightly different treatment.

The test in this CL fails with `Uri.resolve` but not with `Uri.resolveUri`.