### PR TITLE
Add terminal info to flutter command event

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.5.0
+## 5.5.0-wip
 
 - Edit to the `Event.flutterCommandResult` constructor to add `commandHasTerminal`
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.0
+
+- Edit to the `Event.flutterCommandResult` constructor to add `commandHasTerminal`
+
 ## 5.4.0
 
 - Added the `Event.codeSizeAnalysis` constructor

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.5.0';
+const String kPackageVersion = '5.5.0-wip';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.4.0';
+const String kPackageVersion = '5.5.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -283,10 +283,10 @@ final class Event {
   /// [commandPath] - information about the flutter command, such as "build/apk".
   ///
   /// [result] - if the command failed or succeeded.
-  /// 
+  ///
   /// [commandHasTerminal] - boolean indicating if the flutter command ran with
   ///   a terminal.
-  /// 
+  ///
   /// [maxRss] - maximum resident size for a given flutter command.
   Event.flutterCommandResult({
     required String commandPath,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -283,14 +283,21 @@ final class Event {
   /// [commandPath] - information about the flutter command, such as "build/apk".
   ///
   /// [result] - if the command failed or succeeded.
+  /// 
+  /// [commandHasTerminal] - boolean indicating if the flutter command ran with
+  ///   a terminal.
+  /// 
+  /// [maxRss] - maximum resident size for a given flutter command.
   Event.flutterCommandResult({
     required String commandPath,
     required String result,
+    required bool commandHasTerminal,
     int? maxRss,
   })  : eventName = DashEvent.flutterCommandResult,
         eventData = {
           'commandPath': commandPath,
           'result': result,
+          'commandHasTerminal': commandHasTerminal,
           if (maxRss != null) 'maxRss': maxRss,
         };
 

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.4.0
+version: 5.5.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.5.0
+version: 5.5.0-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -385,6 +385,7 @@ void main() {
     Event generateEvent() => Event.flutterCommandResult(
           commandPath: 'commandPath',
           result: 'result',
+          commandHasTerminal: true,
           maxRss: 123,
         );
 
@@ -394,8 +395,9 @@ void main() {
     expect(constructedEvent.eventName, DashEvent.flutterCommandResult);
     expect(constructedEvent.eventData['commandPath'], 'commandPath');
     expect(constructedEvent.eventData['result'], 'result');
+    expect(constructedEvent.eventData['commandHasTerminal'], true);
     expect(constructedEvent.eventData['maxRss'], 123);
-    expect(constructedEvent.eventData.length, 3);
+    expect(constructedEvent.eventData.length, 4);
   });
 
   test('Event.codeSizeAnalysis constructed', () {


### PR DESCRIPTION
Related to tracker issue:
- https://github.com/flutter/flutter/issues/128251

Closes:
- https://github.com/dart-lang/tools/issues/197

While migrating the `Usage.command` static method, includes the `commandHasTerminal` parameter, I realized that it probably makes sense to include it with the previously migrated `CommandResult` event.

This new event will now let us record which flutter command was run, while also keeping track of whether the invocation included a terminal.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
