### PR TITLE
Change "plugins" to "extensions" for VS Code

### DIFF
--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -99,7 +99,7 @@ enum DashTool {
   ),
   vscodePlugins(
     label: 'vscode-plugins',
-    description: 'VS Code IDE plugins for Dart and Flutter',
+    description: 'VS Code IDE extensions for Dart and Flutter',
   );
 
   /// String used as the control flag and the value of the tool key in


### PR DESCRIPTION
VS Code always uses the term "extensions" and not "plugins" so it looked slightly odd seeing "plugins" in the analytics prompt.

I only updated the description because I wasn't sure of the implications of changing "label" (particularly if the beta is already using the old value). As far as I can tell, although it's named "label" it's not user-facing?

FYI @eliasyishak @bwilkerson