### PR TITLE
Improve exception messages for `ExpectJson` extension

### DIFF
--- a/pkgs/extension_discovery/CHANGELOG.md
+++ b/pkgs/extension_discovery/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2-wip
+- Improve error messaging for `package_config.json` parsing.
+
 ## 1.0.1-wip
 
 - Update the package description.

--- a/pkgs/extension_discovery/lib/src/expect_json.dart
+++ b/pkgs/extension_discovery/lib/src/expect_json.dart
@@ -13,30 +13,30 @@ Map<String, Object?> decodeJsonMap(String json) {
 extension ExpectJson on Map<String, Object?> {
   bool expectBool(String key) {
     if (this[key] case bool v) return v;
-    throw FormatException('"key" must be a bool');
+    throw FormatException('The value at "$key" must be a bool:\n$toString()');
   }
 
   num expectNumber(String key) {
     if (this[key] case num v) return v;
-    throw FormatException('"key" must be a number');
+    throw FormatException('The value at "$key" must be a number:\n$toString()');
   }
 
   String expectString(String key) {
     if (this[key] case String v) return v;
-    throw FormatException('"key" must be a string');
+    throw FormatException('The value at "$key" must be a string:\n$toString()');
   }
 
   Uri expectUri(String key) {
     try {
       return Uri.parse(expectString(key));
     } on FormatException {
-      throw FormatException('"key" must be a URI');
+      throw FormatException('The value at "$key" must be a URI:\n$toString()');
     }
   }
 
   List<Object?> expectList(String key) {
     if (this[key] case List<Object?> v) return v;
-    throw FormatException('"key" must be a list');
+    throw FormatException('The value at "$key" must be a list:\n$toString()');
   }
 
   Iterable<Map<String, Object?>> expectListObjects(String key) sync* {
@@ -45,7 +45,9 @@ extension ExpectJson on Map<String, Object?> {
       if (entry case Map<String, Object?> v) {
         yield v;
       } else {
-        throw FormatException('"key" must be a list of map');
+        throw FormatException(
+          'The value at "$key" must be a list of map:\n$toString()',
+        );
       }
     }
   }

--- a/pkgs/extension_discovery/pubspec.yaml
+++ b/pkgs/extension_discovery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: extension_discovery
 description: >-
   A convention and utilities for package extension discovery.
-version: 1.0.1-wip
+version: 1.0.2-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/extension_discovery
 
 dev_dependencies:


### PR DESCRIPTION
While debugging https://github.com/dart-lang/tools/issues/146, I found that the error messages needed to be more specific. This `FormatException`s will now include the name of the "key" that has an invalid value, and the map it is a part of.  This should save considerable time for debugging future format errors.