### PR TITLE
Enum + event constructors added for doctor events

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 4.0.2-wip
+## 4.0.2
 
-- Update to the latest version of `package:dart_flutter_team_lints`.
+- Update to the latest version of `package:dart_flutter_team_lints`
+- Added the `Event.doctorValidatorResult` constructor.
 
 ## 4.0.1
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 5.0.0-wip
+## 5.0.0
 
 - Update to the latest version of `package:dart_flutter_team_lints`
 - Using internal futures list to store send events
-- Added the `Event.doctorValidatorResult` constructor.
+- Added the `Event.doctorValidatorResult` constructor
 
 ## 4.0.1
 
@@ -60,4 +60,4 @@
 
 ## 0.1.0
 
-- Initial version.
+- Initial version

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 4.0.2
+## 5.0.0-wip
 
 - Update to the latest version of `package:dart_flutter_team_lints`
+- Using internal futures list to store send events
 - Added the `Event.doctorValidatorResult` constructor.
 
 ## 4.0.1

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -78,7 +78,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '4.0.2-wip';
+const String kPackageVersion = '4.0.2';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.0.0-wip';
+const String kPackageVersion = '5.0.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -78,7 +78,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '4.0.2';
+const String kPackageVersion = '5.0.0-wip';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -32,6 +32,7 @@ enum DashEvent {
   ),
 
   // Events for the Dart CLI
+
   dartCliCommandExecuted(
     label: 'dart_cli_command_executed',
     description: 'Information about the execution of a Dart CLI command',
@@ -43,7 +44,18 @@ enum DashEvent {
     toolOwner: DashTool.dartTool,
   ),
 
-  // Events for flutter_tools
+  // Events for the Flutter CLI
+
+  doctorResult(
+    label: 'doctor_result',
+    description: 'Results from flutter doctor invocation',
+    toolOwner: DashTool.flutterTool,
+  ),
+  doctorValidatorResult(
+    label: 'doctor_validator_result',
+    description: 'Results from a specific doctor validator',
+    toolOwner: DashTool.flutterTool,
+  ),
   hotReloadTime(
     label: 'hot_reload_time',
     description: 'Hot reload duration',

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -46,11 +46,6 @@ enum DashEvent {
 
   // Events for the Flutter CLI
 
-  doctorResult(
-    label: 'doctor_result',
-    description: 'Results from flutter doctor invocation',
-    toolOwner: DashTool.flutterTool,
-  ),
   doctorValidatorResult(
     label: 'doctor_validator_result',
     description: 'Results from a specific doctor validator',

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -206,30 +206,34 @@ final class Event {
           if (exitCode != null) 'exitCode': exitCode,
         };
 
-  /// Event that contains the results from a flutter doctor invocation
-  /// along with the results for each validator.
-  ///
-  /// [result] - the final result from the doctor invocation, usually will
-  ///   be either "fail", "success", or "warning".
-  Event.doctorResult({
-    required String result,
-  })  : eventName = DashEvent.doctorResult,
-        eventData = {
-          'result': result,
-        };
-
   /// Event that contains the results for a specific doctor validator.
   ///
   /// [validatorName] - the name for the doctor validator.
   ///
   /// [result] - the final result for a specific doctor validator.
+  ///
+  /// [partOfGroupedValidator] - `true` indicates that this validator belongs
+  ///   to a grouped validator.
+  ///
+  /// [timestamp] - epoch formatted timestamp that can be used in combination
+  ///   with the client ID in GA4 to group the validators that ran in one
+  ///   doctor invocation.
+  ///
+  /// [statusInfo] - optional description of the result from the
+  ///   doctor validator.
   Event.doctorValidatorResult({
     required String validatorName,
     required String result,
+    required bool partOfGroupedValidator,
+    required int timestamp,
+    String? statusInfo,
   })  : eventName = DashEvent.doctorValidatorResult,
         eventData = {
           'validatorName': validatorName,
           'result': result,
+          'partOfGroupedValidator': partOfGroupedValidator,
+          'timestamp': timestamp,
+          if (statusInfo != null) 'statusInfo': statusInfo,
         };
 
   Event.hotReloadTime({required int timeMs})

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -206,6 +206,31 @@ final class Event {
           if (exitCode != null) 'exitCode': exitCode,
         };
 
+  /// Event that contains the results from a flutter doctor invocation
+  /// along with the results for each validator.
+  ///
+  /// [success] - boolean value where `true` is a successful doctor invocation.
+  Event.doctorResult({
+    required bool success,
+  })  : eventName = DashEvent.doctorResult,
+        eventData = {
+          'success': success,
+        };
+
+  /// Event that contains the results for a specific doctor validator.
+  ///
+  /// [validatorName] - the name for the doctor validator.
+  ///
+  /// [success] - boolean value where `true` is a successful doctor invocation.
+  Event.doctorValidatorResult({
+    required String validatorName,
+    required bool success,
+  })  : eventName = DashEvent.doctorValidatorResult,
+        eventData = {
+          'validatorName': validatorName,
+          'success': success,
+        };
+
   Event.hotReloadTime({required int timeMs})
       : eventName = DashEvent.hotReloadTime,
         eventData = {'timeMs': timeMs};

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -209,26 +209,28 @@ final class Event {
   /// Event that contains the results from a flutter doctor invocation
   /// along with the results for each validator.
   ///
-  /// [success] - boolean value where `true` is a successful doctor invocation.
+  /// [result] - the final result from the doctor invocation, usually will
+  ///   be either "fail", "success", or "warning".
   Event.doctorResult({
-    required bool success,
+    required String result,
   })  : eventName = DashEvent.doctorResult,
         eventData = {
-          'success': success,
+          'result': result,
         };
 
   /// Event that contains the results for a specific doctor validator.
   ///
   /// [validatorName] - the name for the doctor validator.
   ///
-  /// [success] - boolean value where `true` is a successful doctor invocation.
+  /// [result] - the final result from the doctor invocation, usually will
+  ///   be either "fail", "success", or "warning".
   Event.doctorValidatorResult({
     required String validatorName,
-    required bool success,
+    required String result,
   })  : eventName = DashEvent.doctorValidatorResult,
         eventData = {
           'validatorName': validatorName,
-          'success': success,
+          'result': result,
         };
 
   Event.hotReloadTime({required int timeMs})

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -222,8 +222,7 @@ final class Event {
   ///
   /// [validatorName] - the name for the doctor validator.
   ///
-  /// [result] - the final result from the doctor invocation, usually will
-  ///   be either "fail", "success", or "warning".
+  /// [result] - the final result for a specific doctor validator.
   Event.doctorValidatorResult({
     required String validatorName,
     required String result,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -215,9 +215,9 @@ final class Event {
   /// [partOfGroupedValidator] - `true` indicates that this validator belongs
   ///   to a grouped validator.
   ///
-  /// [timestamp] - epoch formatted timestamp that can be used in combination
-  ///   with the client ID in GA4 to group the validators that ran in one
-  ///   doctor invocation.
+  /// [doctorInvocationId] - epoch formatted timestamp that can be used in
+  ///   combination with the client ID in GA4 to group the validators that
+  ///   ran in one doctor invocation.
   ///
   /// [statusInfo] - optional description of the result from the
   ///   doctor validator.
@@ -225,14 +225,14 @@ final class Event {
     required String validatorName,
     required String result,
     required bool partOfGroupedValidator,
-    required int timestamp,
+    required int doctorInvocationId,
     String? statusInfo,
   })  : eventName = DashEvent.doctorValidatorResult,
         eventData = {
           'validatorName': validatorName,
           'result': result,
           'partOfGroupedValidator': partOfGroupedValidator,
-          'timestamp': timestamp,
+          'doctorInvocationId': doctorInvocationId,
           if (statusInfo != null) 'statusInfo': statusInfo,
         };
 

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 4.0.2
+version: 5.0.0-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.0.0-wip
+version: 5.0.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 4.0.2-wip
+version: 4.0.2
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:unified_analytics/unified_analytics.dart';
+
+void main() {
+  test('Event.doctorValidatorResult constructed', () {
+    expect(
+        () => Event.doctorValidatorResult(
+              validatorName: 'validatorName',
+              result: 'result',
+              partOfGroupedValidator: false,
+              doctorInvocationId: 123,
+              statusInfo: 'statusInfo',
+            ),
+        returnsNormally);
+  });
+}

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -3,18 +3,28 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+
+import 'package:unified_analytics/src/enums.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
   test('Event.doctorValidatorResult constructed', () {
-    expect(
-        () => Event.doctorValidatorResult(
-              validatorName: 'validatorName',
-              result: 'result',
-              partOfGroupedValidator: false,
-              doctorInvocationId: 123,
-              statusInfo: 'statusInfo',
-            ),
-        returnsNormally);
+    Event genDoctorValidatorResult() => Event.doctorValidatorResult(
+          validatorName: 'validatorName',
+          result: 'success',
+          partOfGroupedValidator: false,
+          doctorInvocationId: 123,
+          statusInfo: 'statusInfo',
+        );
+
+    final constructedEvent = genDoctorValidatorResult();
+
+    expect(genDoctorValidatorResult, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.doctorValidatorResult);
+    expect(constructedEvent.eventData['validatorName'], 'validatorName');
+    expect(constructedEvent.eventData['result'], 'success');
+    expect(constructedEvent.eventData['partOfGroupedValidator'], false);
+    expect(constructedEvent.eventData['doctorInvocationId'], 123);
+    expect(constructedEvent.eventData['statusInfo'], 'statusInfo');
   });
 }


### PR DESCRIPTION
- Part of: https://github.com/flutter/flutter/issues/128251

As part of the migration for `flutter doctor` events, this PR introduces the new enum and Event constructors for the doctor related events

Using this event, we can create a query to check how validator results change over time, sample query below

<img width="710" alt="image" src="https://github.com/dart-lang/tools/assets/42216813/baf3a70b-9bd4-4efc-b4d9-f3df74c1f7e0">


Additionally, with the `doctorInvocationId` being used to aggregate data across multiple doctor validators, we can get a percentage of validators that returned `success` in one invocation. (ie. there was 9 validators that returned success out of 10, so we can calculate 90% of successes for that invocation)

<img width="385" alt="image" src="https://github.com/dart-lang/tools/assets/42216813/f607e7b3-0b82-4af6-ab70-5bc97321a6c6">

The above shows the average of all percent successes for a given week for all users.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
