### PR TITLE
Suppress telemetry feature

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.1-wip
 
 - Enhanced `LogFileStats` data to include information about flutter channel counts and tool counts
+- Added new method to suppress telemetry collection temporarily for current invocation via `analytics.suppressTelemetry()`
 
 ## 3.0.0
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.1-wip
+## 3.1.0-wip
 
 - Enhanced `LogFileStats` data to include information about flutter channel counts and tool counts
 - Added new method to suppress telemetry collection temporarily for current invocation via `analytics.suppressTelemetry()`

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -368,7 +368,7 @@ class AnalyticsImpl implements Analytics {
   ///
   /// Additionally, if the client has not invoked `clientShowedMessage`,
   /// then no events shall be sent.
-  /// 
+  ///
   /// If the user has suppressed telemetry [_telemetrySuppressed] will
   /// return `true` to prevent events from being sent for current invocation
   @override

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -224,6 +224,13 @@ abstract class Analytics {
   /// Setting the telemetry status will also send an event to GA
   /// indicating the latest status of the telemetry from [reportingBool]
   Future<void> setTelemetry(bool reportingBool);
+
+  /// Calling this will result in telemetry collection being suppressed for
+  /// the current invocation
+  ///
+  /// If you would like to permanently disable telemetry
+  /// collection use `setTelemetry(false)`
+  void suppressTelemetry();
 }
 
 class AnalyticsImpl implements Analytics {
@@ -260,6 +267,9 @@ class AnalyticsImpl implements Analytics {
   /// When set to `true`, various assert statements will be enabled
   /// to ensure usage of this class is within GA4 limitations
   final bool _enableAsserts;
+
+  /// Telemetry suppression flag that is set via `suppressTelemetry()`
+  bool _telemetrySuppressed = false;
 
   AnalyticsImpl({
     required this.tool,
@@ -358,9 +368,15 @@ class AnalyticsImpl implements Analytics {
   ///
   /// Additionally, if the client has not invoked `clientShowedMessage`,
   /// then no events shall be sent.
+  /// 
+  /// If the user has suppressed telemetry [_telemetrySuppressed] will
+  /// return `true` to prevent events from being sent for current invocation
   @override
   bool get okToSend =>
-      telemetryEnabled && !_showMessage && _clientShowedMessage;
+      telemetryEnabled &&
+      !_showMessage &&
+      _clientShowedMessage &&
+      !_telemetrySuppressed;
 
   @override
   Map<String, ToolInfo> get parsedTools => _configHandler.parsedTools;
@@ -460,6 +476,9 @@ class AnalyticsImpl implements Analytics {
     // Pass to the google analytics client to send
     return _gaClient.sendData(body);
   }
+
+  @override
+  void suppressTelemetry() => _telemetrySuppressed = true;
 }
 
 /// An implementation that will never send events.
@@ -504,4 +523,7 @@ class NoOpAnalytics implements Analytics {
 
   @override
   Future<void> setTelemetry(bool reportingBool) async {}
+
+  @override
+  void suppressTelemetry() {}
 }

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -70,7 +70,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '3.0.1-wip';
+const String kPackageVersion = '3.1.0-wip';
 
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 3.0.1-wip
+version: 3.1.0-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/suppression_test.dart
+++ b/pkgs/unified_analytics/test/suppression_test.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:test/test.dart';
+import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/unified_analytics.dart';
+
+void main() {
+  late FileSystem fs;
+  late Directory home;
+  late Analytics initializationAnalytics;
+  late Analytics analytics;
+
+  const homeDirName = 'home';
+  const initialTool = DashTool.flutterTool;
+  const measurementId = 'measurementId';
+  const apiSecret = 'apiSecret';
+  const toolsMessageVersion = 1;
+  const toolsMessage = 'toolsMessage';
+  const flutterChannel = 'flutterChannel';
+  const flutterVersion = 'flutterVersion';
+  const dartVersion = 'dartVersion';
+  const platform = DevicePlatform.macos;
+
+  final testEvent = Event.hotReloadTime(timeMs: 50);
+
+  setUp(() {
+    // Setup the filesystem with the home directory
+    final fsStyle =
+        io.Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
+    fs = MemoryFileSystem.test(style: fsStyle);
+    home = fs.directory(homeDirName);
+
+    // This is the first analytics instance that will be used to demonstrate
+    // that events will not be sent with the first run of analytics
+    initializationAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+    initializationAnalytics.clientShowedMessage();
+
+    // The main analytics instance, other instances can be spawned within tests
+    // to test how to instances running together work
+    //
+    // This instance should have the same parameters as the one above for
+    // [initializationAnalytics]
+    analytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+    analytics.clientShowedMessage();
+  });
+
+  test('Suppression works as expected', () async {
+    analytics.suppressTelemetry();
+    await analytics.send(testEvent);
+
+    final logFileStats = analytics.logFileStats();
+
+    expect(logFileStats, isNull,
+        reason: 'Returns null because no records have been recorded');
+  });
+
+  test('Second instance is not suppressed', () async {
+    analytics.suppressTelemetry();
+    await analytics.send(testEvent);
+
+    final logFileStats = analytics.logFileStats();
+
+    expect(logFileStats, isNull,
+        reason: 'Returns null because no records have been recorded');
+
+    // The newly created instance will not be suppressed
+    final secondAnalytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    // Using a new event here to differentiate from the first one
+    final newEvent = Event.commandExecuted(count: 2, name: 'commandName');
+    await secondAnalytics.send(newEvent);
+
+    // Both instances of `Analytics` should now have data retrieved
+    // from `LogFileStats()` even though only the second instance
+    // was the instance to send an event
+    final secondLogFileStats = analytics.logFileStats()!;
+    final thirdLogFileStats = secondAnalytics.logFileStats()!;
+
+    // Series of checks for each parameter in logFileStats
+    expect(secondLogFileStats.startDateTime, thirdLogFileStats.startDateTime);
+    expect(secondLogFileStats.minsFromStartDateTime,
+        thirdLogFileStats.minsFromStartDateTime);
+    expect(secondLogFileStats.endDateTime, thirdLogFileStats.endDateTime);
+    expect(secondLogFileStats.minsFromEndDateTime,
+        thirdLogFileStats.minsFromEndDateTime);
+    expect(secondLogFileStats.sessionCount, thirdLogFileStats.sessionCount);
+    expect(secondLogFileStats.flutterChannelCount,
+        thirdLogFileStats.flutterChannelCount);
+    expect(secondLogFileStats.toolCount, thirdLogFileStats.toolCount);
+    expect(secondLogFileStats.recordCount, thirdLogFileStats.recordCount);
+    expect(secondLogFileStats.eventCount, thirdLogFileStats.eventCount);
+
+    // Ensure the correct data is in the object
+    expect(secondLogFileStats.eventCount.containsKey(newEvent.eventName.label),
+        true);
+    expect(secondLogFileStats.eventCount[newEvent.eventName.label], 1);
+  });
+}


### PR DESCRIPTION
Addresses issue:
- https://github.com/dart-lang/tools/issues/124

This feature allows us to call a method on the analytics instance and suppress any events from being sent for the current invocation. This will allow clients of this tool such as the flutter-tool to simply call the method for a given command such as `flutter --suppress-analytics`

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
