### PR TITLE
Export Survey in package:unified_analytics

### DIFF
--- a/pkgs/unified_analytics/lib/unified_analytics.dart
+++ b/pkgs/unified_analytics/lib/unified_analytics.dart
@@ -7,4 +7,4 @@ export 'src/config_handler.dart' show ToolInfo;
 export 'src/enums.dart' show DashTool;
 export 'src/event.dart' show Event;
 export 'src/log_handler.dart' show LogFileStats;
-export 'src/survey_handler.dart' show SurveyButton, SurveyHandler;
+export 'src/survey_handler.dart' show Survey, SurveyButton, SurveyHandler;


### PR DESCRIPTION
I think this is just an oversight (and not deliberate). Without it, I can't use `Survey` explicitly in code without importing from `src`.

@eliasyishak 