### PR TITLE
add usage docs to package:cli_config

### DIFF
--- a/pkgs/cli_config/CHANGELOG.md
+++ b/pkgs/cli_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2-wip
+
+- Add usage docs to the readme.
+
 ## 0.1.1
 
 - Support non-String map keys in YAML configuration files.

--- a/pkgs/cli_config/README.md
+++ b/pkgs/cli_config/README.md
@@ -3,4 +3,69 @@
 [![pub package](https://img.shields.io/pub/v/cli_config.svg)](https://pub.dev/packages/cli_config)
 [![package publisher](https://img.shields.io/pub/publisher/cli_config.svg)](https://pub.dev/packages/cli_config/publisher)
 
-A library to take config values from configuration files, CLI arguments, and environment variables.
+A library to take config values from configuration files, CLI arguments, and
+environment variables.
+
+## Usage
+
+Configuration can be provided from commandline arguments, environment variables,
+and configuration files. This library makes these accessible via a uniform API.
+
+Configuration can be provided via the three sources as follows:
+1. commandline argument defines as `-Dsome_key=some_value`,
+2. environment variables as `SOME_KEY=some_value`, and
+3. config files as JSON or YAML as `{'some_key': 'some_value'}`.
+
+The default lookup behavior is that commandline argument defines take precedence
+over environment variables, which take precedence over the configuration file.
+
+If a single value is requested from this configuration, the first source that
+can provide the value will provide it. For example
+`config.string('some_key')` with `{'some_key': 'file_value'}` in the config file
+and `-Dsome_key=cli_value` as commandline argument returns
+`'cli_value'`. The implication is that you can not remove keys from the
+configuration file, only overwrite or append them.
+
+If a list value is requested from this configuration, the values provided by the
+various sources can be combined or not. For example
+`config.optionalStringList('some_key', combineAllConfigs: true)` returns
+`['cli_value', 'file_value']`.
+
+The config is hierarchical in nature, using `.` as the hierarchy separator for
+lookup and commandline defines. The hierarchy should be materialized in the JSON
+or YAML configuration file. For environment variables `__` is used as hierarchy
+separator.
+
+Hierarchical configuration can be provided via the three sources as follows:
+1. commandline argument defines as `-Dsome_key.some_nested_key=some_value`,
+2. environment variables as `SOME_KEY__SOME_NESTED_KEY=some_value`, and
+3. config files as JSON or YAML as
+   ```yaml
+   some_key:
+     some_nested_key:
+       some_value
+   ```
+
+The config is opinionated on the format of the keys in the sources.
+* Command-line argument keys should be lower-cased alphanumeric
+  characters or underscores, with `.` for hierarchy.
+* Environment variables keys should be upper-cased alphanumeric
+   characters or underscores, with `__` for hierarchy.
+* Config files keys should be lower-cased alphanumeric
+  characters or underscores.
+
+In the API they are made available lower-cased and with underscores, and
+`.` as hierarchy separator.
+
+## Example usage
+
+This example creates a configuration which first looks for command-line defines
+in the `args` list then looks in `Platform.environment`, then looks in any local
+configuration file.
+
+```dart
+final config = await Config.fromArgs(args: args);
+final pathValue =
+    config.optionalPath('my_path', resolveUri: true, mustExist: false);
+print(pathValue?.toFilePath());
+```

--- a/pkgs/cli_config/example/pubspec.yaml
+++ b/pkgs/cli_config/example/pubspec.yaml
@@ -1,8 +1,6 @@
 name: cli_config_example
 description: An example for cli_config.
 
-repository: https://github.com/dart-lang/tools/tree/main/pkgs/cli_config/example
-
 publish_to: none
 
 environment:

--- a/pkgs/cli_config/pubspec.yaml
+++ b/pkgs/cli_config/pubspec.yaml
@@ -1,7 +1,8 @@
 name: cli_config
-description: A library to take config values from configuration files, CLI arguments, and environment variables.
-version: 0.1.1
-
+description: >-
+  A library to take config values from configuration files, CLI arguments, and
+  environment variables.
+version: 0.1.2-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/cli_config
 
 environment:


### PR DESCRIPTION
-add usage docs to package:cli_config

Not included in this PR, but it may also be useful to provide examples around env var + config file usage.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
