### PR TITLE
No surveys for opted out users

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.0
 
 - Added `SurveyHandler` feature to `Analytics` instance to fetch available surveys from remote endpoint to display to users
+- Surveys will be disabled for any users that have been opted out
 
 ## 1.1.1
 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -382,6 +382,8 @@ class AnalyticsImpl implements Analytics {
   @override
   Future<List<Survey>> fetchAvailableSurveys() async {
     final List<Survey> surveysToShow = [];
+    if (!okToSend) return surveysToShow;
+
     final LogFileStats? logFileStats = _logHandler.logFileStats();
 
     if (logFileStats == null) return [];

--- a/pkgs/unified_analytics/test/survey_handler_test.dart
+++ b/pkgs/unified_analytics/test/survey_handler_test.dart
@@ -467,7 +467,6 @@ void main() {
         List<Survey> fetchedSurveys = await analytics.fetchAvailableSurveys();
         expect(fetchedSurveys.length, 0);
 
-
         // Setting telemetry back to true should enable the surveys to get returned
         // again; we will also need to send the fake events again because on opt out,
         // the log file will get cleared and one of the conditions for the fake survey


### PR DESCRIPTION
Tracker issue:
- https://github.com/dart-lang/tools/issues/81

For our users that have opted out of telemetry collection, we should prevent any surveys from getting sent to them.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

(note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback)
