### PR TITLE
Move `dateStamp` getter to `utils.dart`

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1-dev
+
+- Refactoring `dateStamp` utility function to be defined in `utils.dart` instead of having static methods in `Initializer` and `ConfigHandler`
+
 ## 1.1.0
 
 - Added a `okToSend` getter so that clients can easily and accurately check the state of the consent mechanism.

--- a/pkgs/unified_analytics/lib/src/config_handler.dart
+++ b/pkgs/unified_analytics/lib/src/config_handler.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 
 import 'constants.dart';
 import 'initializer.dart';
+import 'utils.dart';
 
 /// The regex pattern used to parse the disable analytics line
 const String telemetryFlagPattern = r'^reporting=([0|1]) *$';
@@ -31,12 +32,6 @@ class ConfigHandler {
   static RegExp telemetryFlagRegex =
       RegExp(telemetryFlagPattern, multiLine: true);
   static RegExp toolRegex = RegExp(toolPattern, multiLine: true);
-
-  /// Get a string representation of the current date in the following format
-  /// yyyy-MM-dd (2023-01-09)
-  static String get dateStamp {
-    return DateFormat('yyyy-MM-dd').format(clock.now());
-  }
 
   final FileSystem fs;
   final Directory homeDirectory;

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -70,7 +70,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '1.1.0';
+const String kPackageVersion = '1.1.1-dev';
 
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 
 import 'package:clock/clock.dart';
 import 'package:file/file.dart';
-import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 
 import 'constants.dart';
@@ -36,12 +35,6 @@ class Initializer {
     required this.toolsMessageVersion,
     required this.pddFlag,
   });
-
-  /// Get a string representation of the current date in the following format
-  /// yyyy-MM-dd (2023-01-09)
-  String get dateStamp {
-    return DateFormat('yyyy-MM-dd').format(clock.now());
-  }
 
   /// Creates the text file that will contain the client ID
   /// which will be used across all related tools for analytics

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -6,11 +6,19 @@ import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:math' show Random;
 
+import 'package:clock/clock.dart';
 import 'package:file/file.dart';
+import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 
 import 'enums.dart';
 import 'user_property.dart';
+
+/// Get a string representation of the current date in the following format
+/// yyyy-MM-dd (2023-01-09)
+String get dateStamp {
+  return DateFormat('yyyy-MM-dd').format(clock.now());
+}
 
 /// Format time as 'yyyy-MM-dd HH:mm:ss Z' where Z is the difference between the
 /// timezone of t and UTC formatted according to RFC 822.

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 1.1.0
+version: 1.1.1-dev
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/no_op_analytics_test.dart
+++ b/pkgs/unified_analytics/test/no_op_analytics_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -7,16 +7,16 @@ import 'dart:io' as io;
 import 'dart:math';
 
 import 'package:clock/clock.dart';
-import 'package:unified_analytics/unified_analytics.dart';
-import 'package:unified_analytics/src/config_handler.dart';
-import 'package:unified_analytics/src/constants.dart';
-import 'package:unified_analytics/src/session.dart';
-import 'package:unified_analytics/src/user_property.dart';
-import 'package:unified_analytics/src/utils.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
+
+import 'package:unified_analytics/src/constants.dart';
+import 'package:unified_analytics/src/session.dart';
+import 'package:unified_analytics/src/user_property.dart';
+import 'package:unified_analytics/src/utils.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
   late FileSystem fs;
@@ -468,8 +468,8 @@ reporting=1
 # and the value is a date in the form YYYY-MM-DD, a comma, and
 # a number representing the version of the message that was
 # displayed.
-${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
-${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
+${initialTool.label}=$dateStamp,$toolsMessageVersion
+${initialTool.label}=$dateStamp,$toolsMessageVersion
 ''');
 
     // Initialize a second analytics class for the same tool as
@@ -520,7 +520,7 @@ ${initialTool.label}=${ConfigHandler.dateStamp},$toolsMessageVersion
 
     expect(
       configFile.readAsStringSync().endsWith(
-          '# displayed.\n${initialTool.label}=${ConfigHandler.dateStamp},${toolsMessageVersion + 1}\n'),
+          '# displayed.\n${initialTool.label}=$dateStamp,${toolsMessageVersion + 1}\n'),
       true,
       reason: 'The config file ends with the correctly formatted ending '
           'after removing the duplicate lines for a given tool',

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -8,8 +8,8 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:test/test.dart';
 
-import 'package:unified_analytics/src/config_handler.dart';
 import 'package:unified_analytics/src/constants.dart';
+import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
@@ -277,8 +277,9 @@ void main() {
     secondAnalytics.clientShowedMessage();
 
     expect(
-        configFile.readAsStringSync().endsWith(
-            '${secondTool.label}=${ConfigHandler.dateStamp},$firstVersion\n'),
+        configFile
+            .readAsStringSync()
+            .endsWith('${secondTool.label}=$dateStamp,$firstVersion\n'),
         true);
 
     // Create a new instane of the secondTool with an even
@@ -299,8 +300,9 @@ void main() {
     );
 
     expect(
-        configFile.readAsStringSync().endsWith(
-            '${secondTool.label}=${ConfigHandler.dateStamp},$firstVersion\n'),
+        configFile
+            .readAsStringSync()
+            .endsWith('${secondTool.label}=$dateStamp,$firstVersion\n'),
         true);
 
     // After invoking this method, it will get updated
@@ -308,8 +310,9 @@ void main() {
     thirdAnalytics.clientShowedMessage();
 
     expect(
-        configFile.readAsStringSync().endsWith(
-            '${secondTool.label}=${ConfigHandler.dateStamp},$secondVersion\n'),
+        configFile
+            .readAsStringSync()
+            .endsWith('${secondTool.label}=$dateStamp,$secondVersion\n'),
         true);
   });
 }


### PR DESCRIPTION
Addresses tech debt issue:  https://github.com/dart-lang/tools/issues/17

Keeps the `dateStamp` string getter in one location instead of having static methods defined in two separate classes (tech debt)