### PR TITLE
Add `enabledFeatures` key to `Analytics` constructors

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 5.7.1-wip
+## 5.7.1
 
 - Fix template string for consent message
+- Add `enabledFeatures` to constructor to collect features enabled for each dash tool
 
 ## 5.7.0
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.7.1
+## 5.8.0
 
 - Fix template string for consent message
 - Add `enabledFeatures` to constructor to collect features enabled for each dash tool

--- a/pkgs/unified_analytics/example/unified_analytics_example.dart
+++ b/pkgs/unified_analytics/example/unified_analytics_example.dart
@@ -18,6 +18,7 @@ final Analytics analytics = Analytics.development(
   // This can be set to true while testing to validate
   // against GA4 usage limitations (character limits, etc.)
   enableAsserts: false,
+  enabledFeatures: 'feature-1,feature-2',
 );
 
 // Timing a process and sending the event

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -38,7 +38,7 @@ abstract class Analytics {
   /// An optional parameter [clientIde] is also available for dart and flutter
   /// tooling that are running from IDEs can be resolved. Such as "VSCode"
   /// running the flutter-tool.
-  /// 
+  ///
   /// [enabledFeatures] is also an optional field that can be added to collect
   /// any features that are enabled for a user. For example,
   /// "enable-linux-desktop,cli-animations" are two features that can be enabled

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -38,12 +38,18 @@ abstract class Analytics {
   /// An optional parameter [clientIde] is also available for dart and flutter
   /// tooling that are running from IDEs can be resolved. Such as "VSCode"
   /// running the flutter-tool.
+  /// 
+  /// [enabledFeatures] is also an optional field that can be added to collect
+  /// any features that are enabled for a user. For example,
+  /// "enable-linux-desktop,cli-animations" are two features that can be enabled
+  /// for the flutter-tool.
   factory Analytics({
     required DashTool tool,
     required String dartVersion,
     String? flutterChannel,
     String? flutterVersion,
     String? clientIde,
+    String? enabledFeatures,
     bool enableAsserts = false,
   }) {
     // Create the instance of the file system so clients don't need
@@ -87,6 +93,7 @@ abstract class Analytics {
       surveyHandler: SurveyHandler(homeDirectory: homeDirectory, fs: fs),
       enableAsserts: enableAsserts,
       clientIde: clientIde,
+      enabledFeatures: enabledFeatures,
     );
   }
 
@@ -105,6 +112,7 @@ abstract class Analytics {
     String? flutterChannel,
     String? flutterVersion,
     String? clientIde,
+    String? enabledFeatures,
     bool enableAsserts = true,
   }) {
     // Create the instance of the file system so clients don't need
@@ -155,6 +163,7 @@ abstract class Analytics {
       surveyHandler: SurveyHandler(homeDirectory: homeDirectory, fs: fs),
       enableAsserts: enableAsserts,
       clientIde: clientIde,
+      enabledFeatures: enabledFeatures,
     );
   }
 
@@ -172,6 +181,7 @@ abstract class Analytics {
     String? flutterChannel,
     String? flutterVersion,
     String? clientIde,
+    String? enabledFeatures,
     SurveyHandler? surveyHandler,
     GAClient? gaClient,
     int toolsMessageVersion = kToolsMessageVersion,
@@ -195,6 +205,7 @@ abstract class Analytics {
         gaClient: gaClient ?? const FakeGAClient(),
         enableAsserts: true,
         clientIde: clientIde,
+        enabledFeatures: enabledFeatures,
       );
 
   /// The shared identifier for Flutter and Dart related tooling using
@@ -352,6 +363,7 @@ class AnalyticsImpl implements Analytics {
     required String? flutterChannel,
     required String? flutterVersion,
     required String? clientIde,
+    required String? enabledFeatures,
     required String dartVersion,
     required DevicePlatform platform,
     required this.toolsMessageVersion,
@@ -426,6 +438,7 @@ class AnalyticsImpl implements Analytics {
           truncateStringToLength(io.Platform.operatingSystemVersion, 36),
       locale: io.Platform.localeName,
       clientIde: clientIde,
+      enabledFeatures: enabledFeatures,
     );
 
     // Initialize the log handler to persist events that are being sent
@@ -705,6 +718,7 @@ class FakeAnalytics extends AnalyticsImpl {
     super.flutterChannel,
     super.flutterVersion,
     super.clientIde,
+    super.enabledFeatures,
   }) : super(
           gaClient: const FakeGAClient(),
           enableAsserts: true,

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.7.1';
+const String kPackageVersion = '5.8.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.7.1-wip';
+const String kPackageVersion = '5.7.1';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/user_property.dart
+++ b/pkgs/unified_analytics/lib/src/user_property.dart
@@ -20,6 +20,7 @@ class UserProperty {
   final String hostOsVersion;
   final String locale;
   final String? clientIde;
+  final String? enabledFeatures;
 
   /// This class is intended to capture all of the user's
   /// metadata when the class gets initialized as well as collecting
@@ -34,6 +35,7 @@ class UserProperty {
     required this.hostOsVersion,
     required this.locale,
     required this.clientIde,
+    required this.enabledFeatures,
   });
 
   /// This method will take the data in this class and convert it into
@@ -69,5 +71,6 @@ class UserProperty {
         'host_os_version': hostOsVersion,
         'locale': locale,
         'client_ide': clientIde,
+        'enabled_features': enabledFeatures,
       };
 }

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.7.1
+version: 5.8.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.7.1-wip
+version: 5.7.1
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -47,6 +47,7 @@ void main() {
   const hostOsVersion = 'Version 14.1 (Build 23B74)';
   const locale = 'en';
   const clientIde = 'VSCode';
+  const enabledFeatures = 'enable-linux-desktop,cli-animations';
 
   final testEvent = Event.hotReloadTime(timeMs: 50);
 
@@ -122,6 +123,7 @@ void main() {
       hostOsVersion: hostOsVersion,
       locale: locale,
       clientIde: clientIde,
+      enabledFeatures: enabledFeatures,
     );
   });
 
@@ -604,6 +606,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       'host_os_version',
       'locale',
       'client_ide',
+      'enabled_features',
     ];
     expect(analytics.userPropertyMap.keys.length, userPropertyKeys.length,
         reason: 'There should only be ${userPropertyKeys.length} keys');


### PR DESCRIPTION
Closes:
- https://github.com/dart-lang/tools/issues/198

The main change for this PR will add a new optional field on the `Analytics` constructors to allow sending a string for the enabled features.

From the example file below
```dart
final Analytics analytics = Analytics.development(
  tool: DashTool.flutterTool,
  flutterChannel: 'ey-test-channel',
  flutterVersion: 'Flutter 3.6.0-7.0.pre.47',
  clientIde: 'VSCode',
  dartVersion: 'Dart 2.19.0',
  // This can be set to true while testing to validate
  // against GA4 usage limitations (character limits, etc.)
  enableAsserts: false,
  enabledFeatures: 'feature-1,feature-2',  // <---- the newly added parameter
);
```

The string indicating the enabled features will be sent with every event in the user properties. This is similar to what we did before in flutter GA3 where we set the enabled features for the session.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
