### PR TITLE
Extension discovery 2.0.0

### DIFF
--- a/pkgs/extension_discovery/CHANGELOG.md
+++ b/pkgs/extension_discovery/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0
+- Use `extension/<package>/config.yaml` instead of
+  `extension/<package>/config.json` for better consistency with other tooling.
+- Require that the top-level value in `extension/<package>/config.yaml` is
+  always a `Map`, and that the structure can be converted to a JSON equivalent
+  structure.
+
 ## 1.0.1
 
 - Support optional `packageUri`.

--- a/pkgs/extension_discovery/README.md
+++ b/pkgs/extension_discovery/README.md
@@ -11,13 +11,13 @@ A convention to allow other packages to provide extensions for your package
 
 The convention implemented in this package is that if `foo` provides an
 extension for `<targetPackage>`.
-Then `foo` must contain a config file `extension/<targetPackage>/config.json`.
+Then `foo` must contain a config file `extension/<targetPackage>/config.yaml`.
 This file indicates that `foo` provides an extension for `<targetPackage>`.
 
 If `<targetPackage>` accepts extensions from other packages it must:
  * Find extensions using `findExtensions('<targetPackage>')` from this package.
  * Document how extensions are implemented:
-   * What should the contents of the `extension/<targetPackage>/config.json` file be?
+   * What should the contents of the `extension/<targetPackage>/config.yaml` file be?
    * Should packages providing extensions have a dependency constraint on `<targetPackage>`?
    * What libraries/assets should packages that provide extensions include?
    * Should packages providing extensions specify a [topic in `pubspec.yaml`][1]
@@ -25,8 +25,8 @@ If `<targetPackage>` accepts extensions from other packages it must:
 
 The `findExtensions(targetPackage, packageConfig: ...)` function will:
  * Load `.dart_tool/package_config.json` and find all packages that contain a
-   valid JSON file: `extension/<targetPackage>/config.json`.
- * Provide the package name, location and contents of the `config.json` file,
+   valid YAML file: `extension/<targetPackage>/config.yaml`.
+ * Provide the package name, location and contents of the `config.yaml` file,
    for all detected extensions (aimed at `targetPackage`).
  * Cache the results for fast loading, comparing modification timestamps to
    ensure consistent results.
@@ -41,7 +41,7 @@ created.
 You can also use this package (and associated convention), if you are developing
 a tool that can be extended by packages. In this case, you would call
 `findExtensions(<my_tool_package_name>, packageConfig: ...)` where
-`packageConfig` points to the `.dart_tool/packge_config.json` in the workspace
+`packageConfig` points to the `.dart_tool/package_config.json` in the workspace
 the tool is operating on.
 
 If you tool is not distributed through pub.dev, you might consider publishing
@@ -103,7 +103,7 @@ Future<void> sayHello(String language) async {
 ```
 
 The `findExtensions` function will search other packages for
-`extension/hello_world/config.json`, and provide the contents of this file as
+`extension/hello_world/config.yaml`, and provide the contents of this file as
 well as provide the location of the extending packages.
 As authors of the `hello_world` package we should also document how other
 packages can extend `hello_world`. This is typically done by adding a segment
@@ -115,18 +115,16 @@ to the `README.md`.
 If in another package `hello_world_german` we wanted to extend `hello_world`
 and provide a translation for German, then we would create a
 `hello_world_german` package containing an
-**`extension/hello_world/config.json`**:
+**`extension/hello_world/config.yaml`**:
 
-```json
-{
-  "language": "german",
-  "message": "Hello Welt!"
-}
+```yaml
+language: german
+message: "Hello Welt!"
 ```
 
 Obviously, this is a contrived example. The authors of the `hello_world` package
 could specify all sorts configuration options that extension authors can
-specify in `extension/hello_world/config.json`.
+specify in `extension/hello_world/config.yaml`.
 
 The authors of `hello_world` could also specify that extensions must provide
 certain assets in `extension/hello_world/` or that they must provide certain
@@ -175,7 +173,7 @@ what extension packages can provide. For this reason it is important that the
 authors of `hello_world` very explicitly document how an extension is written.
 
 Obviously, authors of `hello_world` should document what should be specified in
-`extension/hello_world/config.json`. They could also specify that other files
+`extension/hello_world/config.yaml`. They could also specify that other files
 should be provided in `extension/hello_world/`, or that certain Dart libraries
 should be provided in `lib/src/hello_world/...` or something like that.
 

--- a/pkgs/extension_discovery/example/hello_world/lib/hello_world.dart
+++ b/pkgs/extension_discovery/example/hello_world/lib/hello_world.dart
@@ -14,9 +14,6 @@ Future<void> sayHello(String language) async {
   // Search extensions to see if one provides a message for language
   for (final ext in extensions) {
     final config = ext.config;
-    if (config is! Map<String, Object?>) {
-      continue; // ignore extensions with invalid configation
-    }
     if (config['language'] == language) {
       print(config['message']);
       return; // Don't print more messages!

--- a/pkgs/extension_discovery/example/hello_world_german/extension/hello_world/config.json
+++ b/pkgs/extension_discovery/example/hello_world_german/extension/hello_world/config.json
@@ -1,4 +1,0 @@
-{
-  "language": "german",
-  "message": "Hello Welt!"
-}

--- a/pkgs/extension_discovery/example/hello_world_german/extension/hello_world/config.yaml
+++ b/pkgs/extension_discovery/example/hello_world_german/extension/hello_world/config.yaml
@@ -1,0 +1,9 @@
+# This config file let's `package:extension_discovery` find out that
+# `package:hello_world_german` has an extension for `package:hello_world`.
+#
+# The root object must be a map, and the data structure must be representable
+# as JSON, but those are the only constraints. Beyond that it is the
+# responsibility of `package:hello_world` to define what this file should
+# contain, to validate the contents, and do something useful with it.
+language: german
+message: "Hello Welt!"

--- a/pkgs/extension_discovery/lib/extension_discovery.dart
+++ b/pkgs/extension_discovery/lib/extension_discovery.dart
@@ -273,19 +273,13 @@ Future<List<Extension>> _findExtensions({
 
   return UnmodifiableListView(
     registry
-        .map((e) {
-          final config = e.config;
-          if (config == null) {
-            return null;
-          }
-          return Extension._(
-            package: e.package,
-            rootUri: packageConfigUri.resolveUri(e.rootUri),
-            packageUri: e.packageUri,
-            config: config,
-          );
-        })
-        .whereType<Extension>()
+        .where((e) => e.config != null)
+        .map((e) => Extension._(
+              package: e.package,
+              rootUri: packageConfigUri.resolveUri(e.rootUri),
+              packageUri: e.packageUri,
+              config: e.config!,
+            ))
         .toList(growable: false),
   );
 }

--- a/pkgs/extension_discovery/lib/extension_discovery.dart
+++ b/pkgs/extension_discovery/lib/extension_discovery.dart
@@ -201,7 +201,6 @@ Future<List<Extension>> _findExtensions({
               rootUri: p.rootUri,
               packageUri: p.packageUri,
               config: parseYamlFromConfigFile(await configFile.readAsString()),
-              present: true,
             );
             continue;
           } on FormatException {
@@ -215,20 +214,18 @@ Future<List<Extension>> _findExtensions({
             rootUri: p.rootUri,
             packageUri: p.packageUri,
             config: null,
-            present: false,
           );
         }
       } else {
         // If there is no file present, but registry says there is then we need
         // to update the registry.
-        if (p.present) {
+        if (p.config != null) {
           registryUpdated = true;
           registry[i] = (
             package: p.package,
             rootUri: p.rootUri,
             packageUri: p.packageUri,
             config: null,
-            present: false,
           );
         }
       }
@@ -248,7 +245,6 @@ Future<List<Extension>> _findExtensions({
             rootUri: p.rootUri,
             packageUri: p.packageUri,
             config: parseYamlFromConfigFile(await configFile.readAsString()),
-            present: true,
           );
         }
       } on FormatException {
@@ -262,7 +258,6 @@ Future<List<Extension>> _findExtensions({
           rootUri: p.rootUri,
           packageUri: p.packageUri,
           config: null,
-          present: false,
         );
       }
       return null;
@@ -278,13 +273,19 @@ Future<List<Extension>> _findExtensions({
 
   return UnmodifiableListView(
     registry
-        .where((e) => e.present) // TODO: Use config != null
-        .map((e) => Extension._(
-              package: e.package,
-              rootUri: packageConfigUri.resolveUri(e.rootUri),
-              packageUri: e.packageUri,
-              config: e.config!,
-            ))
+        .map((e) {
+          final config = e.config;
+          if (config == null) {
+            return null;
+          }
+          return Extension._(
+            package: e.package,
+            rootUri: packageConfigUri.resolveUri(e.rootUri),
+            packageUri: e.packageUri,
+            config: config,
+          );
+        })
+        .whereType<Extension>()
         .toList(growable: false),
   );
 }

--- a/pkgs/extension_discovery/lib/src/expect_json.dart
+++ b/pkgs/extension_discovery/lib/src/expect_json.dart
@@ -34,6 +34,18 @@ extension ExpectJson on Map<String, Object?> {
     }
   }
 
+  Map<String, Object?> expectMap(String key) {
+    if (this[key] case Map<String, Object?> v) return v;
+    throw FormatException('The value at "$key" must be a map:\n$toString()');
+  }
+
+  Map<String, Object?>? optionalMap(String key) {
+    if (containsKey(key)) {
+      return expectMap(key);
+    }
+    return null;
+  }
+
   Uri? optionalUri(String key) {
     if (containsKey(key)) {
       return expectUri(key);

--- a/pkgs/extension_discovery/lib/src/registry.dart
+++ b/pkgs/extension_discovery/lib/src/registry.dart
@@ -20,8 +20,8 @@ typedef RegistryEntry = ({
   String package,
   Uri rootUri,
   Uri packageUri,
-  Object? config,
-  bool present,
+  Map<String, Object?>? config,
+  bool present, // TODO: Consider removing this field in favor of config = null
 });
 
 typedef Registry = List<RegistryEntry>;
@@ -38,7 +38,7 @@ Future<Registry?> loadRegistry(File registryFile) async {
               package: e.expectString('package'),
               rootUri: e.expectUri('rootUri'),
               packageUri: e.expectUri('packageUri'),
-              config: e['config'],
+              config: e.optionalMap('config'),
               present: e.expectBool('present'),
             ))
         .toList(growable: false);
@@ -80,7 +80,7 @@ Future<void> saveRegistry(
                 'package': e.package,
                 'rootUri': e.rootUri.toString(),
                 'packageUri': e.packageUri.toString(),
-                'config': e.config,
+                if (e.config != null) 'config': e.config,
                 'present': e.present,
               })
           .toList(),

--- a/pkgs/extension_discovery/lib/src/yaml_config_format.dart
+++ b/pkgs/extension_discovery/lib/src/yaml_config_format.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Utilities for loading and validating YAML from a config file.
+///
+/// When writing YAML config files it's often preferable to force a few
+/// constraints on the YAML files. Specifically:
+///  * Root value must be a map.
+///  * No anchors / aliases, this can't be represented in JSON and
+///    can be used to created cycles, which might crash someone trying to
+///    serialize the data as JSON.
+///  * Maps can only have string keys.
+///
+/// Basically, only allow value that can't be represented in JSON.
+///
+/// This library aims to provide a [parseYamlFromConfigFile] that throws
+/// a [FormatException] when parsing YAML files that doesn't satisfy this
+/// constraint.
+library;
+
+import 'package:yaml/yaml.dart'
+    show YamlList, YamlMap, YamlNode, YamlScalar, loadYamlNode;
+
+/// Parse YAML from a config file.
+///
+/// This will validate that:
+///  * Maps only have string keys.
+///  * Anchor and aliases are not used (to avoid cycles).
+///  * Values can be represented as JSON.
+///  * Root node is a map.
+///
+/// Throw will throw [FormatException], if the [yamlString] does not satisfy
+/// constraints above.
+///
+/// Returns a structure consisting of the following types:
+///  * `null`,
+///  * [bool] (`true` or `false`),
+///  * [String],
+///  * [num] ([int] or [double]),
+///  * [List<Object?>], and,
+///  * [Map<String, Object?>].
+Map<String, Object?> parseYamlFromConfigFile(String yamlString) {
+  final visited = <YamlNode>{};
+  Object? toPlainType(YamlNode n) {
+    if (!visited.add(n)) {
+      throw FormatException(
+        'Anchors/aliases are not supported in YAML config files',
+      );
+    }
+    if (n is YamlScalar) {
+      return switch (n.value) {
+        null => null,
+        String s => s,
+        num n => n,
+        bool b => b,
+        _ => throw FormatException(
+            'Only null, string, number, bool, map and lists are supported '
+            'in YAML config files',
+          ),
+      };
+    }
+    if (n is YamlList) {
+      return n.nodes.map(toPlainType).toList();
+    }
+    if (n is YamlMap) {
+      return n.nodes.map((key, value) {
+        final k = toPlainType(key as YamlNode);
+        if (k is! String) {
+          throw FormatException(
+            'Only string keys are allowed in YAML config files',
+          );
+        }
+        return MapEntry(k, toPlainType(value));
+      });
+    }
+    throw UnsupportedError('Unknown YamlNode: $n');
+  }
+
+  final value = toPlainType(loadYamlNode(yamlString));
+  if (value is! Map<String, Object?>) {
+    throw FormatException('The root of a YAML config file must be a map');
+  }
+  return value;
+}

--- a/pkgs/extension_discovery/pubspec.yaml
+++ b/pkgs/extension_discovery/pubspec.yaml
@@ -14,6 +14,5 @@ dev_dependencies:
   test: ^1.21.0
   test_descriptor: ^2.0.1
 
-
 environment:
   sdk: ^3.0.0

--- a/pkgs/extension_discovery/pubspec.yaml
+++ b/pkgs/extension_discovery/pubspec.yaml
@@ -1,14 +1,19 @@
 name: extension_discovery
 description: >-
   A convention and utilities for package extension discovery.
-version: 1.0.1
+version: 2.0.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/extension_discovery
 
+dependencies:
+  yaml: ^3.0.0
+
 dev_dependencies:
+  collection: ^1.18.0
   dart_flutter_team_lints: ^1.0.0
   lints: ^2.0.0
   test: ^1.21.0
   test_descriptor: ^2.0.1
+
 
 environment:
   sdk: ^3.0.0

--- a/pkgs/extension_discovery/test/find_extensions_test.dart
+++ b/pkgs/extension_discovery/test/find_extensions_test.dart
@@ -55,9 +55,9 @@ void main() {
         'name': 'foo',
         'environment': {'sdk': '^3.0.0'},
       }),
-      // It has a config.json for myapp
+      // It has a config.yaml for myapp
       d.dir('extension/myapp', [
-        d.json('config.json', {'fromFoo': true}),
+        d.json('config.yaml', {'fromFoo': true}),
       ]),
     ]).create();
 
@@ -89,14 +89,14 @@ void main() {
               e.package == 'foo' &&
               e.rootUri == d.directoryUri('foo/') &&
               e.packageUri == Uri.parse('lib/') &&
-              (e.config as Map)['fromFoo'] == true,
+              e.config['fromFoo'] == true,
         ),
         isTrue,
       );
     }
 
     // ################################## Modify the config
-    await d.json('foo/extension/myapp/config.json', {'fromFoo': 42}).create();
+    await d.json('foo/extension/myapp/config.yaml', {'fromFoo': 42}).create();
 
     // Check that we do find an extension
     {
@@ -111,14 +111,14 @@ void main() {
               e.package == 'foo' &&
               e.rootUri == d.directoryUri('foo/') &&
               e.packageUri == Uri.parse('lib/') &&
-              (e.config as Map)['fromFoo'] == 42,
+              e.config['fromFoo'] == 42,
         ),
         isTrue,
       );
     }
 
     // ################################## Make config invalid
-    await d.file('foo/extension/myapp/config.json', 'invalid json').create();
+    await d.file('foo/extension/myapp/config.yaml', 'invalid YAML').create();
 
     // Check that we do not find extensions
     {
@@ -130,7 +130,7 @@ void main() {
     }
 
     // ################################## Make config valid again
-    await d.json('foo/extension/myapp/config.json', true).create();
+    await d.json('foo/extension/myapp/config.yaml', {'fromFoo': true}).create();
 
     // Check that we do find extensions
     {
@@ -142,7 +142,7 @@ void main() {
     }
 
     // ################################## Remove config file
-    await d.file('foo/extension/myapp/config.json').io.delete();
+    await d.file('foo/extension/myapp/config.yaml').io.delete();
     // Check that we do not find extensions
     {
       final ext = await findExtensions(
@@ -153,7 +153,7 @@ void main() {
     }
 
     // ################################## Make config valid again
-    await d.json('foo/extension/myapp/config.json', {'fromFoo': true}).create();
+    await d.json('foo/extension/myapp/config.yaml', {'fromFoo': true}).create();
 
     // Check that we do find extensions
     {
@@ -170,9 +170,9 @@ void main() {
         'name': 'bar',
         'environment': {'sdk': '^3.0.0'},
       }),
-      // It has a config.json for myapp
+      // It has a config.yaml for myapp
       d.dir('extension/myapp', [
-        d.json('config.json', {'fromFoo': false}),
+        d.json('config.yaml', {'fromFoo': false}),
       ]),
     ]).create();
 
@@ -214,7 +214,7 @@ void main() {
               e.package == 'foo' &&
               e.rootUri == d.directoryUri('foo/') &&
               e.packageUri == Uri.parse('lib/') &&
-              (e.config as Map)['fromFoo'] == true,
+              e.config['fromFoo'] == true,
         ),
         isTrue,
       );
@@ -224,7 +224,7 @@ void main() {
               e.package == 'bar' &&
               e.rootUri == d.directoryUri('bar/') &&
               e.packageUri == Uri.parse('lib/') &&
-              (e.config as Map)['fromFoo'] == false,
+              e.config['fromFoo'] == false,
         ),
         isTrue,
       );
@@ -247,7 +247,7 @@ void main() {
 
     // Delete config from package that has an absolute path, hence, a package
     // we assume to be immutable.
-    await d.file('bar/extension/myapp/config.json').io.delete();
+    await d.file('bar/extension/myapp/config.yaml').io.delete();
 
     // Check that we do find both extensions
     {
@@ -259,7 +259,7 @@ void main() {
       // This is the wrong result, but it is expected. Essentially, if we expect
       // that if you have packages in package_config.json using an absolute path
       // then these won't be modified. If you do modify the
-      //   extension/<targetPackage>/config.json
+      //   extension/<targetPackage>/config.yaml
       // file, then the cache will give the wrong result. The workaround is to
       // touch `package_config.json`, or run `dart pub get` (essentially).
       expect(ext.any((e) => e.package == 'bar'), isTrue);
@@ -296,7 +296,7 @@ void main() {
 
     // ################################## What if foo has extensions for bar
     await d.dir('foo/extension/bar', [
-      d.json('config.json', {'fromFoo': true}),
+      d.json('config.yaml', {'fromFoo': true}),
     ]).create();
 
     {
@@ -311,7 +311,7 @@ void main() {
 
     // ################################## myapp could also extend bar
     await d.dir('myapp/extension/bar', [
-      d.json('config.json', {'fromFoo': false}),
+      d.json('config.yaml', {'fromFoo': false}),
     ]).create();
 
     {
@@ -323,5 +323,28 @@ void main() {
       expect(ext.any((e) => e.package == 'bar'), isFalse);
       expect(ext.any((e) => e.package == 'myapp'), isTrue);
     }
-  });
+
+    // ################################## config could also be written in YAML
+    await d.dir('myapp/extension/bar', [
+      d.file('config.yaml', '''
+writtenAsYaml: true
+'''),
+    ]).create();
+
+    {
+      final ext = await findExtensions(
+        'bar',
+        packageConfig: d.fileUri('myapp/.dart_tool/package_config.json'),
+      );
+      expect(ext.any((e) => e.package == 'foo'), isTrue);
+      expect(ext.any((e) => e.package == 'bar'), isFalse);
+      expect(ext.any((e) => e.package == 'myapp'), isTrue);
+      expect(
+        ext.any(
+          (e) => e.package == 'myapp' && e.config['writtenAsYaml'] == true,
+        ),
+        isTrue,
+      );
+    }
+  }, timeout: Timeout.none);
 }

--- a/pkgs/extension_discovery/test/find_extensions_test.dart
+++ b/pkgs/extension_discovery/test/find_extensions_test.dart
@@ -346,5 +346,5 @@ writtenAsYaml: true
         isTrue,
       );
     }
-  }, timeout: Timeout.none);
+  });
 }

--- a/pkgs/extension_discovery/test/integration_test.dart
+++ b/pkgs/extension_discovery/test/integration_test.dart
@@ -96,9 +96,9 @@ Future<void> main(List<String> args) async {
         'name': 'foo',
         'environment': {'sdk': '^3.0.0'},
       }),
-      // It has a config.json for myapp
+      // It has a config.yaml for myapp
       d.dir('extension/myapp', [
-        d.json('config.json', {'fromFoo': true}),
+        d.json('config.yaml', {'fromFoo': true}),
       ]),
     ]).create();
 

--- a/pkgs/extension_discovery/test/yaml_config_format_test.dart
+++ b/pkgs/extension_discovery/test/yaml_config_format_test.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:collection/collection.dart' show DeepCollectionEquality;
+
+import 'package:extension_discovery/src/yaml_config_format.dart';
+import 'package:test/test.dart';
+
+void _testInvalid(String name, String yaml, {String match = ''}) {
+  test(name, () {
+    expect(
+      () => parseYamlFromConfigFile(yaml),
+      throwsA(isFormatException.having(
+        (e) => e.message,
+        'message',
+        contains(match),
+      )),
+    );
+  });
+}
+
+void _testValid(String name, String yaml) {
+  test(name, () {
+    parseYamlFromConfigFile(yaml);
+  });
+}
+
+void main() {
+  group('parseYamlFromConfigFile', () {
+    group('root must be a map', () {
+      _testInvalid('empty string', '', match: 'map');
+      _testInvalid('null', 'null', match: 'map');
+      _testInvalid('list', '[]', match: 'map');
+      _testInvalid('number (1)', '42', match: 'map');
+      _testInvalid('number (2)', '42.2', match: 'map');
+      _testInvalid('bool (1)', 'true', match: 'map');
+      _testInvalid('bool (2)', 'false', match: 'map');
+      _testInvalid('string', '"hello world"', match: 'map');
+    });
+
+    _testInvalid('must not have alias', match: 'alias', '''
+      keyA: &myref
+        - value 1
+        - value 2
+      KeyB: *myref
+    ''');
+
+    // it works without aliases
+    _testValid('listed inside a map is fine', '''
+      keyA:
+        - value 1
+        - value 2
+      KeyB:
+        - value 1
+        - value 2
+    ''');
+
+    _testValid('comments are cool', '''
+      keyA:
+        - value 1 # this is fine
+        - value 2
+    ''');
+
+    _testInvalid(
+        'Top-level map with integer keys is not allowed', match: 'key', '''
+        42: "value"   # this is NOT fine
+        43: true
+    ''');
+
+    _testValid('Map with quoted integer keys is fine', '''
+        "42": "value"   # this is fine
+        '43': true
+    ''');
+
+    _testInvalid('Map with integer keys is not allowed', match: 'key', '''
+      keyA:
+        - value 1 # this is fine
+        - value 2
+      KeyB:
+        42: value 3 # this is NOT fine
+    ''');
+
+    _testInvalid('Map with list keys is not allowed', match: 'key', '''
+      keyA:
+        - [1, 2, 3] # this is fine, crazy but fine!
+      keyB:
+        [1, 2, 3]: value 3 # this is NOT fine
+    ''');
+
+    _testInvalid('Map with boolean keys is not allowed (1)', match: 'key', '''
+      keyA: true
+      keyB:
+        true: value 3 # this is NOT fine
+    ''');
+
+    _testInvalid('Map with boolean keys is not allowed (2)', match: 'key', '''
+      keyA: true
+      keyB:
+        false: value 3 # this is NOT fine
+    ''');
+
+    _testInvalid('Map with null keys is not allowed', match: 'key', '''
+      keyA: null # fine
+      keyB:
+        null: value 3 # this is NOT fine
+    ''');
+
+    _testValid('complex structures is fine', '''
+      keyA: |
+        multi-line
+        string
+      keyB: 42    # number
+      keyC: 42.2  # double
+      keyD: [1, 2]
+      keyE:
+      - 1
+      - 2
+      keyF:
+        k: "v"
+    ''');
+
+    test('complex structures matches the same JSON', () {
+      final yaml = '''
+        keyA: "hello"
+        keyB: 42    # number
+        keyC: 42.2  # double
+        keyD: [1, 2]
+        keyE:
+        - 1
+        - 2
+        keyF:
+          k: "v"
+      ''';
+      final data = parseYamlFromConfigFile(yaml);
+      expect(
+        DeepCollectionEquality().equals(data, {
+          'keyA': 'hello',
+          'keyB': 42,
+          'keyC': 42.2,
+          'keyD': [1, 2],
+          'keyE': [1, 2],
+          'keyF': {'k': 'v'},
+        }),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
 * Changed `config.json` to `config.yaml` for consistency with other tooling.
 * Added robustness checks on YAML to ensure:
   * Root is a map,
   * Config can be serialized as JSON,
   * We don't leak YamlNode subtypes out of the API for this package
     (keeping YAML an implementation detail from the perspective of a consumer of this package).
 * Tweaked the cache format (bumped the version number)
 * Bumped package version number to 2.0.0
 * Added a few more tests :rocket: 

Fixes https://github.com/dart-lang/tools/issues/152