### PR TITLE
[unified_analytics] Initialize date formatting (package:intl requirement)

### DIFF
--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -8,6 +8,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:file/memory.dart';
 import 'package:http/http.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
@@ -291,6 +292,10 @@ class AnalyticsImpl implements Analytics {
     required gaClient,
     bool pddFlag = false,
   }) : _gaClient = gaClient {
+    // Initialize date formatting for `package:intl` within constructor
+    // so clients using this package won't need to
+    initializeDateFormatting();
+
     // This initializer class will let the instance know
     // if it was the first run; if it is, nothing will be sent
     // on the first run


### PR DESCRIPTION
As part of https://github.com/dart-lang/tools/issues/70, initializing date formatting upstream within the package will ensure that clients using this package won't need to call it before implementing.

This package requires date formatting for the dates that are written and read from the config file that stores when each tool was onboarded to telemetry collection.