### PR TITLE
Added `dartCliCommandExecuted` and `pubGet` events

### DIFF
--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -31,7 +31,7 @@ enum DashEvent {
   dartCliCommandExecuted(
     label: 'dart_cli_command_executed',
     description:
-        'Information about the execution of a Dart or Flutter CLI command',
+        'Information about the execution of a Dart CLI command',
     toolOwner: DashTool.dartTool,
   ),
   pubGet(

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -18,11 +18,6 @@ enum DashEvent {
     label: 'analytics_collection_enabled',
     description: 'The opt-in status for analytics collection',
   ),
-  cliCommandExecuted(
-    label: 'cli_command_executed',
-    description:
-        'Information about the execution of a Dart or Flutter CLI command',
-  ),
   surveyAction(
     label: 'survey_action',
     description: 'Actions taken by users when shown survey',
@@ -33,6 +28,12 @@ enum DashEvent {
   ),
 
   // Events for the Dart CLI
+  dartCliCommandExecuted(
+    label: 'dart_cli_command_executed',
+    description:
+        'Information about the execution of a Dart or Flutter CLI command',
+    toolOwner: DashTool.dartTool,
+  ),
   pubGet(
     label: 'pub_get',
     description: 'Pub package resolution details',

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -55,6 +55,10 @@ enum DashEvent {
     label: 'plugin_use',
     description: 'Information about how often a plugin was used',
   ),
+  pubGet(
+    label: 'pub_get',
+    description: 'Pub package resolution details',
+  ),
   serverSession(
     label: 'server_session',
     description: 'Dart Analyzer Server session data',

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -14,6 +14,22 @@ enum DashEvent {
     label: 'analytics_collection_enabled',
     description: 'The opt-in status for analytics collection',
   ),
+  cliCommandExecuted(
+    label: 'cli_command_executed',
+    description:
+      'Information about the execution of a Dart or Flutter CLI command',
+  ),
+  timing(
+    label: 'timing',
+    description: 'Timing data collected after performing some operation',
+  ),
+
+  // Events for the Dart CLI
+  pubGet(
+    label: 'pub_get',
+    description: 'Pub package resolution details',
+    toolOwner: DashTool.dartTool,
+  ),
 
   // Events for flutter_tools
   hotReloadTime(
@@ -54,10 +70,6 @@ enum DashEvent {
   pluginUse(
     label: 'plugin_use',
     description: 'Information about how often a plugin was used',
-  ),
-  pubGet(
-    label: 'pub_get',
-    description: 'Pub package resolution details',
   ),
   serverSession(
     label: 'server_session',

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -30,8 +30,7 @@ enum DashEvent {
   // Events for the Dart CLI
   dartCliCommandExecuted(
     label: 'dart_cli_command_executed',
-    description:
-        'Information about the execution of a Dart CLI command',
+    description: 'Information about the execution of a Dart CLI command',
     toolOwner: DashTool.dartTool,
   ),
   pubGet(

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -17,7 +17,7 @@ enum DashEvent {
   cliCommandExecuted(
     label: 'cli_command_executed',
     description:
-      'Information about the execution of a Dart or Flutter CLI command',
+        'Information about the execution of a Dart or Flutter CLI command',
   ),
   timing(
     label: 'timing',

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -21,8 +21,8 @@ final class Event {
   ///
   /// [name] - the name of the command that was executed
   ///
-  /// [enabledExperiments] - a comma separated set of Dart language experiments
-  ///    enabled when running the command.
+  /// [enabledExperiments] - a set of Dart language experiments enabled when
+  ///          running the command.
   ///
   /// [exitCode] - the process exit code set as a result of running the command.
   Event.cliCommandExecuted({

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -21,22 +21,17 @@ final class Event {
   ///
   /// [name] - the name of the command that was executed
   ///
-  /// [flags] - the set of names for flags and options provided to the command.
-  ///    Does not include values provided by users for options.
-  ///
-  /// [enabledExperiments] - the set of Dart language experiments enabled when
-  ///    running the command.
+  /// [enabledExperiments] - a comma separated set of Dart language experiments
+  ///    enabled when running the command.
   ///
   /// [exitCode] - the process exit code set as a result of running the command.
   Event.cliCommandExecuted({
     required String name,
-    required List<String> flags,
-    required List<String> enabledExperiments,
+    required String enabledExperiments,
     int? exitCode,
   })  : eventName = DashEvent.cliCommandExecuted,
         eventData = {
           'name': name,
-          'flags': flags,
           'enabledExperiments': enabledExperiments,
           if (exitCode != null) 'exitCode': exitCode,
         };

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -18,8 +18,7 @@ final class Event {
       : eventName = DashEvent.analyticsCollectionEnabled,
         eventData = {'status': status};
 
-  /// Event that is emitted when a Dart or Flutter CLI command has been
-  /// executed.
+  /// Event that is emitted when a Dart CLI command has been executed.
   ///
   /// [name] - the name of the command that was executed
   ///
@@ -27,11 +26,11 @@ final class Event {
   ///          running the command.
   ///
   /// [exitCode] - the process exit code set as a result of running the command.
-  Event.cliCommandExecuted({
+  Event.dartCliCommandExecuted({
     required String name,
     required String enabledExperiments,
     int? exitCode,
-  })  : eventName = DashEvent.cliCommandExecuted,
+  })  : eventName = DashEvent.dartCliCommandExecuted,
         eventData = {
           'name': name,
           'enabledExperiments': enabledExperiments,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -16,6 +16,68 @@ final class Event {
       : eventName = DashEvent.analyticsCollectionEnabled,
         eventData = {'status': status};
 
+  /// Event that is emitted when a Dart or Flutter CLI command has been
+  /// executed.
+  ///
+  /// [name] - the name of the command that was executed
+  ///
+  /// [flags] - the set of names for flags and options provided to the command.
+  ///    Does not include values provided by users for options.
+  ///
+  /// [enabledExperiments] - the set of Dart language experiments enabled when
+  ///    running the command.
+  ///
+  /// [exitCode] - the process exit code set as a result of running the command.
+  Event.cliCommandExecuted({
+    required String name,
+    required List<String> flags,
+    required List<String> enabledExperiments,
+    int? exitCode,
+  })  : eventName = DashEvent.cliCommandExecuted,
+        eventData = {
+          'name': name,
+          'flags': flags,
+          'enabledExperiments': enabledExperiments,
+          if (exitCode != null) 'exitCode': exitCode,
+        };
+
+  /// Event that captures timing data associated with some operation.
+  ///
+  /// [operation] - the operation performed that was timed for this event.
+  ///
+  /// [timeMs] - the time the operation took to complete, in milliseconds.
+  Event.timing({
+    required String operation,
+    required int timeMs,
+  }) : eventName = DashEvent.timing,
+       eventData = {
+         'operation': operation,
+         'timeMs': timeMs,
+       };
+
+  /// Event that is emitted when `pub get` is run.
+  ///
+  /// [packageName] - the name of the package that was resolved
+  ///
+  /// [version] - the resolved, canonicalized package version
+  ///
+  /// [dependencyKind] - the kind of dependency that resulted in this package
+  ///     being resolved (e.g., direct, transitive, or dev dependencies).
+  Event.pubGet({
+    required String packageName,
+    required String version,
+    required String dependencyType,
+  })  : eventName = DashEvent.pubGet,
+        eventData = {
+          'packageName': packageName,
+          'version': version,
+          'dependencyType': dependencyType,
+        };
+
+  Event.hotReloadTime({required int timeMs})
+      : eventName = DashEvent.hotReloadTime,
+        eventData = {'timeMs': timeMs};
+
   /// Event that is emitted periodically to report the performance of the
   /// analysis server's handling of a specific kind of notification from the
   /// client.
@@ -198,10 +260,6 @@ final class Event {
           'transitiveFileUniqueLineCount': transitiveFileUniqueLineCount,
         };
 
-  Event.hotReloadTime({required int timeMs})
-      : eventName = DashEvent.hotReloadTime,
-        eventData = {'timeMs': timeMs};
-
   /// Event that is emitted periodically to report the number of times each lint
   /// has been enabled.
   ///
@@ -328,24 +386,5 @@ final class Event {
         eventData = {
           'diagnostic': diagnostic,
           'adjustments': adjustments,
-        };
-
-  /// Event that is emitted when `pub get` is run.
-  ///
-  /// [packageName] - the name of the package that was resolved
-  ///
-  /// [version] - the resolved, canonicalized package version
-  ///
-  /// [dependencyKind] - the kind of dependency that resulted in this package
-  ///     being resolved (e.g., direct, transitive, or dev dependencies).
-  Event.pubGet({
-    required String packageName,
-    required String version,
-    required String dependencyType,
-  })  : eventName = DashEvent.pubGet,
-        eventData = {
-          'packageName': packageName,
-          'version': version,
-          'dependencyType': dependencyType,
         };
 }

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -175,28 +175,13 @@ final class Event {
   /// [count] - the number of times the command was executed
   ///
   /// [name] - the name of the command that was executed
-  ///
-  /// [flags] - the set of names for flags and options provided to the command.
-  ///    Does not include values provided by users for options.
-  ///
-  /// [enabledExperiments] - the set of Dart language experiments enabled when
-  ///    running the command.
-  ///
-  /// [exitCode] - the process exit code set as a result of running the command.
   Event.commandExecuted({
     required int count,
     required String name,
-    List<String>? flags,
-    List<String>? enabledExperiments,
-    int? exitCode,
   })  : eventName = DashEvent.commandExecuted,
         eventData = {
           'count': count,
           'name': name,
-          if (flags != null) 'flags': flags,
-          if (enableExperiments != null)
-            'enabledExperiments': enabledExperiments,
-          if (exitCode != null) 'exitCode': exitCode,
         };
 
   /// Event that is emitted on shutdown to report the structure of the analysis

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -36,20 +36,6 @@ final class Event {
           if (exitCode != null) 'exitCode': exitCode,
         };
 
-  /// Event that captures timing data associated with some operation.
-  ///
-  /// [operation] - the operation performed that was timed for this event.
-  ///
-  /// [timeMs] - the time the operation took to complete, in milliseconds.
-  Event.timing({
-    required String operation,
-    required int timeMs,
-  })  : eventName = DashEvent.timing,
-        eventData = {
-          'operation': operation,
-          'timeMs': timeMs,
-        };
-
   /// Event that is emitted when `pub get` is run.
   ///
   /// [packageName] - the name of the package that was resolved

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -49,11 +49,11 @@ final class Event {
   Event.timing({
     required String operation,
     required int timeMs,
-  }) : eventName = DashEvent.timing,
-       eventData = {
-         'operation': operation,
-         'timeMs': timeMs,
-       };
+  })  : eventName = DashEvent.timing,
+        eventData = {
+          'operation': operation,
+          'timeMs': timeMs,
+        };
 
   /// Event that is emitted when `pub get` is run.
   ///
@@ -175,10 +175,8 @@ final class Event {
   /// [count] - the number of times the command was executed
   ///
   /// [name] - the name of the command that was executed
-  Event.commandExecuted({
-    required int count,
-    required String name,
-  })  : eventName = DashEvent.commandExecuted,
+  Event.commandExecuted({required int count, required String name})
+      : eventName = DashEvent.commandExecuted,
         eventData = {
           'count': count,
           'name': name,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -113,11 +113,28 @@ final class Event {
   /// [count] - the number of times the command was executed
   ///
   /// [name] - the name of the command that was executed
-  Event.commandExecuted({required int count, required String name})
-      : eventName = DashEvent.commandExecuted,
+  ///
+  /// [flags] - the set of names for flags and options provided to the command.
+  ///    Does not include values provided by users for options.
+  ///
+  /// [enabledExperiments] - the set of Dart language experiments enabled when
+  ///    running the command.
+  ///
+  /// [exitCode] - the process exit code set as a result of running the command.
+  Event.commandExecuted({
+    required int count,
+    required String name,
+    List<String>? flags,
+    List<String>? enabledExperiments,
+    int? exitCode,
+  })  : eventName = DashEvent.commandExecuted,
         eventData = {
           'count': count,
           'name': name,
+          if (flags != null) 'flags': flags,
+          if (enableExperiments != null)
+            'enabledExperiments': enabledExperiments,
+          if (exitCode != null) 'exitCode': exitCode,
         };
 
   /// Event that is emitted on shutdown to report the structure of the analysis
@@ -311,5 +328,24 @@ final class Event {
         eventData = {
           'diagnostic': diagnostic,
           'adjustments': adjustments,
+        };
+
+  /// Event that is emitted when `pub get` is run.
+  ///
+  /// [packageName] - the name of the package that was resolved
+  ///
+  /// [version] - the resolved, canonicalized package version
+  ///
+  /// [dependencyKind] - the kind of dependency that resulted in this package
+  ///     being resolved (e.g., direct, transitive, or dev dependencies).
+  Event.pubGet({
+    required String packageName,
+    required String version,
+    required String dependencyType,
+  })  : eventName = DashEvent.pubGet,
+        eventData = {
+          'packageName': packageName,
+          'version': version,
+          'dependencyType': dependencyType,
         };
 }


### PR DESCRIPTION
Required for migration of Dart CLI and dart-lang/pub from `package:usage` to `package:unified_analytics`.