### PR TITLE
Refactoring class to add send event APIs for each event

### DIFF
--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -11,8 +11,9 @@ import 'package:http/http.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
-import 'package:unified_analytics/src/asserts.dart';
 
+import 'analytics_events.dart';
+import 'asserts.dart';
 import 'config_handler.dart';
 import 'constants.dart';
 import 'enums.dart';
@@ -64,7 +65,7 @@ abstract class Analytics {
       apiSecret: kGoogleAnalyticsApiSecret,
     );
 
-    return AnalyticsImplNoEvents(
+    return AnalyticsImpl(
       tool: tool,
       homeDirectory: homeDirectory,
       flutterChannel: flutterChannel,

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -64,7 +64,7 @@ abstract class Analytics {
       apiSecret: kGoogleAnalyticsApiSecret,
     );
 
-    return AnalyticsImpl(
+    return AnalyticsImplNoEvents(
       tool: tool,
       homeDirectory: homeDirectory,
       flutterChannel: flutterChannel,
@@ -78,7 +78,7 @@ abstract class Analytics {
     );
   }
 
-  /// Factory constructor to return the [AnalyticsImpl] class with
+  /// Factory constructor to return the [AnalyticsImplNoEvents] class with
   /// Google Analytics credentials that point to a test instance and
   /// not the production instance where live data will be sent
   ///
@@ -123,7 +123,7 @@ abstract class Analytics {
       apiSecret: kTestApiSecret,
     );
 
-    return AnalyticsImpl(
+    return AnalyticsImplNoEvents(
       tool: tool,
       homeDirectory: homeDirectory,
       flutterChannel: flutterChannel,
@@ -137,7 +137,7 @@ abstract class Analytics {
     );
   }
 
-  /// Factory constructor to return the [AnalyticsImpl] class with a
+  /// Factory constructor to return the [AnalyticsImplNoEvents] class with a
   /// [MemoryFileSystem] to use for testing
   @visibleForTesting
   factory Analytics.test({
@@ -226,7 +226,7 @@ abstract class Analytics {
   Future<void> setTelemetry(bool reportingBool);
 }
 
-class AnalyticsImpl implements Analytics {
+class AnalyticsImplNoEvents implements Analytics {
   final DashTool tool;
   final FileSystem fs;
   late final ConfigHandler _configHandler;
@@ -261,7 +261,7 @@ class AnalyticsImpl implements Analytics {
   /// to ensure usage of this class is within GA4 limitations
   final bool _enableAsserts;
 
-  AnalyticsImpl({
+  AnalyticsImplNoEvents({
     required this.tool,
     required Directory homeDirectory,
     String? flutterChannel,
@@ -464,7 +464,7 @@ class AnalyticsImpl implements Analytics {
 /// An implementation that will never send events.
 ///
 /// This is for clients that opt to either not send analytics, or will migrate
-/// to use [AnalyticsImpl] at a later time.
+/// to use [AnalyticsImplNoEvents] at a later time.
 class NoOpAnalytics implements Analytics {
   const NoOpAnalytics._();
 
@@ -509,13 +509,13 @@ class NoOpAnalytics implements Analytics {
   Future<void> setTelemetry(bool reportingBool) async {}
 }
 
-/// This class extends [AnalyticsImpl] and subs out any methods that
+/// This class extends [AnalyticsImplNoEvents] and subs out any methods that
 /// are not suitable for tests; the following have been altered from the
 /// default implementation. All other methods are included
 ///
 /// - `sendEvent(...)` has been altered to prevent data from being sent to GA
 /// during testing
-class TestAnalytics extends AnalyticsImpl {
+class TestAnalytics extends AnalyticsImplNoEvents {
   TestAnalytics({
     required super.tool,
     required super.homeDirectory,

--- a/pkgs/unified_analytics/lib/src/analytics_events.dart
+++ b/pkgs/unified_analytics/lib/src/analytics_events.dart
@@ -15,6 +15,8 @@ class AnalyticsImpl extends AnalyticsImplNoEvents {
   AnalyticsImpl({
     required super.tool,
     required super.homeDirectory,
+    String? flutterChannel,
+    String? flutterVersion,
     required super.dartVersion,
     required super.platform,
     required super.toolsMessageVersion,

--- a/pkgs/unified_analytics/lib/src/analytics_events.dart
+++ b/pkgs/unified_analytics/lib/src/analytics_events.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'analytics.dart';
+import 'enums.dart';
+
+class AnalyticsImpl extends AnalyticsImplNoEvents {
+  /// The [Analytics] implementation that includes the
+  /// events that will be sent by tools using this package
+  ///
+  /// Using pre-defined events with preconfigured parameters
+  /// ensures that events being sent are standardized and
+  /// can be audited by referencing the APIs in this file
+  AnalyticsImpl({
+    required super.tool,
+    required super.homeDirectory,
+    required super.dartVersion,
+    required super.platform,
+    required super.toolsMessageVersion,
+    required super.fs,
+    required super.gaClient,
+    required super.enableAsserts,
+  });
+
+  Future<void> sendMemoryEvent({
+    String? rss,
+    int? periodSec,
+    double? mbPerSec,
+  }) async {
+    await sendEvent(eventName: DashEvent.memoryInfo, eventData: {
+      if (rss != null) 'rss': rss,
+      if (periodSec != null) 'periodSec': periodSec,
+      if (mbPerSec != null) 'mbPerSec': mbPerSec
+    });
+  }
+}


### PR DESCRIPTION
As discussed offline with @hixie. We should really refactor the class so that each event we have defined in the `enums.dart` file has its own sendEvent api instead of allowing clients of this package invoking `sendEvent` on their own.

By doing this, we can standardize what we expect to see in the `eventData` map object. This allows us to audit all of the event apis and what data is included by each client of this tool

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
