### PR TITLE
Add a `okToSend` getter to the Analytics class

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Added a `okToSend` getter so that clients can easily and accurately check the state of the consent mechanism.
+
 ## 1.0.1
 
 - Error handling on the `analytics.sendEvent(...)` method to silently error out and return a `500` http status code to let tools using this package know Google Analytics did not receive the event (all successful requests will have a status code of `2xx` provided by Google Analytics)

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -379,7 +379,6 @@ class AnalyticsImpl implements Analytics {
   String get getConsentMessage =>
       kToolsMessage.replaceAll('[tool name]', tool.description);
 
-  @override
   /// Checking the [telemetryEnabled] boolean reflects what the
   /// config file reflects
   ///
@@ -390,7 +389,9 @@ class AnalyticsImpl implements Analytics {
   ///
   /// Additionally, if the client has not invoked `clientShowedMessage`,
   /// then no events shall be sent.
-  bool get okToSend => telemetryEnabled && !_showMessage && _clientShowedMessage;
+  @override
+  bool get okToSend =>
+      telemetryEnabled && !_showMessage && _clientShowedMessage;
 
   @override
   Map<String, ToolInfo> get parsedTools => _configHandler.parsedTools;

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -206,6 +206,11 @@ abstract class Analytics {
   /// run or when the message has been updated
   String get getConsentMessage;
 
+  /// Returns true if it is OK to send an analytics message.   Do not cache,
+  /// as this depends on factors that can change, such as the configuration
+  /// file contents.
+  bool get okToSend;
+
   /// Returns a map object with all of the tools that have been parsed
   /// out of the configuration file
   Map<String, ToolInfo> get parsedTools;
@@ -375,6 +380,19 @@ class AnalyticsImpl implements Analytics {
       kToolsMessage.replaceAll('[tool name]', tool.description);
 
   @override
+  /// Checking the [telemetryEnabled] boolean reflects what the
+  /// config file reflects
+  ///
+  /// Checking the [_showMessage] boolean indicates if this the first
+  /// time the tool is using analytics or if there has been an update
+  /// the messaging found in constants.dart - in both cases, analytics
+  /// will not be sent until the second time the tool is used
+  ///
+  /// Additionally, if the client has not invoked `clientShowedMessage`,
+  /// then no events shall be sent.
+  bool get okToSend => telemetryEnabled && !_showMessage && _clientShowedMessage;
+
+  @override
   Map<String, ToolInfo> get parsedTools => _configHandler.parsedTools;
 
   @override
@@ -418,17 +436,7 @@ class AnalyticsImpl implements Analytics {
     required DashEvent eventName,
     Map<String, Object?> eventData = const {},
   }) {
-    // Checking the [telemetryEnabled] boolean reflects what the
-    // config file reflects
-    //
-    // Checking the [_showMessage] boolean indicates if this the first
-    // time the tool is using analytics or if there has been an update
-    // the messaging found in constants.dart - in both cases, analytics
-    // will not be sent until the second time the tool is used
-    //
-    // Additionally, if the client has not invoked `clientShowedMessage`,
-    // then no events shall be sent
-    if (!telemetryEnabled || _showMessage || !_clientShowedMessage) return null;
+    if (!okToSend) return null;
 
     // Construct the body of the request
     final Map<String, Object?> body = generateRequestBody(
@@ -478,6 +486,9 @@ class NoOpAnalytics implements Analytics {
 
   @override
   final String getConsentMessage = '';
+
+  @override
+  final bool okToSend = false;
 
   @override
   final Map<String, ToolInfo> parsedTools = const <String, ToolInfo>{};
@@ -536,7 +547,7 @@ class TestAnalytics extends AnalyticsImpl {
     required DashEvent eventName,
     Map<String, Object?> eventData = const {},
   }) {
-    if (!telemetryEnabled || _showMessage || !_clientShowedMessage) return null;
+    if (!okToSend) return null;
 
     // Calling the [generateRequestBody] method will ensure that the
     // session file is getting updated without actually making any

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -70,7 +70,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '1.0.1';
+const String kPackageVersion = '1.1.0';
 
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 1.0.1
+version: 1.1.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:


### PR DESCRIPTION
In order for the analyzer to use the same consent protocol for crash reporting as the rest of the analytics, we have to know dynamically whether or not it is OK to send a crash report.   The `_clientShowedMessage` private variable has no getter so it is not possible to reproduce the same check that Analytics uses internally.  This small refactor adds a getter to provide a one-stop shop to check whether it is OK to send.