### PR TITLE
New enum + constructor added for `nullSafetyMigrationResult`

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.0
+
+- Added the `Event.nullSafetyAnalysisResult` constructor
+
 ## 5.4.0
 
 - Added the `Event.codeSizeAnalysis` constructor

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.5.0
 
-- Added the `Event.nullSafetyAnalysisResult` constructor
+- Added the `Event.nullSafetyMigrationResult` constructor
 
 ## 5.4.0
 

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.4.0';
+const String kPackageVersion = '5.5.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -76,6 +76,11 @@ enum DashEvent {
     description: 'Information related to the Flutter hot runner',
     toolOwner: DashTool.flutterTool,
   ),
+  nullSafetyAnalysisResult(
+    label: 'null_safety_analysis_results',
+    description: 'Information related to null safety analysis within flutter',
+    toolOwner: DashTool.flutterTool,
+  ),
 
   // Events for language_server below
 

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -76,9 +76,10 @@ enum DashEvent {
     description: 'Information related to the Flutter hot runner',
     toolOwner: DashTool.flutterTool,
   ),
-  nullSafetyAnalysisResult(
-    label: 'null_safety_analysis_results',
-    description: 'Information related to null safety analysis within flutter',
+  nullSafetyMigrationResult(
+    label: 'null_safety_migration_result',
+    description:
+        'Information related to null safety migration within a package',
     toolOwner: DashTool.flutterTool,
   ),
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -43,6 +43,30 @@ final class Event {
           'method': method,
         };
 
+  /// Contains information about null safety migration within a flutter project.
+  ///
+  /// [runtimeMode] - The null safety runtime mode the app should be built in.
+  ///
+  /// [nullSafeMigratedLibraries] - count of libraries with language versions
+  ///   that are greater than 2.12 to indicate migration to null safety.
+  ///
+  /// [nullSafeTotalLibraries] - the total number of packages in the package
+  ///   config.
+  ///
+  /// [languageVersion] - the dart language version for the package.
+  Event.nullSafetyAnalysisResult({
+    required String runtimeMode,
+    required int nullSafeMigratedLibraries,
+    required int nullSafeTotalLibraries,
+    String? languageVersion,
+  })  : eventName = DashEvent.nullSafetyAnalysisResult,
+        eventData = {
+          'runtimeMode': runtimeMode,
+          'nullSafeMigratedLibraries': nullSafeMigratedLibraries,
+          'nullSafeTotalLibraries': nullSafeTotalLibraries,
+          if (languageVersion != null) 'languageVersion': languageVersion,
+        };
+
   /// Event that is emitted periodically to report the performance of the
   /// analysis server's handling of a specific kind of request from the client.
   ///

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -54,12 +54,12 @@ final class Event {
   ///   config.
   ///
   /// [languageVersion] - the dart language version for the package.
-  Event.nullSafetyAnalysisResult({
+  Event.nullSafetyMigrationResult({
     required String runtimeMode,
     required int nullSafeMigratedLibraries,
     required int nullSafeTotalLibraries,
     String? languageVersion,
-  })  : eventName = DashEvent.nullSafetyAnalysisResult,
+  })  : eventName = DashEvent.nullSafetyMigrationResult,
         eventData = {
           'runtimeMode': runtimeMode,
           'nullSafeMigratedLibraries': nullSafeMigratedLibraries,

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.4.0
+version: 5.5.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -409,6 +409,24 @@ void main() {
     expect(constructedEvent.eventData.length, 1);
   });
 
+  test('Event.nullSafetyAnalysisResult constructed', () {
+    Event generateEvent() => Event.nullSafetyAnalysisResult(
+        runtimeMode: 'runtimeMode',
+        nullSafeMigratedLibraries: 4,
+        nullSafeTotalLibraries: 5,
+        languageVersion: 'languageVersion');
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.nullSafetyAnalysisResult);
+    expect(constructedEvent.eventData['runtimeMode'], 'runtimeMode');
+    expect(constructedEvent.eventData['nullSafeMigratedLibraries'], 4);
+    expect(constructedEvent.eventData['nullSafeTotalLibraries'], 5);
+    expect(constructedEvent.eventData['languageVersion'], 'languageVersion');
+    expect(constructedEvent.eventData.length, 4);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {
@@ -417,7 +435,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 21;
+    final eventsAccountedForInTests = 22;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -409,8 +409,8 @@ void main() {
     expect(constructedEvent.eventData.length, 1);
   });
 
-  test('Event.nullSafetyAnalysisResult constructed', () {
-    Event generateEvent() => Event.nullSafetyAnalysisResult(
+  test('Event.nullSafetyMigrationResult constructed', () {
+    Event generateEvent() => Event.nullSafetyMigrationResult(
         runtimeMode: 'runtimeMode',
         nullSafeMigratedLibraries: 4,
         nullSafeTotalLibraries: 5,
@@ -419,7 +419,7 @@ void main() {
     final constructedEvent = generateEvent();
 
     expect(generateEvent, returnsNormally);
-    expect(constructedEvent.eventName, DashEvent.nullSafetyAnalysisResult);
+    expect(constructedEvent.eventName, DashEvent.nullSafetyMigrationResult);
     expect(constructedEvent.eventData['runtimeMode'], 'runtimeMode');
     expect(constructedEvent.eventData['nullSafeMigratedLibraries'], 4);
     expect(constructedEvent.eventData['nullSafeTotalLibraries'], 5);


### PR DESCRIPTION
Related to tracker issue:
- https://github.com/flutter/flutter/issues/128251

This event is for the [`NullSafetyAnalysisEvent`](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/reporting/events.dart#L256-L315) class.

This event has a more involved `send` method that actually [sends 3 separate events](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/reporting/events.dart#L293-L301). I have taken those 3 separate events and consolidated them down to just one event with 4 parameters included.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
