### PR TITLE
Add enum + event constructor for code size analysis

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.0
+
+- Added the `Event.codeSizeAnalysis` constructor
+
 ## 5.3.0
 
 - User property "host_os_version" added to provide detail version information about the host

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.3.0';
+const String kPackageVersion = '5.4.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -46,6 +46,11 @@ enum DashEvent {
 
   // Events for the Flutter CLI
 
+  codeSizeAnalysis(
+    label: 'code_size_analysis',
+    description: 'Indicates when the "--analyize-size" command is run',
+    toolOwner: DashTool.flutterTool,
+  ),
   doctorValidatorResult(
     label: 'doctor_validator_result',
     description: 'Results from a specific doctor validator',

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -110,6 +110,15 @@ final class Event {
           if (removed != null) 'removed': removed,
         };
 
+  /// An event that reports when the code size measurement is run
+  /// via `--analyze-size`.
+  /// 
+  /// [kind] - string identifier for which platform was run "ios", "apk",
+  ///   "aab", etc.
+  Event.codeSizeAnalysis({required String kind})
+      : eventName = DashEvent.codeSizeAnalysis,
+        eventData = {'kind': kind};
+
   /// Event that is emitted periodically to report the number of times a given
   /// command has been executed.
   ///

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -112,7 +112,7 @@ final class Event {
 
   /// An event that reports when the code size measurement is run
   /// via `--analyze-size`.
-  /// 
+  ///
   /// [kind] - string identifier for which platform was run "ios", "apk",
   ///   "aab", etc.
   Event.codeSizeAnalysis({required String kind})

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -113,11 +113,13 @@ final class Event {
   /// An event that reports when the code size measurement is run
   /// via `--analyze-size`.
   ///
-  /// [kind] - string identifier for which platform was run "ios", "apk",
+  /// [platform] - string identifier for which platform was run "ios", "apk",
   ///   "aab", etc.
-  Event.codeSizeAnalysis({required String kind})
+  Event.codeSizeAnalysis({required String platform})
       : eventName = DashEvent.codeSizeAnalysis,
-        eventData = {'kind': kind};
+        eventData = {
+          'platform': platform,
+        };
 
   /// Event that is emitted periodically to report the number of times a given
   /// command has been executed.

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.3.0
+version: 5.4.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -399,13 +399,13 @@ void main() {
   });
 
   test('Event.codeSizeAnalysis constructed', () {
-    Event generateEvent() => Event.codeSizeAnalysis(kind: 'kind');
+    Event generateEvent() => Event.codeSizeAnalysis(platform: 'platform');
 
     final constructedEvent = generateEvent();
 
     expect(generateEvent, returnsNormally);
     expect(constructedEvent.eventName, DashEvent.codeSizeAnalysis);
-    expect(constructedEvent.eventData['kind'], 'kind');
+    expect(constructedEvent.eventData['platform'], 'platform');
     expect(constructedEvent.eventData.length, 1);
   });
 

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -398,6 +398,17 @@ void main() {
     expect(constructedEvent.eventData.length, 3);
   });
 
+  test('Event.codeSizeAnalysis constructed', () {
+    Event generateEvent() => Event.codeSizeAnalysis(kind: 'kind');
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.codeSizeAnalysis);
+    expect(constructedEvent.eventData['kind'], 'kind');
+    expect(constructedEvent.eventData.length, 1);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {
@@ -406,7 +417,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 20;
+    final eventsAccountedForInTests = 21;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '


### PR DESCRIPTION
Related to tracker issue:
- https://github.com/flutter/flutter/issues/128251

This migrates the `CodeSizeEvent` event, which is defined [here](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/reporting/events.dart#L236-L244) and below

```dart
/// An event that reports when the code size measurement is run via `--analyze-size`.
class CodeSizeEvent extends UsageEvent {
  CodeSizeEvent(String platform, {
    required Usage flutterUsage,
  }) : super(
    'code-size-analysis',
    platform,
    flutterUsage: flutterUsage
  );
}
```

There is only one reference of this class getting called within the flutter tool code base and it is within [`flutter_tools/lib/src/base/analyze_size.dart`](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/base/analyze_size.dart#L90)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
