### PR TITLE
Fix crash caused by response encoding for GAClient

### DIFF
--- a/pkgs/unified_analytics/lib/src/ga_client.dart
+++ b/pkgs/unified_analytics/lib/src/ga_client.dart
@@ -70,7 +70,15 @@ class GAClient {
       );
       // ignore: avoid_catches_without_on_clauses
     } catch (error) {
-      return Future<http.Response>.value(http.Response(error.toString(), 500));
+      return Future<http.Response>.value(
+        http.Response(
+          error.toString(),
+          500,
+          headers: <String, String>{
+            'content-type': 'text/plain; charset=utf-8',
+          },
+        ),
+      );
     }
   }
 }


### PR DESCRIPTION
Fix #131 

The `Response` in http package uses `content-type` in response header to infer the encoding for its body. However, the header is not specified in this fake response and latin1 will be used as fallback, which cannot encode non-latin letters.

In this pr, a proper header is added and `utf-8` will be used to encode response body.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
