### PR TITLE
`--disable-telemetry` --> `--disable-analytics`

### DIFF
--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -95,7 +95,7 @@ This data is used to help improve the Dart platform, Flutter framework, and rela
 Telemetry is not sent on the very first run.
 To disable reporting of telemetry, run this terminal command:
 
-[dart|flutter] --disable-telemetry.
+[dart|flutter] --disable-analytics.
 If you opt out of telemetry, an opt-out event will be sent,
 and then no further information will be sent.
 This data is collected in accordance with the


### PR DESCRIPTION
To reduce confusion around the opt out commands, we will use the `--disable-analytics` flag that has already been implemented in dart

Flutter also has its own `flutter config --no-analytics` for opting out, but this [PR](https://github.com/flutter/flutter/pull/132588) has the update to use the new flag

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
