### PR TITLE
Add catcherror callback for `sendData`

### DIFF
--- a/pkgs/unified_analytics/lib/src/ga_client.dart
+++ b/pkgs/unified_analytics/lib/src/ga_client.dart
@@ -48,12 +48,16 @@ class GAClient {
   /// Receive the payload in Map form and parse
   /// into JSON to send to GA
   Future<http.Response> sendData(Map<String, Object?> body) {
-    return _client.post(
+    return _client
+        .post(
       Uri.parse(postUrl),
       headers: <String, String>{
         'Content-Type': 'application/json; charset=UTF-8',
       },
       body: jsonEncode(body),
-    );
+    )
+        .catchError((error) {
+      return Future<http.Response>.value(http.Response(error.toString(), 500));
+    });
   }
 }


### PR DESCRIPTION
As pointed out by Danny, the package will cause which ever tool is using it to crash if the client fails to send an event.

This PR adds error handling so that each tool using this package won't crash the tool using it in the case of a http client error (ie. wifi connection drops, client connection was closed before events were sent, etc.)