### PR TITLE
[cli_config] Support non-String map keys

### DIFF
--- a/pkgs/cli_config/CHANGELOG.md
+++ b/pkgs/cli_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Support non-String map keys in YAML configuration files.
+
 ## 0.1.0
 
 - Initial version.

--- a/pkgs/cli_config/CHANGELOG.md
+++ b/pkgs/cli_config/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.1
 
 - Support non-String map keys in YAML configuration files.
+- Support null values in YAML configuration files.
 
 ## 0.1.0
 

--- a/pkgs/cli_config/lib/src/config.dart
+++ b/pkgs/cli_config/lib/src/config.dart
@@ -103,7 +103,7 @@ class Config {
     Uri? fileSourceUri,
   }) {
     // Parse config file.
-    final fileConfig = FileParser().parseMap(fileParsed);
+    final fileConfig = FileParser().parseMap<String>(fileParsed);
 
     // Parse CLI argument defines.
     final cliConfig = DefinesParser().parse(commandLineDefines);

--- a/pkgs/cli_config/lib/src/config.dart
+++ b/pkgs/cli_config/lib/src/config.dart
@@ -103,7 +103,7 @@ class Config {
     Uri? fileSourceUri,
   }) {
     // Parse config file.
-    final fileConfig = FileParser().parseMap<String>(fileParsed);
+    final fileConfig = FileParser().parseToplevelMap(fileParsed);
 
     // Parse CLI argument defines.
     final cliConfig = DefinesParser().parse(commandLineDefines);

--- a/pkgs/cli_config/lib/src/file_parser.dart
+++ b/pkgs/cli_config/lib/src/file_parser.dart
@@ -5,7 +5,7 @@
 import 'package:yaml/yaml.dart';
 
 class FileParser {
-  Map<String, Object> parse(
+  Map<String, Object?> parse(
     String fileContents, {
     Uri? sourceUrl,
   }) {
@@ -19,11 +19,11 @@ class FileParser {
     return parseMap(parsedYaml);
   }
 
-  Map<K, Object> parseMap<K extends Object>(Map<dynamic, dynamic> input) {
-    final result = <K, Object>{};
+  Map<K, Object?> parseMap<K extends Object>(Map<dynamic, dynamic> input) {
+    final result = <K, Object?>{};
     for (final entry in input.entries) {
       final keyUnparsed = entry.key;
-      final value = parseValue(entry.value as Object);
+      final value = parseValue(entry.value);
       if (keyUnparsed is String) {
         final key = parseKey(entry.key as String);
         result[key as K] = value;
@@ -34,7 +34,7 @@ class FileParser {
     return result;
   }
 
-  Object parseValue(Object value) {
+  Object? parseValue(Object? value) {
     if (value is Map) {
       return parseMap(value);
     }

--- a/pkgs/cli_config/lib/src/file_parser.dart
+++ b/pkgs/cli_config/lib/src/file_parser.dart
@@ -5,7 +5,7 @@
 import 'package:yaml/yaml.dart';
 
 class FileParser {
-  Map<String, dynamic> parse(
+  Map<String, Object> parse(
     String fileContents, {
     Uri? sourceUrl,
   }) {
@@ -19,10 +19,20 @@ class FileParser {
     return parseMap(parsedYaml);
   }
 
-  Map<String, Object> parseMap(Map<dynamic, dynamic> input) => {
-        for (final entry in input.entries)
-          parseKey(entry.key as String): parseValue(entry.value as Object),
-      };
+  Map<K, Object> parseMap<K extends Object>(Map<dynamic, dynamic> input) {
+    final result = <K, Object>{};
+    for (final entry in input.entries) {
+      final keyUnparsed = entry.key;
+      final value = parseValue(entry.value as Object);
+      if (keyUnparsed is String) {
+        final key = parseKey(entry.key as String);
+        result[key as K] = value;
+      } else {
+        result[keyUnparsed as K] = value;
+      }
+    }
+    return result;
+  }
 
   Object parseValue(Object value) {
     if (value is Map) {

--- a/pkgs/cli_config/lib/src/file_parser.dart
+++ b/pkgs/cli_config/lib/src/file_parser.dart
@@ -16,34 +16,25 @@ class FileParser {
     if (parsedYaml is! Map) {
       throw FormatException('YAML config must be set of key value pairs.');
     }
-    return parseMap(parsedYaml);
+    return parseToplevelMap(parsedYaml);
   }
 
-  Map<K, Object?> parseMap<K extends Object>(Map<dynamic, dynamic> input) {
-    final result = <K, Object?>{};
+  Map<String, Object?> parseToplevelMap(Map<dynamic, dynamic> input) {
+    final result = <String, Object?>{};
     for (final entry in input.entries) {
-      final keyUnparsed = entry.key;
-      final value = parseValue(entry.value);
-      if (keyUnparsed is String) {
-        final key = parseKey(entry.key as String);
-        result[key as K] = value;
-      } else {
-        result[keyUnparsed as K] = value;
-      }
+      final key = parseToplevelKey(entry.key);
+      final value = entry.value as Object?;
+      result[key] = value;
     }
     return result;
   }
 
-  Object? parseValue(Object? value) {
-    if (value is Map) {
-      return parseMap(value);
-    }
-    return value;
-  }
-
   static final _keyRegex = RegExp('([a-z-_]+)');
 
-  String parseKey(String key) {
+  String parseToplevelKey(Object? key) {
+    if (key is! String) {
+      throw FormatException("Key '$key' is not a String.");
+    }
     final match = _keyRegex.matchAsPrefix(key);
     if (match == null || match.group(0) != key) {
       throw FormatException("Define '$key' does not match expected pattern "

--- a/pkgs/cli_config/pubspec.yaml
+++ b/pkgs/cli_config/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cli_config
 description: A library to take config values from configuration files, CLI arguments, and environment variables.
-version: 0.1.0
+version: 0.1.1
 
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/cli_config
 

--- a/pkgs/cli_config/test/cli_config_test.dart
+++ b/pkgs/cli_config/test/cli_config_test.dart
@@ -504,4 +504,27 @@ void main() {
       expect(config.pathList('my_list'), <String>[]);
     }
   });
+
+  test('non-string key maps', () {
+    // This is valid in YAML (not in JSON).
+    //
+    // Such values cannot be accessed with our hierarchical keys, but they can
+    // be accessed with [Config.valueOf].
+    final config = Config(
+      fileParsed: {
+        'my_non_string_key_map': {
+          1: 'asdf',
+          2: 'foo',
+        },
+      },
+    );
+
+    expect(
+      config.valueOf<Map<Object, Object>>('my_non_string_key_map'),
+      {
+        1: 'asdf',
+        2: 'foo',
+      },
+    );
+  });
 }

--- a/pkgs/cli_config/test/cli_config_test.dart
+++ b/pkgs/cli_config/test/cli_config_test.dart
@@ -371,11 +371,20 @@ void main() {
     expect(() => Config.fromConfigFileContents(fileContents: "['asdf']"),
         throwsFormatException);
     expect(
-      () => Config.fromConfigFileContents(fileContents: '''foo:
-  bar:
-    WRONGKEY:
-      1
-'''),
+      () => Config.fromConfigFileContents(
+          fileContents: '''
+WRONGKEY:
+  1
+'''
+              .trim()),
+      throwsFormatException,
+    );
+    expect(
+      () => Config.fromConfigFileContents(
+          fileContents: '''
+1: 'asdf'
+'''
+              .trim()),
       throwsFormatException,
     );
   });

--- a/pkgs/cli_config/test/cli_config_test.dart
+++ b/pkgs/cli_config/test/cli_config_test.dart
@@ -520,10 +520,29 @@ void main() {
     );
 
     expect(
-      config.valueOf<Map<Object, Object>>('my_non_string_key_map'),
+      config.valueOf<Map<Object, Object?>>('my_non_string_key_map'),
       {
         1: 'asdf',
         2: 'foo',
+      },
+    );
+  });
+
+  test('null values in maps', () {
+    final config = Config(
+      fileParsed: {
+        'my_non_string_key_map': {
+          'x': null,
+          'y': 42,
+        },
+      },
+    );
+
+    expect(
+      config.valueOf<Map<Object, Object?>>('my_non_string_key_map'),
+      {
+        'x': null,
+        'y': 42,
       },
     );
   });


### PR DESCRIPTION
YAML supports non-String map keys.
Our hierarchical key structure requires Strings as keys for maps, otherwise we can't get hierarchical access.
Give a proper error message on non-String keys.

Also, having null values in maps is useless as the config file is the last source. The value should then just be omitted.