### PR TITLE
Enum + event added for `commandUsageValues`

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.7.0
+
+- Added the `Event.commandUsageValues` constructor
+
 ## 5.6.0
 
 - Added the `Event.timing` constructor

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.6.0';
+const String kPackageVersion = '5.7.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -65,6 +65,12 @@ enum DashEvent {
     description: 'Indicates when the "--analyize-size" command is run',
     toolOwner: DashTool.flutterTool,
   ),
+  commandUsageValues(
+    label: 'command_usage_values',
+    description: 'Contains command level custom dimensions from legacy '
+        'flutter analytics',
+    toolOwner: DashTool.flutterTool,
+  ),
   doctorValidatorResult(
     label: 'doctor_validator_result',
     description: 'Results from a specific doctor validator',

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -168,6 +168,8 @@ final class Event {
   /// sent, for example, "create".
   Event.commandUsageValues({
     required String workflow,
+    required bool commandHasTerminal,
+
     // Assemble && build bundle implementation parameters
     String? buildBundleTargetPlatform,
     bool? buildBundleIsModule,
@@ -209,6 +211,7 @@ final class Event {
   })  : eventName = DashEvent.commandUsageValues,
         eventData = {
           'workflow': workflow,
+          // 'commandHasTerminal': commandHasTerminal,
           if (buildBundleTargetPlatform != null)
             'buildBundleTargetPlatform': buildBundleTargetPlatform,
           if (buildBundleIsModule != null)

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -19,33 +19,6 @@ final class Event {
       : eventName = DashEvent.analyticsCollectionEnabled,
         eventData = {'status': status};
 
-  /// Event that records how long a given process takes to complete.
-  ///
-  /// [workflow] - the overall process or command being run, for example
-  ///   "build" is a possible value for the flutter tool.
-  ///
-  /// [variableName] - the specific variable being measured, for example
-  ///   "gradle" would indicate how long it took for a gradle build under the
-  ///   "build" [workflow].
-  ///
-  /// [elapsedMilliseconds] - how long the process took in milliseconds.
-  ///
-  /// [label] - an optional field that can be used for further filtering, for
-  ///   example, "success" can indicate how long a successful build in gradle
-  ///   takes to complete.
-  Event.timing({
-    required String workflow,
-    required String variableName,
-    required int elapsedMilliseconds,
-    String? label,
-  })  : eventName = DashEvent.timing,
-        eventData = {
-          'workflow': workflow,
-          'variableName': variableName,
-          'elapsedMilliseconds': elapsedMilliseconds,
-          if (label != null) 'label': label,
-        };
-
   /// This is for various workflows within the flutter tool related
   /// to iOS and macOS workflows.
   ///
@@ -180,6 +153,102 @@ final class Event {
         eventData = {
           'count': count,
           'name': name,
+        };
+
+  /// Event to capture previous custom dimension values from
+  /// legacy flutter analytics.
+  ///
+  /// The parameters below are a superset of all the implementations
+  /// of the `usageValues` getter in the `FlutterCommand` class within
+  /// the flutter-tool. There should never be a time where all of the parameters
+  /// are passed to this constructor.
+  ///
+  /// The custom dimensions from each implementation are grouped by sharing
+  /// the same prefix.
+  Event.commandUsageValues({
+    required String workflow,
+    // Assemble && build bundle implementation parameters
+    String? buildBundleTargetPlatform,
+    bool? buildBundleIsModule,
+
+    // Build aar implementation parameters
+    String? buildAarProjectType,
+    String? buildAarTargetPlatform,
+
+    // Build apk implementation parameters
+    String? buildApkTargetPlatform,
+    String? buildApkBuildMode,
+    bool? buildApkSplitPerAbi,
+
+    // Build app bundle implementation parameters
+    String? buildAppBundleTargetPlatform,
+    String? buildAppBundleBuildMode,
+
+    // Create implementation parameters
+    String? createProjectType,
+    String? createAndroidLanguage,
+    String? createIosLanguage,
+
+    // Packages implementation parameters
+    int? packagesNumberPlugins,
+    bool? packagesProjectModule,
+    String? packagesAndroidEmbeddingVersion,
+
+    // Run implementation parameters
+    bool? runIsEmulator,
+    String? runTargetName,
+    String? runTargetOsVersion,
+    String? runModeName,
+    bool? runProjectModule,
+    String? runProjectHostLanguage,
+    String? runAndroidEmbeddingVersion,
+    bool? runEnableImpeller,
+    String? runIOSInterfaceType,
+    bool? runIsTest,
+  })  : eventName = DashEvent.commandUsageValues,
+        eventData = {
+          'workflow': workflow,
+          if (buildBundleTargetPlatform != null)
+            'buildBundleTargetPlatform': buildBundleTargetPlatform,
+          if (buildBundleIsModule != null)
+            'buildBundleIsModule': buildBundleIsModule,
+          if (buildAarProjectType != null)
+            'buildAarProjectType': buildAarProjectType,
+          if (buildAarTargetPlatform != null)
+            'buildAarTargetPlatform': buildAarTargetPlatform,
+          if (buildApkTargetPlatform != null)
+            'buildApkTargetPlatform': buildApkTargetPlatform,
+          if (buildApkBuildMode != null) 'buildApkBuildMode': buildApkBuildMode,
+          if (buildApkSplitPerAbi != null)
+            'buildApkSplitPerAbi': buildApkSplitPerAbi,
+          if (buildAppBundleTargetPlatform != null)
+            'buildAppBundleTargetPlatform': buildAppBundleTargetPlatform,
+          if (buildAppBundleBuildMode != null)
+            'buildAppBundleBuildMode': buildAppBundleBuildMode,
+          if (createProjectType != null) 'createProjectType': createProjectType,
+          if (createAndroidLanguage != null)
+            'createAndroidLanguage': createAndroidLanguage,
+          if (createIosLanguage != null) 'createIosLanguage': createIosLanguage,
+          if (packagesNumberPlugins != null)
+            'packagesNumberPlugins': packagesNumberPlugins,
+          if (packagesProjectModule != null)
+            'packagesProjectModule': packagesProjectModule,
+          if (packagesAndroidEmbeddingVersion != null)
+            'packagesAndroidEmbeddingVersion': packagesAndroidEmbeddingVersion,
+          if (runIsEmulator != null) 'runIsEmulator': runIsEmulator,
+          if (runTargetName != null) 'runTargetName': runTargetName,
+          if (runTargetOsVersion != null)
+            'runTargetOsVersion': runTargetOsVersion,
+          if (runModeName != null) 'runModeName': runModeName,
+          if (runProjectModule != null) 'runProjectModule': runProjectModule,
+          if (runProjectHostLanguage != null)
+            'runProjectHostLanguage': runProjectHostLanguage,
+          if (runAndroidEmbeddingVersion != null)
+            'runAndroidEmbeddingVersion': runAndroidEmbeddingVersion,
+          if (runEnableImpeller != null) 'runEnableImpeller': runEnableImpeller,
+          if (runIOSInterfaceType != null)
+            'runIOSInterfaceType': runIOSInterfaceType,
+          if (runIsTest != null) 'runIsTest': runIsTest,
         };
 
   /// Event that is emitted on shutdown to report the structure of the analysis
@@ -585,6 +654,33 @@ final class Event {
   })  : eventName = DashEvent.surveyShown,
         eventData = {
           'surveyId': surveyId,
+        };
+
+  /// Event that records how long a given process takes to complete.
+  ///
+  /// [workflow] - the overall process or command being run, for example
+  ///   "build" is a possible value for the flutter tool.
+  ///
+  /// [variableName] - the specific variable being measured, for example
+  ///   "gradle" would indicate how long it took for a gradle build under the
+  ///   "build" [workflow].
+  ///
+  /// [elapsedMilliseconds] - how long the process took in milliseconds.
+  ///
+  /// [label] - an optional field that can be used for further filtering, for
+  ///   example, "success" can indicate how long a successful build in gradle
+  ///   takes to complete.
+  Event.timing({
+    required String workflow,
+    required String variableName,
+    required int elapsedMilliseconds,
+    String? label,
+  })  : eventName = DashEvent.timing,
+        eventData = {
+          'workflow': workflow,
+          'variableName': variableName,
+          'elapsedMilliseconds': elapsedMilliseconds,
+          if (label != null) 'label': label,
         };
 
   @override

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -164,7 +164,8 @@ final class Event {
   /// are passed to this constructor.
   ///
   /// The custom dimensions from each implementation are grouped by sharing
-  /// the same prefix.
+  /// the same prefix. The [workflow] indicates which implementation is being
+  /// sent, for example, "create".
   Event.commandUsageValues({
     required String workflow,
     // Assemble && build bundle implementation parameters

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -155,17 +155,14 @@ final class Event {
           'name': name,
         };
 
-  /// Event to capture previous custom dimension values from
-  /// legacy flutter analytics.
+  /// Event to capture usage values for different flutter commands.
   ///
-  /// The parameters below are a superset of all the implementations
-  /// of the `usageValues` getter in the `FlutterCommand` class within
-  /// the flutter-tool. There should never be a time where all of the parameters
-  /// are passed to this constructor.
-  ///
-  /// The custom dimensions from each implementation are grouped by sharing
-  /// the same prefix. The [workflow] indicates which implementation is being
-  /// sent, for example, "create".
+  /// There are several implementations of the `FlutterCommand` class within the
+  /// flutter-tool that pass information based on the [workflow] being ran. An
+  /// example of a [workflow] can be "create". The optional parameters for this
+  /// constructor are a superset of all the implementations of `FlutterCommand`.
+  /// There should never be a time where all of the parameters are passed to
+  /// this constructor.
   Event.commandUsageValues({
     required String workflow,
     required bool commandHasTerminal,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -211,7 +211,7 @@ final class Event {
   })  : eventName = DashEvent.commandUsageValues,
         eventData = {
           'workflow': workflow,
-          // 'commandHasTerminal': commandHasTerminal,
+          'commandHasTerminal': commandHasTerminal,
           if (buildBundleTargetPlatform != null)
             'buildBundleTargetPlatform': buildBundleTargetPlatform,
           if (buildBundleIsModule != null)

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.6.0
+version: 5.7.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -461,6 +461,7 @@ void main() {
   test('Event.commandUsageValues constructed', () {
     Event generateEvent() => Event.commandUsageValues(
           workflow: 'workflow',
+          commandHasTerminal: true,
           buildBundleTargetPlatform: 'buildBundleTargetPlatform',
           buildBundleIsModule: true,
           buildAarProjectType: 'buildAarProjectType',
@@ -485,6 +486,7 @@ void main() {
           runAndroidEmbeddingVersion: 'runAndroidEmbeddingVersion',
           runEnableImpeller: true,
           runIOSInterfaceType: 'runIOSInterfaceType',
+          runIsTest: true,
         );
 
     final constructedEvent = generateEvent();
@@ -531,7 +533,7 @@ void main() {
     expect(constructedEvent.eventData['runEnableImpeller'], true);
     expect(constructedEvent.eventData['runIOSInterfaceType'],
         'runIOSInterfaceType');
-    expect(constructedEvent.eventData.length, 25);
+    expect(constructedEvent.eventData.length, 27);
   });
 
   test('Confirm all constructors were checked', () {

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -458,6 +458,82 @@ void main() {
     expect(constructedEvent.eventData.length, 4);
   });
 
+  test('Event.commandUsageValues constructed', () {
+    Event generateEvent() => Event.commandUsageValues(
+          workflow: 'workflow',
+          buildBundleTargetPlatform: 'buildBundleTargetPlatform',
+          buildBundleIsModule: true,
+          buildAarProjectType: 'buildAarProjectType',
+          buildAarTargetPlatform: 'buildAarTargetPlatform',
+          buildApkTargetPlatform: 'buildApkTargetPlatform',
+          buildApkBuildMode: 'buildApkBuildMode',
+          buildApkSplitPerAbi: true,
+          buildAppBundleTargetPlatform: 'buildAppBundleTargetPlatform',
+          buildAppBundleBuildMode: 'buildAppBundleBuildMode',
+          createProjectType: 'createProjectType',
+          createAndroidLanguage: 'createAndroidLanguage',
+          createIosLanguage: 'createIosLanguage',
+          packagesNumberPlugins: 123,
+          packagesProjectModule: true,
+          packagesAndroidEmbeddingVersion: 'packagesAndroidEmbeddingVersion',
+          runIsEmulator: true,
+          runTargetName: 'runTargetName',
+          runTargetOsVersion: 'runTargetOsVersion',
+          runModeName: 'runModeName',
+          runProjectModule: true,
+          runProjectHostLanguage: 'runProjectHostLanguage',
+          runAndroidEmbeddingVersion: 'runAndroidEmbeddingVersion',
+          runEnableImpeller: true,
+          runIOSInterfaceType: 'runIOSInterfaceType',
+        );
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.commandUsageValues);
+    expect(constructedEvent.eventData['workflow'], 'workflow');
+    expect(constructedEvent.eventData['buildBundleTargetPlatform'],
+        'buildBundleTargetPlatform');
+    expect(constructedEvent.eventData['buildBundleIsModule'], true);
+    expect(constructedEvent.eventData['buildAarProjectType'],
+        'buildAarProjectType');
+    expect(constructedEvent.eventData['buildAarTargetPlatform'],
+        'buildAarTargetPlatform');
+    expect(constructedEvent.eventData['buildApkTargetPlatform'],
+        'buildApkTargetPlatform');
+    expect(
+        constructedEvent.eventData['buildApkBuildMode'], 'buildApkBuildMode');
+    expect(constructedEvent.eventData['buildApkSplitPerAbi'], true);
+    expect(constructedEvent.eventData['buildAppBundleTargetPlatform'],
+        'buildAppBundleTargetPlatform');
+    expect(constructedEvent.eventData['buildAppBundleBuildMode'],
+        'buildAppBundleBuildMode');
+    expect(
+        constructedEvent.eventData['createProjectType'], 'createProjectType');
+    expect(constructedEvent.eventData['createAndroidLanguage'],
+        'createAndroidLanguage');
+    expect(
+        constructedEvent.eventData['createIosLanguage'], 'createIosLanguage');
+    expect(constructedEvent.eventData['packagesNumberPlugins'], 123);
+    expect(constructedEvent.eventData['packagesProjectModule'], true);
+    expect(constructedEvent.eventData['packagesAndroidEmbeddingVersion'],
+        'packagesAndroidEmbeddingVersion');
+    expect(constructedEvent.eventData['runIsEmulator'], true);
+    expect(constructedEvent.eventData['runTargetName'], 'runTargetName');
+    expect(
+        constructedEvent.eventData['runTargetOsVersion'], 'runTargetOsVersion');
+    expect(constructedEvent.eventData['runModeName'], 'runModeName');
+    expect(constructedEvent.eventData['runProjectModule'], true);
+    expect(constructedEvent.eventData['runProjectHostLanguage'],
+        'runProjectHostLanguage');
+    expect(constructedEvent.eventData['runAndroidEmbeddingVersion'],
+        'runAndroidEmbeddingVersion');
+    expect(constructedEvent.eventData['runEnableImpeller'], true);
+    expect(constructedEvent.eventData['runIOSInterfaceType'],
+        'runIOSInterfaceType');
+    expect(constructedEvent.eventData.length, 25);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {
@@ -466,7 +542,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 24;
+    final eventsAccountedForInTests = 25;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '


### PR DESCRIPTION
Related to tracker issue:
- https://github.com/flutter/flutter/issues/128251

This is a migration for the flutter `Usage.command` static method. When calling this method from `FlutterCommand` or a child class, it will fetch the necessary `CustomDimensions` for that command. There are a few child classes of `FlutterCommand` that override the `usageValues` getter to provide their own custom dimensions.

As a result, this means that parameters we need to send for each of those classes varies. So instead of creating a separate `Event` constructor for each of these child classes, we will instead have just one constructor that contains a superset of all possible custom dimension parameters. This makes the parameter count for this `Event` large (even larger than the maximum 25 parameters allowed). However, when sending this class from the flutter tool, we will ensure that the number of parameters used is going to be below the max (25) parameter count.

Snippet of what the Event below
```dart
  Event.commandUsageValues({
    required String workflow,
    required bool commandHasTerminal,

    // Assemble && build bundle implementation parameters
    String? buildBundleTargetPlatform,
    bool? buildBundleIsModule,

    // Build aar implementation parameters
    String? buildAarProjectType,
    String? buildAarTargetPlatform,

    // Build apk implementation parameters
    String? buildApkTargetPlatform,
    String? buildApkBuildMode,
    bool? buildApkSplitPerAbi,

    // Build app bundle implementation parameters
    String? buildAppBundleTargetPlatform,
    String? buildAppBundleBuildMode,

    // Create implementation parameters
    String? createProjectType,
    String? createAndroidLanguage,
    String? createIosLanguage,

    // Packages implementation parameters
    int? packagesNumberPlugins,
    bool? packagesProjectModule,
    String? packagesAndroidEmbeddingVersion,

    // Run implementation parameters
    bool? runIsEmulator,
    String? runTargetName,
    String? runTargetOsVersion,
    String? runModeName,
    bool? runProjectModule,
    String? runProjectHostLanguage,
    String? runAndroidEmbeddingVersion,
    bool? runEnableImpeller,
    String? runIOSInterfaceType,
    bool? runIsTest,
  })
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
