### PR TITLE
Support optional packageUri

### DIFF
--- a/pkgs/extension_discovery/CHANGELOG.md
+++ b/pkgs/extension_discovery/CHANGELOG.md
@@ -1,10 +1,8 @@
-## 1.0.2-wip
-- Improve error messaging for `package_config.json` parsing.
-
 ## 1.0.1-wip
 
-- Update the package description.
 - Support optional `packageUri`.
+- Improve error messaging for `package_config.json` parsing.
+- Update the package description.
 
 ## 1.0.0
 

--- a/pkgs/extension_discovery/CHANGELOG.md
+++ b/pkgs/extension_discovery/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.1-wip
 
 - Update the package description.
+- Support optional `packageUri`.
 
 ## 1.0.0
 

--- a/pkgs/extension_discovery/lib/src/expect_json.dart
+++ b/pkgs/extension_discovery/lib/src/expect_json.dart
@@ -34,6 +34,13 @@ extension ExpectJson on Map<String, Object?> {
     }
   }
 
+  Uri? optionalUri(String key) {
+    if (containsKey(key)) {
+      return expectUri(key);
+    }
+    return null;
+  }
+
   List<Object?> expectList(String key) {
     if (this[key] case List<Object?> v) return v;
     throw FormatException('"key" must be a list');

--- a/pkgs/extension_discovery/lib/src/package_config.dart
+++ b/pkgs/extension_discovery/lib/src/package_config.dart
@@ -18,14 +18,14 @@ Future<PackageConfig> loadPackageConfig(
     if (packageConfig.expectNumber('configVersion') != 2) {
       throw FormatException('"configVersion" must be 2');
     }
-    return packageConfig
-        .expectListObjects('packages')
-        .map((p) => (
-              name: p.expectString('name'),
-              rootUri: p.expectUri('rootUri').asDirectory(),
-              packageUri: p.expectUri('packageUri').asDirectory(),
-            ))
-        .toList();
+    return packageConfig.expectListObjects('packages').map((p) {
+      final rootUri = p.expectUri('rootUri').asDirectory();
+      return (
+        name: p.expectString('name'),
+        rootUri: rootUri,
+        packageUri: p.optionalUri('packageUri')?.asDirectory() ?? rootUri,
+      );
+    }).toList();
   } on IOException catch (e) {
     if (!packageConfigFile.existsSync()) {
       throw packageConfigNotFound(packageConfigFile.uri);

--- a/pkgs/extension_discovery/pubspec.yaml
+++ b/pkgs/extension_discovery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: extension_discovery
 description: >-
   A convention and utilities for package extension discovery.
-version: 1.0.2-wip
+version: 1.0.1-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/extension_discovery
 
 dev_dependencies:


### PR DESCRIPTION
Ensure that we support cases where `packageUri` is not present.

Fixes https://github.com/dart-lang/tools/issues/146