### PR TITLE
Utility function added to check permissions on directory

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Refactoring `dateStamp` utility function to be defined in `utils.dart` instead of having static methods in `Initializer` and `ConfigHandler`
 - Remove the `pddFlag` now that the revisions to the PDD have been finalized to persist data in the log file and session json file
 - Opting out will now delete the contents of the CLIENT ID, session json, and log files; opting back in will regenerate them as events send
+- Now checking if write permissions are enabled for user's home directory, if not allowed, `NoOpAnalytics` returned by `Analytics` factory constructor
 
 ## 1.1.0
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1
+## 2.0.0
 
 - Refactoring `dateStamp` utility function to be defined in `utils.dart` instead of having static methods in `Initializer` and `ConfigHandler`
 - Remove the `pddFlag` now that the revisions to the PDD have been finalized to persist data in the log file and session json file

--- a/pkgs/unified_analytics/example/unified_analytics_example.dart
+++ b/pkgs/unified_analytics/example/unified_analytics_example.dart
@@ -46,7 +46,7 @@ void main() async {
   for (int i = 0; i < 2000; i++) {
     count += i;
   }
-  await Future<void>.delayed(const Duration(seconds: 100));
+  await Future<void>.delayed(const Duration(milliseconds: 100));
 
   // Calculate the metric to send
   final int runTime = DateTime.now().difference(start).inMilliseconds;

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -35,6 +35,12 @@ abstract class Analytics {
     // resolve on their own
     const FileSystem fs = LocalFileSystem();
 
+    // Ensure that the home directory has permissions enabled to write
+    final Directory homeDirectory = getHomeDirectory(fs);
+    if (!checkDirectoryForWritePermissions(homeDirectory)) {
+      return NoOpAnalytics();
+    }
+
     // Resolve the OS using dart:io
     final DevicePlatform platform;
     if (io.Platform.operatingSystem == 'linux') {
@@ -77,6 +83,12 @@ abstract class Analytics {
     // Create the instance of the file system so clients don't need
     // resolve on their own
     const FileSystem fs = LocalFileSystem();
+
+    // Ensure that the home directory has permissions enabled to write
+    final Directory homeDirectory = getHomeDirectory(fs);
+    if (!checkDirectoryForWritePermissions(homeDirectory)) {
+      return NoOpAnalytics();
+    }
 
     // Resolve the OS using dart:io
     final DevicePlatform platform;

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -36,8 +36,9 @@ abstract class Analytics {
     const FileSystem fs = LocalFileSystem();
 
     // Ensure that the home directory has permissions enabled to write
-    final Directory homeDirectory = getHomeDirectory(fs);
-    if (!checkDirectoryForWritePermissions(homeDirectory)) {
+    final Directory? homeDirectory = getHomeDirectory(fs);
+    if (homeDirectory == null ||
+        !checkDirectoryForWritePermissions(homeDirectory)) {
       return NoOpAnalytics();
     }
 
@@ -85,8 +86,9 @@ abstract class Analytics {
     const FileSystem fs = LocalFileSystem();
 
     // Ensure that the home directory has permissions enabled to write
-    final Directory homeDirectory = getHomeDirectory(fs);
-    if (!checkDirectoryForWritePermissions(homeDirectory)) {
+    final Directory? homeDirectory = getHomeDirectory(fs);
+    if (homeDirectory == null ||
+        !checkDirectoryForWritePermissions(homeDirectory)) {
       return NoOpAnalytics();
     }
 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -60,7 +60,7 @@ abstract class Analytics {
 
     return AnalyticsImpl(
       tool: tool,
-      homeDirectory: getHomeDirectory(fs),
+      homeDirectory: homeDirectory,
       flutterChannel: flutterChannel,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,
@@ -113,7 +113,7 @@ abstract class Analytics {
 
     return AnalyticsImpl(
       tool: tool,
-      homeDirectory: getHomeDirectory(fs),
+      homeDirectory: homeDirectory,
       flutterChannel: flutterChannel,
       flutterVersion: flutterVersion,
       dartVersion: dartVersion,

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -70,7 +70,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '1.1.1';
+const String kPackageVersion = '2.0.0';
 
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -20,6 +20,18 @@ String get dateStamp {
   return DateFormat('yyyy-MM-dd').format(clock.now());
 }
 
+/// Reads in a directory and returns `true` if write permissions are enabled
+/// 
+/// Uses the [FileStat] method `modeString()` to return a string in the form
+/// of `rwxrwxrwx` where the second character in the string indicates if write
+/// is enabled with a `w` or disabled with `-`
+bool checkDirectoryForWritePermissions(Directory directory) {
+  if (!directory.existsSync()) return false;
+
+  final FileStat fileStat = directory.statSync();
+  return fileStat.modeString()[1] == 'w';
+}
+
 /// Format time as 'yyyy-MM-dd HH:mm:ss Z' where Z is the difference between the
 /// timezone of t and UTC formatted according to RFC 822.
 String formatDateTime(DateTime t) {

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -88,7 +88,7 @@ Map<String, Object?> generateRequestBody({
 /// This will use environment variables to get the user's
 /// home directory where all the directory will be created that will
 /// contain all of the analytics files
-Directory getHomeDirectory(FileSystem fs) {
+Directory? getHomeDirectory(FileSystem fs) {
   String? home;
   Map<String, String> envVars = io.Platform.environment;
 
@@ -100,7 +100,9 @@ Directory getHomeDirectory(FileSystem fs) {
     home = envVars['AppData'];
   }
 
-  return fs.directory(home!);
+  if (home == null) return null;
+
+  return fs.directory(home);
 }
 
 /// Returns `true` if user has opted out of legacy analytics in Dart or Flutter

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -21,7 +21,7 @@ String get dateStamp {
 }
 
 /// Reads in a directory and returns `true` if write permissions are enabled
-/// 
+///
 /// Uses the [FileStat] method `modeString()` to return a string in the form
 /// of `rwxrwxrwx` where the second character in the string indicates if write
 /// is enabled with a `w` or disabled with `-`

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 1.1.1
+version: 2.0.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/no_op_analytics_test.dart
+++ b/pkgs/unified_analytics/test/no_op_analytics_test.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:test/test.dart';
 
+import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
@@ -44,5 +47,14 @@ void main() {
     await analytics.sendEvent(eventName: DashEvent.analyticsCollectionEnabled);
 
     expect(analytics.logFileStats(), isNull);
+  });
+
+  test('Home directory without write permissions', () {
+    final FileSystem fs = MemoryFileSystem.test(style: FileSystemStyle.posix);
+    final Directory home = fs.directory('home');
+    home.createSync();
+
+    expect(home.statSync().modeString(), 'r-xrw-rwx');
+    expect(checkDirectoryForWritePermissions(home), false);
   });
 }


### PR DESCRIPTION
Addresses issue:
- https://github.com/dart-lang/tools/issues/93

Issue filed in the `flutter/flutter` repo:
- https://github.com/flutter/flutter/issues/127055

This makes use of the `Directory`'s `statSync()` method along with the `modeString()` method on `FileStat` to return the permissions set on a given directory and checks for write permissions. If there are no permissions to write to a user's home directory, the factory constructor will return a NoOp implementation

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for a week or two of latency for initial review feedback.

---
