### PR TITLE
Enum + event constructor added for `flutterCommandResult`

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -3,6 +3,7 @@
 - User property "host_os_version" added to provide detail version information about the host
 - User property "locale" added to provide language related information
 - User property "client_ide" (optional) added to provide the IDE used by the Dash tool using this package, if applicable
+- Added the `Event.flutterCommandResult` constructor
 
 ## 5.2.0
 

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -56,6 +56,11 @@ enum DashEvent {
     description: 'Information for a flutter build invocation',
     toolOwner: DashTool.flutterTool,
   ),
+  flutterCommandResult(
+    label: 'flutter_command_result',
+    description: 'Provides information about flutter commands that ran',
+    toolOwner: DashTool.flutterTool,
+  ),
   hotReloadTime(
     label: 'hot_reload_time',
     description: 'Hot reload duration',

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -266,6 +266,21 @@ final class Event {
           if (error != null) 'error': error,
         };
 
+  /// Provides information about which flutter command was run
+  /// and whether it was successful.
+  /// 
+  /// [commandPath] - information about the flutter command, such as "build/apk".
+  /// 
+  /// [result] - if the command failed or succeeded.
+  Event.flutterCommandResult({
+    required String commandPath,
+    required String result,
+  })  : eventName = DashEvent.flutterCommandResult,
+        eventData = {
+          'commandPath': commandPath,
+          'result': result,
+        };
+
   // TODO: eliasyishak, remove this or replace once we have a generic
   //  timing event that can be used by potentially more than one DashTool
   Event.hotReloadTime({required int timeMs})

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -275,10 +275,12 @@ final class Event {
   Event.flutterCommandResult({
     required String commandPath,
     required String result,
+    int? maxRss,
   })  : eventName = DashEvent.flutterCommandResult,
         eventData = {
           'commandPath': commandPath,
           'result': result,
+          if (maxRss != null) 'maxRss': maxRss,
         };
 
   // TODO: eliasyishak, remove this or replace once we have a generic

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -268,9 +268,9 @@ final class Event {
 
   /// Provides information about which flutter command was run
   /// and whether it was successful.
-  /// 
+  ///
   /// [commandPath] - information about the flutter command, such as "build/apk".
-  /// 
+  ///
   /// [result] - if the command failed or succeeded.
   Event.flutterCommandResult({
     required String commandPath,

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -385,6 +385,7 @@ void main() {
     Event generateEvent() => Event.flutterCommandResult(
           commandPath: 'commandPath',
           result: 'result',
+          maxRss: 123,
         );
 
     final constructedEvent = generateEvent();
@@ -392,8 +393,9 @@ void main() {
     expect(generateEvent, returnsNormally);
     expect(constructedEvent.eventName, DashEvent.flutterCommandResult);
     expect(constructedEvent.eventData['commandPath'], 'commandPath');
-    expect(constructedEvent.eventData['commandPath'], 'commandPath');
-    expect(constructedEvent.eventData.length, 2);
+    expect(constructedEvent.eventData['result'], 'result');
+    expect(constructedEvent.eventData['maxRss'], 123);
+    expect(constructedEvent.eventData.length, 3);
   });
 
   test('Confirm all constructors were checked', () {

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -381,6 +381,21 @@ void main() {
     expect(constructedEvent.eventData.length, 19);
   });
 
+  test('Event.flutterCommandResult constructed', () {
+    Event generateEvent() => Event.flutterCommandResult(
+          commandPath: 'commandPath',
+          result: 'result',
+        );
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.flutterCommandResult);
+    expect(constructedEvent.eventData['commandPath'], 'commandPath');
+    expect(constructedEvent.eventData['commandPath'], 'commandPath');
+    expect(constructedEvent.eventData.length, 2);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {
@@ -389,7 +404,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 19;
+    final eventsAccountedForInTests = 20;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '


### PR DESCRIPTION
Part of tracker issue:
- https://github.com/flutter/flutter/issues/128251

Intended to be the replacement for [`CommandResultEvent`](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/reporting/events.dart#L191-L193) from legacy analytics in `flutter/flutter`

There is only one place within the flutter-tool that we call the `CommandResultEvent.send` method and it is [here](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/runner/flutter_command.dart#L1592-L1600)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
