### PR TITLE
Prepare release of `package:extension_discovery` version `1.0.1`

### DIFF
--- a/pkgs/extension_discovery/CHANGELOG.md
+++ b/pkgs/extension_discovery/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.1-wip
+## 1.0.1
 
 - Support optional `packageUri`.
 - Improve error messaging for `package_config.json` parsing.

--- a/pkgs/extension_discovery/pubspec.yaml
+++ b/pkgs/extension_discovery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: extension_discovery
 description: >-
   A convention and utilities for package extension discovery.
-version: 1.0.1-wip
+version: 1.0.1
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/extension_discovery
 
 dev_dependencies:


### PR DESCRIPTION
Seems e5ce42a724cbf96877b0802f69da637d4fa63dee have landed in the Dart SDK. Assuming it sticks I'm thinking we can release this in a few days.