### PR TITLE
Use constant for no op client id

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+- Adding constant for the NoOpAnalytics instance client ID to enable clients to reference it in tests
+
 ## 4.0.0
 
 - Enhanced `LogFileStats` data to include information about flutter channel counts and tool counts

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 4.0.1
+
 - Adding constant for the NoOpAnalytics instance client ID to enable clients to reference it in tests
 
 ## 4.0.0

--- a/pkgs/unified_analytics/example/unified_analytics_example.dart
+++ b/pkgs/unified_analytics/example/unified_analytics_example.dart
@@ -39,7 +39,8 @@ void main() async {
     analytics.clientShowedMessage();
   }
 
-  print('Current user is opted in: ${analytics.telemetryEnabled}');
+  print('Current user ${analytics.clientId} '
+      'is opted in: ${analytics.telemetryEnabled}');
 
   // Example of long running process
   await Future<void>.delayed(const Duration(milliseconds: 100));

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -697,6 +697,9 @@ class FakeAnalytics extends AnalyticsImpl {
 /// This is for clients that opt to either not send analytics, or will migrate
 /// to use [AnalyticsImpl] at a later time.
 class NoOpAnalytics implements Analytics {
+  /// The hard-coded client ID value for each NoOp instance.
+  static String get staticClientId => 'xxxx-xxxx';
+
   @override
   final String getConsentMessage = '';
 
@@ -721,7 +724,7 @@ class NoOpAnalytics implements Analytics {
   const NoOpAnalytics._();
 
   @override
-  String get clientId => clientIdNoOp;
+  String get clientId => staticClientId;
 
   @override
   void clientShowedMessage() {}

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -721,7 +721,7 @@ class NoOpAnalytics implements Analytics {
   const NoOpAnalytics._();
 
   @override
-  String get clientId => 'xxxx-xxxx';
+  String get clientId => clientIdNoOp;
 
   @override
   void clientShowedMessage() {}

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// The hard coded client ID for the [NoOpAnalytics]
+const String clientIdNoOp = 'xxxx-xxxx';
+
 /// URL endpoint for sending Google Analytics Events.
 const String kAnalyticsUrl = 'https://www.google-analytics.com/mp/collect';
 

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// The hard coded client ID for the [NoOpAnalytics]
+/// The hard coded client ID for the [NoOpAnalytics] instance.
 const String clientIdNoOp = 'xxxx-xxxx';
 
 /// URL endpoint for sending Google Analytics Events.

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -81,7 +81,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '4.0.0';
+const String kPackageVersion = '4.0.1';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// The hard coded client ID for the [NoOpAnalytics] instance.
-const String clientIdNoOp = 'xxxx-xxxx';
-
 /// URL endpoint for sending Google Analytics Events.
 const String kAnalyticsUrl = 'https://www.google-analytics.com/mp/collect';
 

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 4.0.0
+version: 4.0.1
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:


### PR DESCRIPTION
Using constant for no op client id so that it can also be referenced in client tests (ie. flutter-tool tests)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
