### PR TITLE
[extension_discovery] Drop unneeded dependency on pkg:lints

### DIFF
--- a/pkgs/extension_discovery/pubspec.yaml
+++ b/pkgs/extension_discovery/pubspec.yaml
@@ -13,6 +13,5 @@ dependencies:
 dev_dependencies:
   collection: ^1.18.0
   dart_flutter_team_lints: ^2.0.0
-  lints: ^2.0.0
   test: ^1.21.0
   test_descriptor: ^2.0.1


### PR DESCRIPTION
An explicit dep on `pkg:lints` is not needed.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
