### PR TITLE
Added enum + event for timing events

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.6.0
+
+- Added the `Event.timing` constructor
+
 ## 5.5.0
 
 - Edit to the `Event.flutterCommandResult` constructor to add `commandHasTerminal`

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.5.0';
+const String kPackageVersion = '5.6.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -34,6 +34,10 @@ enum DashEvent {
     label: 'survey_shown',
     description: 'Survey shown to the user',
   ),
+  timing(
+    label: 'timing',
+    description: 'Events for timing how long a process takes',
+  ),
 
   // Events for the Dart CLI
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -24,14 +24,14 @@ final class Event {
   /// [workflow] - the overall process or command being run, for example
   ///   "build" is a possible value for the flutter tool.
   ///
-  /// [variableName] - the specific variable being measure, for example
+  /// [variableName] - the specific variable being measured, for example
   ///   "gradle" would indicate how long it took for a gradle build under the
   ///   "build" [workflow].
   ///
   /// [elapsedMilliseconds] - how long the process took in milliseconds.
   ///
   /// [label] - an optional field that can be used for further filtering, for
-  ///   example, "success" can indicate how long a successful build in grade
+  ///   example, "success" can indicate how long a successful build in gradle
   ///   takes to complete.
   Event.timing({
     required String workflow,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -19,6 +19,33 @@ final class Event {
       : eventName = DashEvent.analyticsCollectionEnabled,
         eventData = {'status': status};
 
+  /// Event that records how long a given process takes to complete.
+  /// 
+  /// [workflow] - the overall process or command being run, for example
+  ///   "build" is a possible value for the flutter tool.
+  /// 
+  /// [variableName] - the specific variable being measure, for example
+  ///   "gradle" would indicate how long it took for a gradle build under the
+  ///   "build" [workflow].
+  /// 
+  /// [elapsedMilliseconds] - how long the process took in milliseconds.
+  /// 
+  /// [label] - an optional field that can be used for further filtering, for
+  ///   example, "success" can indicate how long a successful build in grade
+  ///   takes to complete.
+  Event.timing({
+    required String workflow,
+    required String variableName,
+    required int elapsedMilliseconds,
+    String? label,
+  })  : eventName = DashEvent.timing,
+        eventData = {
+          'workflow': workflow,
+          'variableName': variableName,
+          'elapsedMilliseconds': elapsedMilliseconds,
+          if (label != null) 'label': label,
+        };
+
   /// This is for various workflows within the flutter tool related
   /// to iOS and macOS workflows.
   ///

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -20,16 +20,16 @@ final class Event {
         eventData = {'status': status};
 
   /// Event that records how long a given process takes to complete.
-  /// 
+  ///
   /// [workflow] - the overall process or command being run, for example
   ///   "build" is a possible value for the flutter tool.
-  /// 
+  ///
   /// [variableName] - the specific variable being measure, for example
   ///   "gradle" would indicate how long it took for a gradle build under the
   ///   "build" [workflow].
-  /// 
+  ///
   /// [elapsedMilliseconds] - how long the process took in milliseconds.
-  /// 
+  ///
   /// [label] - an optional field that can be used for further filtering, for
   ///   example, "success" can indicate how long a successful build in grade
   ///   takes to complete.

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.5.0
+version: 5.6.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -439,6 +439,25 @@ void main() {
     expect(constructedEvent.eventData.length, 1);
   });
 
+  test('Event.timing constructed', () {
+    Event generateEvent() => Event.timing(
+          workflow: 'workflow',
+          variableName: 'variableName',
+          elapsedMilliseconds: 123,
+          label: 'label',
+        );
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.timing);
+    expect(constructedEvent.eventData['workflow'], 'workflow');
+    expect(constructedEvent.eventData['variableName'], 'variableName');
+    expect(constructedEvent.eventData['elapsedMilliseconds'], 123);
+    expect(constructedEvent.eventData['label'], 'label');
+    expect(constructedEvent.eventData.length, 4);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {
@@ -447,7 +466,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 23;
+    final eventsAccountedForInTests = 24;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '


### PR DESCRIPTION
Related to tracker issue:
- https://github.com/flutter/flutter/issues/128251

This PR adds a general timing event that can be used by any client of `package:unified_analytics`. The fields in the `Event` constructor for this event have been designed to match what was used for the `sendTiming` method in [`flutter/flutter`](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/reporting/usage.dart#L295-L311)

```dart
  @override
  void sendTiming(
    String category,
    String variableName,
    Duration duration, {
    String? label,
  }) {
    if (suppressAnalytics) {
      return;
    }
    _analytics.sendTiming(
      variableName,
      duration.inMilliseconds,
      category: category,
      label: label,
    );
  }
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
