### PR TITLE
Asserts added to check all relevant GA4 limitations

### DIFF
--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@4f052778de9a9b80cb16cfb9079b02287285a4cb
+      - uses: actions/labeler@0776a679364a9a16110aac8d0f40f5e11009e327
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Refactoring `dateStamp` utility function to be defined in `utils.dart` instead of having static methods in `Initializer` and `ConfigHandler`
 - Remove the `pddFlag` now that the revisions to the PDD have been finalized to persist data in the log file and session json file
 - Opting out will now delete the contents of the CLIENT ID, session json, and log files; opting back in will regenerate them as events send
+- `enableAsserts` parameter added to constructors for `Analytics` to check body of POST request for Google Analytics 4 limitations
 
 ## 1.1.0
 

--- a/pkgs/unified_analytics/example/unified_analytics_example.dart
+++ b/pkgs/unified_analytics/example/unified_analytics_example.dart
@@ -46,7 +46,7 @@ void main() async {
   for (int i = 0; i < 2000; i++) {
     count += i;
   }
-  await Future<void>.delayed(const Duration(seconds: 100));
+  await Future<void>.delayed(const Duration(milliseconds: 100));
 
   // Calculate the metric to send
   final int runTime = DateTime.now().difference(start).inMilliseconds;

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -26,11 +26,15 @@ import 'utils.dart';
 abstract class Analytics {
   /// The default factory constructor that will return an implementation
   /// of the [Analytics] abstract class using the [LocalFileSystem]
+  ///
+  /// If [enableAsserts] is set to `true`, then asserts for GA4 limitations
+  /// will be enabled
   factory Analytics({
     required DashTool tool,
     required String dartVersion,
     String? flutterChannel,
     String? flutterVersion,
+    bool enableAsserts = false,
   }) {
     // Create the instance of the file system so clients don't need
     // resolve on their own
@@ -63,17 +67,22 @@ abstract class Analytics {
       toolsMessageVersion: kToolsMessageVersion,
       fs: fs,
       gaClient: gaClient,
+      enableAsserts: enableAsserts,
     );
   }
 
   /// Factory constructor to return the [AnalyticsImpl] class with
   /// Google Analytics credentials that point to a test instance and
   /// not the production instance where live data will be sent
+  ///
+  /// By default, [enableAsserts] is set to `true` to check against
+  /// GA4 limitations
   factory Analytics.development({
     required DashTool tool,
     required String dartVersion,
     String? flutterChannel,
     String? flutterVersion,
+    bool enableAsserts = true,
   }) {
     // Create the instance of the file system so clients don't need
     // resolve on their own
@@ -110,7 +119,7 @@ abstract class Analytics {
       toolsMessageVersion: kToolsMessageVersion,
       fs: fs,
       gaClient: gaClient,
-      enableAsserts: true,
+      enableAsserts: enableAsserts,
     );
   }
 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -259,7 +259,6 @@ class AnalyticsImpl implements Analytics {
     required enableAsserts,
   })  : _gaClient = gaClient,
         _enableAsserts = enableAsserts {
-    print(_enableAsserts);
     // Initialize date formatting for `package:intl` within constructor
     // so clients using this package won't need to
     initializeDateFormatting();

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -154,6 +154,7 @@ abstract class Analytics {
                   : FileSystemStyle.posix,
             ),
         gaClient: FakeGAClient(),
+        enableAsserts: true,
       );
 
   /// Retrieves the consent message to prompt users with on first
@@ -255,9 +256,10 @@ class AnalyticsImpl implements Analytics {
     required this.toolsMessageVersion,
     required this.fs,
     required gaClient,
-    enableAsserts = false,
+    required enableAsserts,
   })  : _gaClient = gaClient,
         _enableAsserts = enableAsserts {
+    print(_enableAsserts);
     // Initialize date formatting for `package:intl` within constructor
     // so clients using this package won't need to
     initializeDateFormatting();
@@ -511,6 +513,7 @@ class TestAnalytics extends AnalyticsImpl {
     required super.toolsMessageVersion,
     required super.fs,
     required super.gaClient,
+    required super.enableAsserts,
   });
 
   @override

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -402,9 +402,9 @@ class AnalyticsImpl implements Analytics {
       userProperty: userProperty,
     );
 
-    _logHandler.save(data: body);
-
     if (_enableAsserts) checkBody(body);
+
+    _logHandler.save(data: body);
 
     // Pass to the google analytics client to send
     return _gaClient.sendData(body);
@@ -531,6 +531,8 @@ class TestAnalytics extends AnalyticsImpl {
       eventData: eventData,
       userProperty: userProperty,
     );
+
+    if (_enableAsserts) checkBody(body);
 
     _logHandler.save(data: body);
 

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -118,11 +118,10 @@ void checkBody(Map<String, Object?> body) {
 
     // GA4 Limitation:
     // User property values must be 36 characters or fewer
-    if (value['value'].runtimeType == String) {
-      if ((value['value'] as String).length > 36) {
-        throw AnalyticsException(
-            'Limit user property values to 36 chars or less');
-      }
+    final Object? userPropValue = value['value'];
+    if (userPropValue is String && userPropValue.length > 36) {
+      throw AnalyticsException(
+          'Limit user property values to 36 chars or less');
     }
   }
 }

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -3,7 +3,6 @@
 ///
 /// Limitations can be found:
 /// https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#limitations
-
 void checkBody(Map<String, Object?> body) {
   // Ensure we have the correct top level keys
   if (!body.keys.contains('client_id')) {
@@ -55,7 +54,10 @@ void checkBody(Map<String, Object?> body) {
     }
 
     // Loop through each of the event parameters
-    eventParams.forEach((key, value) {
+    for (MapEntry entry in eventParams.entries) {
+      final String key = entry.key;
+      final Object? value = entry.value;
+
       // GA4 Limitation:
       // Ensure that each value for the event params is one
       // of the following types:
@@ -94,7 +96,7 @@ void checkBody(Map<String, Object?> body) {
               'Limit characters in event param value to 100 chars or less');
         }
       }
-    });
+    }
   }
 
   // GA4 Limitation:
@@ -104,8 +106,9 @@ void checkBody(Map<String, Object?> body) {
   }
 
   // Checks for each user property item
-  userProperties.forEach((key, value) {
-    value as Map<String, Object?>;
+  for (MapEntry entry in userProperties.entries) {
+    final String key = entry.key;
+    final Map<String, Object?> value = entry.value as Map<String, Object?>;
 
     // GA4 Limitation:
     // User property names must be 24 characters or fewer
@@ -121,7 +124,7 @@ void checkBody(Map<String, Object?> body) {
             'Limit user property values to 36 chars or less');
       }
     }
-  });
+  }
 }
 
 class AnalyticsException implements Exception {

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -1,0 +1,77 @@
+/// Checks that the body of the request being sent to
+/// GA4 is within the limitations
+///
+/// Limitations can be found:
+/// https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#limitations
+void checkBody(Map<String, Object?> body) {
+  final List events = body['events'] as List;
+  final Map<String, Object?> userProperties =
+      body['user_properties'] as Map<String, Object?>;
+
+  // GA4 Limitation:
+  // Requests can have a maximum of 25 events
+  assert(events.length <= 25, 'Limit event params to 25 or less');
+
+  // Checks for each event object
+  for (Map<String, Object?> eventMap in events) {
+    // GA4 Limitation:
+    // Event names must be 40 characters or fewer, may only contain
+    // alpha-numeric characters and underscores, and must start
+    // with an alphabetic character
+    assert((eventMap['name'] as String).length <= 40,
+        'Limit event names to 40 chars or less');
+    assert(RegExp(r'^[A-Za-z0-9_]+$').hasMatch(eventMap['name'] as String),
+        'Event name can only have alphanumeric chars and underscores');
+    assert(RegExp(r'^[A-Za-z]+$').hasMatch((eventMap['name'] as String)[0]),
+        'Event name first char must be alphabetic char');
+
+    // GA4 Limitation:
+    // Events can have a maximum of 25 parameters
+    assert((eventMap['params'] as Map<String, Object?>).length <= 25,
+        'Limit params for each event to less than 25');
+
+    // Loop through each of the event parameters
+    (eventMap['params'] as Map<String, Object?>).forEach((key, value) {
+      // GA4 Limitation:
+      // Parameter names (including item parameters) must be 40 characters
+      // or fewer, may only contain alpha-numeric characters and underscores,
+      // and must start with an alphabetic character
+      assert(key.length <= 40, 'Limit event param names to 40 chars or less');
+      assert(RegExp(r'^[A-Za-z0-9_]+$').hasMatch(key),
+          'Event param name can only have alphanumeric chars and underscores');
+      assert(RegExp(r'^[A-Za-z]+$').hasMatch(key[0]),
+          'Event param name first char must be alphabetic char');
+
+      // TODO (eliasyishak): need to check if passing a Map that gets converted to
+      //  a string is what is breaking this
+      // GA4 Limitation:
+      // Parameter values (including item parameter values) must be 100
+      // characters or fewer
+      if (value.runtimeType == String) {
+        value as String;
+        assert(value.length <= 100,
+            'Limit characters in event param value to 100 chars or less');
+      }
+    });
+  }
+
+  // GA4 Limitation:
+  // Events can have a maximum of 25 user properties
+  assert(userProperties.length <= 25, 'Limit user properties to 25 or less');
+
+  // Checks for each user property item
+  userProperties.forEach((key, value) {
+    value as Map<String, Object?>;
+
+    // GA4 Limitation:
+    // User property names must be 24 characters or fewer
+    assert(key.length <= 24, 'Limit user property names to 24 chars or less');
+
+    // GA4 Limitation:
+    // User property values must be 36 characters or fewer
+    if (value['value'].runtimeType == String) {
+      assert((value['value'] as String).length <= 36,
+          'Limit user property values to 36 chars or less');
+    }
+  });
+}

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -41,6 +41,14 @@ void checkBody(Map<String, Object?> body) {
     // Loop through each of the event parameters
     (eventMap['params'] as Map<String, Object?>).forEach((key, value) {
       // GA4 Limitation:
+      // Ensure that each value for the event params is one
+      // of the following types:
+      // `String`, `int`, `double`, or `bool`
+      assert(
+          value is String || value is int || value is double || value is bool,
+          'Values for event params have to be String, int, double, or bool');
+
+      // GA4 Limitation:
       // Parameter names (including item parameters) must be 40 characters
       // or fewer, may only contain alpha-numeric characters and underscores,
       // and must start with an alphabetic character

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -6,12 +6,15 @@
 
 void checkBody(Map<String, Object?> body) {
   // Ensure we have the correct top level keys
-  assert(body.keys.contains('client_id') == true,
-      'client_id key not found in body of request');
-  assert(body.keys.contains('events') == true,
-      'events key not found in body of request');
-  assert(body.keys.contains('user_properties') == true,
-      'user_properties key not found in body of request');
+  if (!body.keys.contains('client_id')) {
+    throw AnalyticsException('client_id missing from top level keys');
+  }
+  if (!body.keys.contains('events')) {
+    throw AnalyticsException('events missing from top level keys');
+  }
+  if (!body.keys.contains('user_properties')) {
+    throw AnalyticsException('user_properties missing from top level keys');
+  }
 
   final List events = body['events'] as List;
   final Map<String, Object?> userProperties =
@@ -19,7 +22,9 @@ void checkBody(Map<String, Object?> body) {
 
   // GA4 Limitation:
   // Requests can have a maximum of 25 events
-  assert(events.length <= 25, 'Limit event params to 25 or less');
+  if (events.length > 25) {
+    throw AnalyticsException('25 is the max number of events');
+  }
 
   // Checks for each event object
   for (Map<String, Object?> eventMap in events) {
@@ -27,17 +32,22 @@ void checkBody(Map<String, Object?> body) {
     // Event names must be 40 characters or fewer, may only contain
     // alpha-numeric characters and underscores, and must start
     // with an alphabetic character
-    assert((eventMap['name'] as String).length <= 40,
-        'Limit event names to 40 chars or less');
-    assert(RegExp(r'^[A-Za-z0-9_]+$').hasMatch(eventMap['name'] as String),
-        'Event name can only have alphanumeric chars and underscores');
-    assert(RegExp(r'^[A-Za-z]+$').hasMatch((eventMap['name'] as String)[0]),
-        'Event name first char must be alphabetic char');
+    if ((eventMap['name'] as String).length > 40) {
+      throw AnalyticsException('Limit event names to 40 chars or less');
+    }
+    if (!RegExp(r'^[A-Za-z0-9_]+$').hasMatch(eventMap['name'] as String)) {
+      throw AnalyticsException(
+          'Event name can only have alphanumeric chars and underscores');
+    }
+    if (!RegExp(r'^[A-Za-z]+$').hasMatch((eventMap['name'] as String)[0])) {
+      throw AnalyticsException('Event name first char must be alphabetic char');
+    }
 
     // GA4 Limitation:
     // Events can have a maximum of 25 parameters
-    assert((eventMap['params'] as Map<String, Object?>).length <= 25,
-        'Limit params for each event to less than 25');
+    if ((eventMap['params'] as Map<String, Object?>).length > 25) {
+      throw AnalyticsException('Limit params for each event to less than 25');
+    }
 
     // Loop through each of the event parameters
     (eventMap['params'] as Map<String, Object?>).forEach((key, value) {
@@ -45,34 +55,48 @@ void checkBody(Map<String, Object?> body) {
       // Ensure that each value for the event params is one
       // of the following types:
       // `String`, `int`, `double`, or `bool`
-      assert(
-          value is String || value is int || value is double || value is bool,
-          'Values for event params have to be String, int, double, or bool');
+      if (!(value is String ||
+          value is int ||
+          value is double ||
+          value is bool)) {
+        throw AnalyticsException(
+            'Values for event params have to be String, int, double, or bool');
+      }
 
       // GA4 Limitation:
       // Parameter names (including item parameters) must be 40 characters
       // or fewer, may only contain alpha-numeric characters and underscores,
       // and must start with an alphabetic character
-      assert(key.length <= 40, 'Limit event param names to 40 chars or less');
-      assert(RegExp(r'^[A-Za-z0-9_]+$').hasMatch(key),
-          'Event param name can only have alphanumeric chars and underscores');
-      assert(RegExp(r'^[A-Za-z]+$').hasMatch(key[0]),
-          'Event param name first char must be alphabetic char');
+      if (key.length > 40) {
+        throw AnalyticsException('Limit event param names to 40 chars or less');
+      }
+      if (!RegExp(r'^[A-Za-z0-9_]+$').hasMatch(key)) {
+        throw AnalyticsException(
+            'Event param name can only have alphanumeric chars and underscores');
+      }
+      if (!RegExp(r'^[A-Za-z]+$').hasMatch(key[0])) {
+        throw AnalyticsException(
+            'Event param name first char must be alphabetic char');
+      }
 
       // GA4 Limitation:
       // Parameter values (including item parameter values) must be 100
       // characters or fewer
       if (value.runtimeType == String) {
         value as String;
-        assert(value.length <= 100,
-            'Limit characters in event param value to 100 chars or less');
+        if (value.length > 100) {
+          throw AnalyticsException(
+              'Limit characters in event param value to 100 chars or less');
+        }
       }
     });
   }
 
   // GA4 Limitation:
   // Events can have a maximum of 25 user properties
-  assert(userProperties.length <= 25, 'Limit user properties to 25 or less');
+  if (userProperties.length > 25) {
+    throw AnalyticsException('Limit user properties to 25 or less');
+  }
 
   // Checks for each user property item
   userProperties.forEach((key, value) {
@@ -80,13 +104,23 @@ void checkBody(Map<String, Object?> body) {
 
     // GA4 Limitation:
     // User property names must be 24 characters or fewer
-    assert(key.length <= 24, 'Limit user property names to 24 chars or less');
+    if (key.length > 24) {
+      throw AnalyticsException('Limit user property names to 24 chars or less');
+    }
 
     // GA4 Limitation:
     // User property values must be 36 characters or fewer
     if (value['value'].runtimeType == String) {
-      assert((value['value'] as String).length <= 36,
-          'Limit user property values to 36 chars or less');
+      if ((value['value'] as String).length > 36) {
+        throw AnalyticsException(
+            'Limit user property values to 36 chars or less');
+      }
     }
   });
+}
+
+class AnalyticsException implements Exception {
+  final String message;
+
+  AnalyticsException(this.message);
 }

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -28,29 +28,34 @@ void checkBody(Map<String, Object?> body) {
 
   // Checks for each event object
   for (Map<String, Object?> eventMap in events) {
+    final String eventName = eventMap['name'] as String;
+
     // GA4 Limitation:
     // Event names must be 40 characters or fewer, may only contain
     // alpha-numeric characters and underscores, and must start
     // with an alphabetic character
-    if ((eventMap['name'] as String).length > 40) {
+    if (eventName.length > 40) {
       throw AnalyticsException('Limit event names to 40 chars or less');
     }
-    if (!RegExp(r'^[A-Za-z0-9_]+$').hasMatch(eventMap['name'] as String)) {
+    if (!RegExp(r'^[A-Za-z0-9_]+$').hasMatch(eventName)) {
       throw AnalyticsException(
           'Event name can only have alphanumeric chars and underscores');
     }
-    if (!RegExp(r'^[A-Za-z]+$').hasMatch((eventMap['name'] as String)[0])) {
+    if (!RegExp(r'^[A-Za-z]+$').hasMatch(eventName[0])) {
       throw AnalyticsException('Event name first char must be alphabetic char');
     }
 
+    final Map<String, Object?> eventParams =
+        eventMap['params'] as Map<String, Object?>;
+
     // GA4 Limitation:
     // Events can have a maximum of 25 parameters
-    if ((eventMap['params'] as Map<String, Object?>).length > 25) {
+    if (eventParams.length > 25) {
       throw AnalyticsException('Limit params for each event to less than 25');
     }
 
     // Loop through each of the event parameters
-    (eventMap['params'] as Map<String, Object?>).forEach((key, value) {
+    eventParams.forEach((key, value) {
       // GA4 Limitation:
       // Ensure that each value for the event params is one
       // of the following types:

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -1,3 +1,9 @@
+/// Matches only alphabetic chars
+final RegExp alphabeticPattern = RegExp(r'^[A-Za-z]+$');
+
+/// Matches strings that contain alphanumeric chars and underscores
+final RegExp alphaNumericPattern = RegExp(r'^[A-Za-z0-9_]+$');
+
 /// Checks that the body of the request being sent to
 /// GA4 is within the limitations
 ///
@@ -36,11 +42,11 @@ void checkBody(Map<String, Object?> body) {
     if (eventName.length > 40) {
       throw AnalyticsException('Limit event names to 40 chars or less');
     }
-    if (!RegExp(r'^[A-Za-z0-9_]+$').hasMatch(eventName)) {
+    if (!alphaNumericPattern.hasMatch(eventName)) {
       throw AnalyticsException(
           'Event name can only have alphanumeric chars and underscores');
     }
-    if (!RegExp(r'^[A-Za-z]+$').hasMatch(eventName[0])) {
+    if (!alphabeticPattern.hasMatch(eventName[0])) {
       throw AnalyticsException('Event name first char must be alphabetic char');
     }
 
@@ -77,11 +83,11 @@ void checkBody(Map<String, Object?> body) {
       if (key.length > 40) {
         throw AnalyticsException('Limit event param names to 40 chars or less');
       }
-      if (!RegExp(r'^[A-Za-z0-9_]+$').hasMatch(key)) {
+      if (!alphaNumericPattern.hasMatch(key)) {
         throw AnalyticsException(
             'Event param name can only have alphanumeric chars and underscores');
       }
-      if (!RegExp(r'^[A-Za-z]+$').hasMatch(key[0])) {
+      if (!alphabeticPattern.hasMatch(key[0])) {
         throw AnalyticsException(
             'Event param name first char must be alphabetic char');
       }

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -3,11 +3,8 @@
 ///
 /// Limitations can be found:
 /// https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#limitations
-void checkBody(Map<String, Object?> body) {
-  final List events = body['events'] as List;
-  final Map<String, Object?> userProperties =
-      body['user_properties'] as Map<String, Object?>;
 
+void checkBody(Map<String, Object?> body) {
   // Ensure we have the correct top level keys
   assert(body.keys.contains('client_id') == true,
       'client_id key not found in body of request');
@@ -15,6 +12,10 @@ void checkBody(Map<String, Object?> body) {
       'events key not found in body of request');
   assert(body.keys.contains('user_properties') == true,
       'user_properties key not found in body of request');
+
+  final List events = body['events'] as List;
+  final Map<String, Object?> userProperties =
+      body['user_properties'] as Map<String, Object?>;
 
   // GA4 Limitation:
   // Requests can have a maximum of 25 events

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -58,8 +58,6 @@ void checkBody(Map<String, Object?> body) {
       assert(RegExp(r'^[A-Za-z]+$').hasMatch(key[0]),
           'Event param name first char must be alphabetic char');
 
-      // TODO (eliasyishak): need to check if passing a Map that gets converted to
-      //  a string is what is breaking this
       // GA4 Limitation:
       // Parameter values (including item parameter values) must be 100
       // characters or fewer

--- a/pkgs/unified_analytics/lib/src/asserts.dart
+++ b/pkgs/unified_analytics/lib/src/asserts.dart
@@ -8,6 +8,14 @@ void checkBody(Map<String, Object?> body) {
   final Map<String, Object?> userProperties =
       body['user_properties'] as Map<String, Object?>;
 
+  // Ensure we have the correct top level keys
+  assert(body.keys.contains('client_id') == true,
+      'client_id key not found in body of request');
+  assert(body.keys.contains('events') == true,
+      'events key not found in body of request');
+  assert(body.keys.contains('user_properties') == true,
+      'user_properties key not found in body of request');
+
   // GA4 Limitation:
   // Requests can have a maximum of 25 events
   assert(events.length <= 25, 'Limit event params to 25 or less');

--- a/pkgs/unified_analytics/test/asserts_test.dart
+++ b/pkgs/unified_analytics/test/asserts_test.dart
@@ -1,0 +1,3 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.

--- a/pkgs/unified_analytics/test/asserts_test.dart
+++ b/pkgs/unified_analytics/test/asserts_test.dart
@@ -10,6 +10,361 @@ void main() {
   test('Failure if client_id top level key is missing', () {
     final Map<String, Object?> body = {};
 
-    expect(() => checkBody(body), throwsA(isA<AssertionError>()));
+    final String expectedErrorMessage = 'client_id missing from top level keys';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure if events top level key is missing', () {
+    final Map<String, Object?> body = {'client_id': 'xxxxxxx'};
+
+    final String expectedErrorMessage = 'events missing from top level keys';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure if user_properties top level key is missing', () {
+    final Map<String, Object?> body = {'client_id': 'xxxxxxx', 'events': []};
+
+    final String expectedErrorMessage =
+        'user_properties missing from top level keys';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure if more than 25 events found in events list', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[],
+      'user_properties': <String, Object?>{}
+    };
+
+    // Add more than the 25 allowed events
+    for (int i = 0; i < 30; i++) {
+      (body['events'] as List).add({'name': i});
+    }
+
+    final String expectedErrorMessage = '25 is the max number of events';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when event name is greater than 40 chars', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name':
+              'hot_reload_timehot_reload_timehot_reload_timehot_reload_time',
+          'params': {'time_ms': 133, 'count': 1999000}
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage = 'Limit event names to 40 chars or less';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when event name has invalid chars', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time!!',
+          'params': {'time_ms': 133, 'count': 1999000}
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage =
+        'Event name can only have alphanumeric chars and underscores';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when event name does not start with alphabetic char', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': '2hot_reload_time',
+          'params': {'time_ms': 133, 'count': 1999000}
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage =
+        'Event name first char must be alphabetic char';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when an event has more than 25 event params', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          // 'params': {...} SUBBING THIS VALUE OUT 30 Maps
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final Map<String, Object?> params = {};
+    for (int i = 0; i < 30; i++) {
+      params['$i'] = i;
+    }
+
+    // Add the params to the first event in the body
+    (body['events'] as List).first['params'] = params;
+
+    final String expectedErrorMessage =
+        'Limit params for each event to less than 25';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when an value for event params is not a supported type (list)',
+      () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {
+            'time_ms': 133,
+            // Lists and Maps are not supported
+            'count': <int>[1999000],
+          }
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage =
+        'Values for event params have to be String, int, double, or bool';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when an value for event params is not a supported type (map)',
+      () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {
+            'time_ms': 133,
+            // Lists and Maps are not supported
+            'count': <int, int>{5: 20},
+          }
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage =
+        'Values for event params have to be String, int, double, or bool';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when event param name is more than 40 chars', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {'time_mstime_mstime_mstime_mstime_mstime_ms': 133}
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage =
+        'Limit event param names to 40 chars or less';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure for event param name that has invalid chars', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {'time_ns!': 133}
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage =
+        'Event param name can only have alphanumeric chars and underscores';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test(
+      'Failure for event param name that does not start with an alphabetic char',
+      () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {'22time_ns': 133}
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage =
+        'Event param name first char must be alphabetic char';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure for event param values that are greater than 100 chars', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {
+            'time_ns': 'dsfjlksdjfajlfdsfjlks'
+                'djfajlfdsfjlksdjfajlfdsfjlksdjfaj'
+                'lfdsfjlksdjfajlfdsfjlksdjfajlfdsf'
+                'jlksdjfajlfdsfjlksdjfajlf'
+          }
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    final String expectedErrorMessage =
+        'Limit characters in event param value to 100 chars or less';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when body has more than 25 user properties', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {'time_ns': 123}
+        }
+      ],
+      'user_properties': <String, Object?>{}
+    };
+
+    for (int i = 0; i < 30; i++) {
+      (body['user_properties']! as Map<String, Object?>)['$i'] = i;
+    }
+
+    final String expectedErrorMessage = 'Limit user properties to 25 or less';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when user properties names are greater than 24 chars', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {'time_ns': 123}
+        }
+      ],
+      'user_properties': <String, Object?>{
+        'testtesttesttesttesttesttest': <String, Object?>{}, // TOO LONG
+      }
+    };
+
+    final String expectedErrorMessage =
+        'Limit user property names to 24 chars or less';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
+  });
+
+  test('Failure when user properties values are greater than 36 chars', () {
+    final Map<String, Object?> body = {
+      'client_id': 'xxxxxxx',
+      'events': <Map<String, Object?>>[
+        {
+          'name': 'hot_reload_time',
+          'params': {'time_ns': 123}
+        }
+      ],
+      'user_properties': <String, Object?>{
+        'test': <String, Object?>{
+          'value': 'testtesttesttesttesttesttesttesttesttest' // TOO LONG
+        },
+      }
+    };
+
+    final String expectedErrorMessage =
+        'Limit user property values to 36 chars or less';
+    expect(
+        () => checkBody(body),
+        throwsA(predicate(
+            (AnalyticsException e) => e.message == expectedErrorMessage,
+            expectedErrorMessage)));
   });
 }

--- a/pkgs/unified_analytics/test/asserts_test.dart
+++ b/pkgs/unified_analytics/test/asserts_test.dart
@@ -1,3 +1,15 @@
 // Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:unified_analytics/src/asserts.dart';
+
+void main() {
+  test('Failure if client_id top level key is missing', () {
+    final Map<String, Object?> body = {};
+
+    expect(() => checkBody(body), throwsA(isA<AssertionError>()));
+  });
+}

--- a/pkgs/unified_analytics/test/asserts_test.dart
+++ b/pkgs/unified_analytics/test/asserts_test.dart
@@ -367,4 +367,27 @@ void main() {
             (AnalyticsException e) => e.message == expectedErrorMessage,
             expectedErrorMessage)));
   });
+
+  test('Successful body passes all asserts', () {
+    final Map<String, Object?> body = {
+      'client_id': '46cc0ba6-f604-4fd9-aa2f-8a20beb24cd4',
+      'events': [
+        {
+          'name': 'testing',
+          'params': {'time_ns': 345}
+        }
+      ],
+      'user_properties': {
+        'session_id': {'value': 1673466750423},
+        'flutter_channel': {'value': 'ey-test-channel'},
+        'host': {'value': 'macos'},
+        'flutter_version': {'value': 'Flutter 3.6.0-7.0.pre.47'},
+        'dart_version': {'value': 'Dart 2.19.0'},
+        'tool': {'value': 'flutter-tools'},
+        'local_time': {'value': '2023-01-11 14:53:31.471816 -0500'}
+      }
+    };
+
+    expect(() => checkBody(body), isA<void>());
+  });
 }

--- a/pkgs/unified_analytics/test/asserts_test.dart
+++ b/pkgs/unified_analytics/test/asserts_test.dart
@@ -388,6 +388,6 @@ void main() {
       }
     };
 
-    expect(() => checkBody(body), isA<void>());
+    expect(() => checkBody(body), returnsNormally);
   });
 }


### PR DESCRIPTION
Addresses:
- https://github.com/dart-lang/tools/issues/94

Asserts added (and can be turned on from factory constructors) to check against GA4 limitations. By default `Analytics()` constructor will have asserts disabled and the `Analytics.development()` constructor will have them enabled

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for a week or two of latency for initial review feedback.

---
