### PR TITLE
Add generic usage event used for iOS/macOS workflows + generic `exception` event

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 5.5.0-wip
+## 5.5.0
 
 - Edit to the `Event.flutterCommandResult` constructor to add `commandHasTerminal`
 - Added timeout for `Analytics.setTelemetry` to prevent the clients from hanging
 - Added the `Event.appleUsageEvent` constructor
+- Added the `Event.exception` constructor
 
 ## 5.4.0
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Edit to the `Event.flutterCommandResult` constructor to add `commandHasTerminal`
 - Added timeout for `Analytics.setTelemetry` to prevent the clients from hanging
+- Added the `Event.appleUsageEvent` constructor
 
 ## 5.4.0
 

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.5.0-wip';
+const String kPackageVersion = '5.5.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -46,6 +46,12 @@ enum DashEvent {
 
   // Events for the Flutter CLI
 
+  appleUsageEvent(
+    label: 'apple_usage_event',
+    description:
+        'Events related to iOS/macOS workflows within the flutter tool',
+    toolOwner: DashTool.flutterTool,
+  ),
   codeSizeAnalysis(
     label: 'code_size_analysis',
     description: 'Indicates when the "--analyize-size" command is run',

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -22,6 +22,10 @@ enum DashEvent {
     label: 'analytics_collection_enabled',
     description: 'The opt-in status for analytics collection',
   ),
+  exception(
+    label: 'exception',
+    description: 'General errors to log',
+  ),
   surveyAction(
     label: 'survey_action',
     description: 'Actions taken by users when shown survey',

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -277,6 +277,25 @@ final class Event {
           if (error != null) 'error': error,
         };
 
+  /// This is for various workflows within the flutter tool related
+  /// to iOS and macOS workflows.
+  ///
+  /// [workflow] - which workflow is running, such as "assemble".
+  ///
+  /// [parameter] - subcategory of the workflow, such as "ios-archive".
+  ///
+  /// [label] - usually to indicate success or failure of the workflow.
+  Event.appleUsageEvent({
+    required String workflow,
+    required String parameter,
+    String? label,
+  })  : eventName = DashEvent.appleUsageEvent,
+        eventData = {
+          'workflow': workflow,
+          'parameter': parameter,
+          if (label != null) 'label': label,
+        };
+
   /// Provides information about which flutter command was run
   /// and whether it was successful.
   ///

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -19,6 +19,25 @@ final class Event {
       : eventName = DashEvent.analyticsCollectionEnabled,
         eventData = {'status': status};
 
+  /// This is for various workflows within the flutter tool related
+  /// to iOS and macOS workflows.
+  ///
+  /// [workflow] - which workflow is running, such as "assemble".
+  ///
+  /// [parameter] - subcategory of the workflow, such as "ios-archive".
+  ///
+  /// [label] - usually to indicate success or failure of the workflow.
+  Event.appleUsageEvent({
+    required String workflow,
+    required String parameter,
+    String? label,
+  })  : eventName = DashEvent.appleUsageEvent,
+        eventData = {
+          'workflow': workflow,
+          'parameter': parameter,
+          if (label != null) 'label': label,
+        };
+
   /// Event that is emitted periodically to report the performance of the
   /// analysis server's handling of a specific kind of notification from the
   /// client.
@@ -275,25 +294,6 @@ final class Event {
           if (command != null) 'command': command,
           if (settings != null) 'settings': settings,
           if (error != null) 'error': error,
-        };
-
-  /// This is for various workflows within the flutter tool related
-  /// to iOS and macOS workflows.
-  ///
-  /// [workflow] - which workflow is running, such as "assemble".
-  ///
-  /// [parameter] - subcategory of the workflow, such as "ios-archive".
-  ///
-  /// [label] - usually to indicate success or failure of the workflow.
-  Event.appleUsageEvent({
-    required String workflow,
-    required String parameter,
-    String? label,
-  })  : eventName = DashEvent.appleUsageEvent,
-        eventData = {
-          'workflow': workflow,
-          'parameter': parameter,
-          if (label != null) 'label': label,
         };
 
   /// Provides information about which flutter command was run

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -266,6 +266,14 @@ final class Event {
           if (statusInfo != null) 'statusInfo': statusInfo,
         };
 
+  /// Generic event for all dash tools to use when encountering an
+  /// exception that we want to log.
+  ///
+  /// [exception] - string representation of the exception that occured.
+  Event.exception({required String exception})
+      : eventName = DashEvent.exception,
+        eventData = {'exception': exception};
+
   /// Event that is emitted from the flutter tool when a build invocation
   /// has been run by the user.
   ///

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -26,16 +26,16 @@ final class Event {
   ///
   /// [parameter] - subcategory of the workflow, such as "ios-archive".
   ///
-  /// [label] - usually to indicate success or failure of the workflow.
+  /// [result] - usually to indicate success or failure of the workflow.
   Event.appleUsageEvent({
     required String workflow,
     required String parameter,
-    String? label,
+    String? result,
   })  : eventName = DashEvent.appleUsageEvent,
         eventData = {
           'workflow': workflow,
           'parameter': parameter,
-          if (label != null) 'label': label,
+          if (result != null) 'result': result,
         };
 
   /// Event that is emitted periodically to report the performance of the

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.5.0-wip
+version: 5.5.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -415,7 +415,7 @@ void main() {
     Event generateEvent() => Event.appleUsageEvent(
           workflow: 'workflow',
           parameter: 'parameter',
-          label: 'label',
+          result: 'result',
         );
 
     final constructedEvent = generateEvent();
@@ -424,7 +424,7 @@ void main() {
     expect(constructedEvent.eventName, DashEvent.appleUsageEvent);
     expect(constructedEvent.eventData['workflow'], 'workflow');
     expect(constructedEvent.eventData['parameter'], 'parameter');
-    expect(constructedEvent.eventData['label'], 'label');
+    expect(constructedEvent.eventData['result'], 'result');
     expect(constructedEvent.eventData.length, 3);
   });
 

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -428,6 +428,17 @@ void main() {
     expect(constructedEvent.eventData.length, 3);
   });
 
+  test('Event.exception constructed', () {
+    Event generateEvent() => Event.exception(exception: 'exception');
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.exception);
+    expect(constructedEvent.eventData['exception'], 'exception');
+    expect(constructedEvent.eventData.length, 1);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {
@@ -436,7 +447,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 22;
+    final eventsAccountedForInTests = 23;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -411,6 +411,23 @@ void main() {
     expect(constructedEvent.eventData.length, 1);
   });
 
+  test('Event.appleUsageEvent constructed', () {
+    Event generateEvent() => Event.appleUsageEvent(
+          workflow: 'workflow',
+          parameter: 'parameter',
+          label: 'label',
+        );
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.appleUsageEvent);
+    expect(constructedEvent.eventData['workflow'], 'workflow');
+    expect(constructedEvent.eventData['parameter'], 'parameter');
+    expect(constructedEvent.eventData['label'], 'label');
+    expect(constructedEvent.eventData.length, 3);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {
@@ -419,7 +436,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 21;
+    final eventsAccountedForInTests = 22;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '


### PR DESCRIPTION
Related to tracker issue:
- https://github.com/flutter/flutter/issues/128251

This PR adds 2 events here, one for the generic `UsageEvent` in flutter, and another for the `sendException` method in flutter.

For the `UsageEvent`, you can refer to this [sheet](https://docs.google.com/spreadsheets/d/11KJLkHXFpECMX7tw-trNkYSr5MHDG15XNGv6TgLjfQs/edit?usp=sharing&resourcekey=0-j4qdvsOEEg3wQW79YlY1-g) which shows all the call sites for that event. I found that all of these events were apple related so I consolidated them down into just one event. The event created for is called `Event.appleUsageEvent`

For the `sendException` method, we are only sending the exception's runtimeType as a string from flutter, so i created the `Event.exception` constructor which takes just one parameter for the exception string. Because this not specific to only flutter, we can have other dash tools also use this event to track exceptions in their workflows.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
