### PR TITLE
[wip] Survey handler functionality

### DIFF
--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -51,6 +51,9 @@ reporting=1
 # a number representing the version of the message that was
 # displayed.''';
 
+/// Link to contextual survey metadata file
+const String kContextualSurveyUrl = 'https://docs.flutter.dev/f/contextual-survey-metadata.json';
+
 /// Name of the directory where all of the files necessary for this package
 /// will be located
 const String kDartToolDirectoryName = '.dart-tool';

--- a/pkgs/unified_analytics/lib/src/survey_handler.dart
+++ b/pkgs/unified_analytics/lib/src/survey_handler.dart
@@ -21,7 +21,6 @@ class SurveyHandler {
     final http.Response response = await http.get(uri);
 
     // Parse the returned body and add to the list
-    print(utf8.decode(response.bodyBytes));
-    print(jsonDecode(utf8.decode(response.bodyBytes)));
+    print(jsonDecode(response.body));
   }
 }

--- a/pkgs/unified_analytics/lib/src/survey_handler.dart
+++ b/pkgs/unified_analytics/lib/src/survey_handler.dart
@@ -7,6 +7,91 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import 'constants.dart';
+import 'log_handler.dart';
+
+class Condition {
+  /// How to query the log file
+  ///
+  /// Example: logFileStats.recordCount refers to the
+  /// total record count being returned by [LogFileStats]
+  final String field;
+  final String operator;
+  final int value;
+
+  Condition(
+    this.field,
+    this.operator,
+    this.value,
+  );
+
+  Condition.fromJson(Map<String, dynamic> json)
+      : field = json['field'],
+        operator = json['operator'],
+        value = json['value'];
+
+  Map<String, Object?> toMap() => <String, Object?>{
+        'field': field,
+        'operator': operator,
+        'value': value,
+      };
+
+  @override
+  String toString() => jsonEncode(toMap());
+}
+
+class Survey {
+  final String uniqueId;
+  final String url;
+  final DateTime startDate;
+  final DateTime endDate;
+  final String description;
+  final int dismissForDays;
+  final String moreInfoUrl;
+  final double samplingRate;
+  final List<Condition> conditionList;
+
+  Survey(
+    this.uniqueId,
+    this.url,
+    this.startDate,
+    this.endDate,
+    this.description,
+    this.dismissForDays,
+    this.moreInfoUrl,
+    this.samplingRate,
+    this.conditionList,
+  );
+
+  /// Parse the contents of the json metadata file hosted externally
+  Survey.fromJson(Map<String, dynamic> json)
+      : uniqueId = json['uniqueId'],
+        url = json['url'],
+        startDate = DateTime.parse(json['startDate']),
+        endDate = DateTime.parse(json['endDate']),
+        description = json['description'],
+        dismissForDays = int.parse(json['dismissForDays']),
+        moreInfoUrl = json['moreInfoURL'],
+        samplingRate = double.parse(json['samplingRate']),
+        conditionList = (json['conditions'] as List)
+            .map((e) => Condition.fromJson(e))
+            .toList();
+
+  @override
+  String toString() {
+    final JsonEncoder encoder = JsonEncoder.withIndent('  ');
+    return encoder.convert({
+      'uniqueId': uniqueId,
+      'url': url,
+      'startDate': startDate.toString(),
+      'endDate': endDate.toString(),
+      'description': description,
+      'dismissForDays': dismissForDays,
+      'moreInfoUrl': moreInfoUrl,
+      'samplingRate': samplingRate,
+      'conditionList': conditionList.map((e) => e.toMap()).toList(),
+    });
+  }
+}
 
 class SurveyHandler {
   /// Contains metadata for each survey hosted at the [kContextualSurveyUrl]
@@ -16,11 +101,16 @@ class SurveyHandler {
   SurveyHandler();
 
   /// Retrieves the survey metadata file from [kContextualSurveyUrl]
-  Future<void> fetchSurveyList() async {
+  Future<List<Survey>> fetchSurveyList() async {
     final Uri uri = Uri.parse(kContextualSurveyUrl);
     final http.Response response = await http.get(uri);
 
-    // Parse the returned body and add to the list
-    print(jsonDecode(response.body));
+    final List<Survey> surveyList = (jsonDecode(response.body) as List)
+        .map(
+          (e) => Survey.fromJson(e),
+        )
+        .toList();
+
+    return surveyList;
   }
 }

--- a/pkgs/unified_analytics/lib/src/survey_handler.dart
+++ b/pkgs/unified_analytics/lib/src/survey_handler.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'constants.dart';
+
+class SurveyHandler {
+  /// Contains metadata for each survey hosted at the [kContextualSurveyUrl]
+  /// endpoint; if there are no surveys available, the list will remain empty
+  final List<Map<String, Object?>> surveyList = [];
+
+  SurveyHandler();
+
+  /// Retrieves the survey metadata file from [kContextualSurveyUrl]
+  Future<void> fetchSurveyList() async {
+    final Uri uri = Uri.parse(kContextualSurveyUrl);
+    final http.Response response = await http.get(uri);
+
+    // Parse the returned body and add to the list
+    print(utf8.decode(response.bodyBytes));
+    print(jsonDecode(utf8.decode(response.bodyBytes)));
+  }
+}

--- a/pkgs/unified_analytics/lib/unified_analytics.dart
+++ b/pkgs/unified_analytics/lib/unified_analytics.dart
@@ -6,3 +6,4 @@ export 'src/analytics.dart' show Analytics, NoOpAnalytics;
 export 'src/config_handler.dart' show ToolInfo;
 export 'src/enums.dart';
 export 'src/log_handler.dart' show LogFileStats;
+export 'src/survey_handler.dart' show SurveyHandler;

--- a/pkgs/unified_analytics/test/survey_handler_test.dart
+++ b/pkgs/unified_analytics/test/survey_handler_test.dart
@@ -14,6 +14,6 @@ void main() {
   });
 
   test('survey tester', () async {
-    await surveyHandler.fetchSurveyList();
+    print(await surveyHandler.fetchSurveyList());
   });
 }

--- a/pkgs/unified_analytics/test/survey_handler_test.dart
+++ b/pkgs/unified_analytics/test/survey_handler_test.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:unified_analytics/unified_analytics.dart';
+
+void main() {
+  late SurveyHandler surveyHandler;
+
+  setUp(() {
+    surveyHandler = SurveyHandler();
+  });
+
+  test('survey tester', () async {
+    await surveyHandler.fetchSurveyList();
+  });
+}


### PR DESCRIPTION
Relevant issue:
- https://github.com/dart-lang/tools/issues/81

This PR will add functionality to enable tools using this package (flutter-tools, analyzer, etc.) to share available surveys with our users. It will enable the `Analytics` class to fetch the available surveys from https://docs.flutter.dev/f/contextual-survey-metadata.json and parse the conditions (if applicable) using the locally persisted log file. If the conditions are met, then this package will return the relevant information (url, description, etc.) to the tool so that it can prompt the user with a survey link.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for a week or two of latency for initial review feedback.

---
