### PR TITLE
Enum + event constructor for pub result events

### DIFF
--- a/pkgs/unified_analytics/lib/src/survey_handler.dart
+++ b/pkgs/unified_analytics/lib/src/survey_handler.dart
@@ -258,6 +258,9 @@ class SurveyHandler {
   }
 
   /// Retrieves the survey metadata file from [kContextualSurveyUrl].
+  ///
+  /// Note: This will only return surveys that are within the start and end
+  /// periods of a given survey.
   Future<List<Survey>> fetchSurveyList() async {
     final List<dynamic> body;
     try {


### PR DESCRIPTION
Related to the tracker issue:
- https://github.com/flutter/flutter/issues/128251

Implementing the class below from `flutter/flutter` in this package
```dart
class PubResultEvent extends UsageEvent {
  PubResultEvent({
    required String context,
    required String result,
    required Usage usage,
  }) : super('pub-result', context, label: result, flutterUsage: usage);
}
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
