### PR TITLE
Add timeout to `setTelemetry`

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.5.0-wip
 
 - Edit to the `Event.flutterCommandResult` constructor to add `commandHasTerminal`
+- Added timeout for `Analytics.setTelemetry` to prevent the clients from hanging
 
 ## 5.4.0
 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -647,8 +647,12 @@ class AnalyticsImpl implements Analytics {
       _clientId = _clientIdFile.readAsStringSync();
     }
 
-    // Pass to the google analytics client to send
-    return _gaClient.sendData(body);
+    // Pass to the google analytics client to send with a
+    // timeout incase http clients hang
+    return _gaClient.sendData(body).timeout(
+          const Duration(milliseconds: kDelayDuration),
+          onTimeout: () => Response('', 200),
+        );
   }
 
   @override


### PR DESCRIPTION
Closes issue:
- https://github.com/dart-lang/tools/issues/203

Related to the flutter/flutter issue here:
- https://github.com/flutter/flutter/issues/138147

This adds a timeout to the `setTelemetry` method, previously it was just one event being sent so we did not add any timeouts, but if the one request we send with each opt out/in event hangs, then we should cancel it.

This does not change the underlying opt out/in functionality, it will only drop the event from being sent if the request takes too long

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
