### PR TITLE
Enum + event constructors added for build events

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.0
+
+- Added the `Event.flutterBuildInfo` constructor
+
 ## 5.0.0
 
 - Update to the latest version of `package:dart_flutter_team_lints`

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.0.0';
+const String kPackageVersion = '5.1.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -51,6 +51,11 @@ enum DashEvent {
     description: 'Results from a specific doctor validator',
     toolOwner: DashTool.flutterTool,
   ),
+  flutterBuildInfo(
+    label: 'flutter_build_info',
+    description: 'Information for a flutter build invocation',
+    toolOwner: DashTool.flutterTool,
+  ),
   hotReloadTime(
     label: 'hot_reload_time',
     description: 'Hot reload duration',

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -236,6 +236,33 @@ final class Event {
           if (statusInfo != null) 'statusInfo': statusInfo,
         };
 
+  /// Event that is emitted from the flutter tool when a build invocation
+  /// has been run by the user
+  ///
+  /// [label] -
+  ///
+  /// [buildType] -
+  ///
+  /// [command] -
+  ///
+  /// [settings] -
+  ///
+  /// [error] -
+  Event.flutterBuildInfo({
+    required String label,
+    required String buildType,
+    required String command,
+    required String settings,
+    required String error,
+  })  : eventName = DashEvent.flutterBuildInfo,
+        eventData = {
+          'label': label,
+          'buildType': buildType,
+          'command': command,
+          'settings': settings,
+          'error': error,
+        };
+
   Event.hotReloadTime({required int timeMs})
       : eventName = DashEvent.hotReloadTime,
         eventData = {'timeMs': timeMs};

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -237,30 +237,33 @@ final class Event {
         };
 
   /// Event that is emitted from the flutter tool when a build invocation
-  /// has been run by the user
+  /// has been run by the user.
   ///
-  /// [label] -
+  /// [label] - the identifier for that build event.
   ///
-  /// [buildType] -
+  /// [buildType] - the identifier for which platform the build event was for,
+  ///   examples include "ios", "gradle", and "web".
   ///
-  /// [command] -
+  /// [command] - the command that was ran to kick off the build event.
   ///
-  /// [settings] -
+  /// [settings] - the settings used for the build event related to
+  ///   configuration and other relevant build information.
   ///
-  /// [error] -
+  /// [error] - short identifier used to explain the cause of the build error,
+  ///   stacktraces should not be passed to this parameter.
   Event.flutterBuildInfo({
     required String label,
     required String buildType,
-    required String command,
-    required String settings,
-    required String error,
+    String? command,
+    String? settings,
+    String? error,
   })  : eventName = DashEvent.flutterBuildInfo,
         eventData = {
           'label': label,
           'buildType': buildType,
-          'command': command,
-          'settings': settings,
-          'error': error,
+          if (command != null) 'command': command,
+          if (settings != null) 'settings': settings,
+          if (error != null) 'error': error,
         };
 
   Event.hotReloadTime({required int timeMs})

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.0.0
+version: 5.1.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -340,7 +340,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 17;
+    final eventsAccountedForInTests = 18;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -311,6 +311,27 @@ void main() {
     expect(constructedEvent.eventData.length, 1);
   });
 
+  test('Event.flutterBuildInfo constructed', () {
+    Event generateEvent() => Event.flutterBuildInfo(
+          label: 'label',
+          buildType: 'buildType',
+          command: 'command',
+          settings: 'settings',
+          error: 'error',
+        );
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.flutterBuildInfo);
+    expect(constructedEvent.eventData['label'], 'label');
+    expect(constructedEvent.eventData['buildType'], 'buildType');
+    expect(constructedEvent.eventData['command'], 'command');
+    expect(constructedEvent.eventData['settings'], 'settings');
+    expect(constructedEvent.eventData['error'], 'error');
+    expect(constructedEvent.eventData.length, 5);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {


### PR DESCRIPTION
Related to issue:
- https://github.com/flutter/flutter/issues/128251

Migrating the `BuildEvent` from `package:usage` to `package:unified_analytics`

Snippet of the code for `BuildEvent`

```dart
class BuildEvent extends UsageEvent {
  BuildEvent(String label, {
    String? command,
    String? settings,
    String? eventError,
    required Usage flutterUsage,
    required String type,
  }) : _command = command,
  _settings = settings,
  _eventError = eventError,
      super(
    // category
    'build',
    // parameter
    type,
    label: label,
    flutterUsage: flutterUsage,
  );

  final String? _command;
  final String? _settings;
  final String? _eventError;

  @override
  void send() {
    final CustomDimensions parameters = CustomDimensions(
      buildEventCommand: _command,
      buildEventSettings: _settings,
      buildEventError: _eventError,
    );
    flutterUsage.sendEvent(
      category,
      parameter,
      label: label,
      parameters: parameters,
    );
  }
}
```


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
