### PR TITLE
Checking for devtools config file for opt out

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.1
+
+- Check devtools config file for legacy opt out status
+
 ## 5.8.0
 
 - Fix template string for consent message

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.8.0';
+const String kPackageVersion = '5.8.1';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.8.0
+version: 5.8.1
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/legacy_analytics_test.dart
+++ b/pkgs/unified_analytics/test/legacy_analytics_test.dart
@@ -271,8 +271,8 @@ NOT VALID JSON
     expect(analytics.telemetryEnabled, false);
   });
 
-  test('Telemetry disabled if flutter config file corrupted', () {
-    // Create the file for the dart legacy opt out with text that
+  test('Telemetry disabled if devtools config file corrupted', () {
+    // Create the file for the devtools legacy opt out with text that
     // is not valid JSON
     final devtoolsLegacyConfigFile =
         home.childDirectory('.flutter-devtools').childFile('.devtools');
@@ -309,8 +309,8 @@ NOT VALID JSON
     expect(analytics.telemetryEnabled, false);
   });
 
-  test('Telemetry disabled if devtools config file corrupted', () {
-    // Create the file for the devtools legacy opt out with text that
+  test('Telemetry disabled if flutter config file corrupted', () {
+    // Create the file for the flutter legacy opt out with text that
     // is not valid JSON
     final fluttterLegacyConfigFile =
         home.childDirectory('.dart').childFile('dartdev.json');

--- a/pkgs/unified_analytics/test/legacy_analytics_test.dart
+++ b/pkgs/unified_analytics/test/legacy_analytics_test.dart
@@ -102,7 +102,7 @@ void main() {
   });
 
   test('Honor legacy flutter analytics opt out', () {
-    // Create the file for the dart legacy opt out
+    // Create the file for the flutter legacy opt out
     final flutterLegacyConfigFile =
         home.childDirectory('.dart').childFile('dartdev.json');
     flutterLegacyConfigFile.createSync(recursive: true);
@@ -134,7 +134,7 @@ void main() {
   });
 
   test('Telemetry enabled if legacy flutter analytics is enabled', () {
-    // Create the file for the dart legacy opt out
+    // Create the file for the flutter legacy opt out
     final flutterLegacyConfigFile =
         home.childDirectory('.dart').childFile('dartdev.json');
     flutterLegacyConfigFile.createSync(recursive: true);
@@ -143,6 +143,78 @@ void main() {
   "firstRun": false,
   "clientId": "4c3a3d1e-e545-47e7-b4f8-10129f6ab169",
   "enabled": true
+}
+''');
+
+    // The main analytics instance, other instances can be spawned within tests
+    // to test how to instances running together work
+    analytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(analytics.telemetryEnabled, true);
+  });
+
+  test('Honor legacy devtools analytics opt out', () {
+    // Create the file for the devtools legacy opt out
+    final devtoolsLegacyConfigFile =
+        home.childDirectory('.flutter-devtools').childFile('.devtools');
+    devtoolsLegacyConfigFile.createSync(recursive: true);
+    devtoolsLegacyConfigFile.writeAsStringSync('''
+{
+  "analyticsEnabled": false,
+  "isFirstRun": false,
+  "lastReleaseNotesVersion": "2.31.0",
+  "2023-Q4": {
+    "surveyActionTaken": false,
+    "surveyShownCount": 0
+  }
+}
+''');
+
+    // The main analytics instance, other instances can be spawned within tests
+    // to test how to instances running together work
+    analytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(analytics.telemetryEnabled, false);
+  });
+
+  test('Telemetry enabled if legacy devtools analytics is enabled', () {
+    // Create the file for the devtools legacy opt out
+    final devtoolsLegacyConfigFile =
+        home.childDirectory('.flutter-devtools').childFile('.devtools');
+    devtoolsLegacyConfigFile.createSync(recursive: true);
+    devtoolsLegacyConfigFile.writeAsStringSync('''
+{
+  "analyticsEnabled": true,
+  "isFirstRun": false,
+  "lastReleaseNotesVersion": "2.31.0",
+  "2023-Q4": {
+    "surveyActionTaken": false,
+    "surveyShownCount": 0
+  }
 }
 ''');
 
@@ -201,6 +273,44 @@ NOT VALID JSON
 
   test('Telemetry disabled if flutter config file corrupted', () {
     // Create the file for the dart legacy opt out with text that
+    // is not valid JSON
+    final devtoolsLegacyConfigFile =
+        home.childDirectory('.flutter-devtools').childFile('.devtools');
+    devtoolsLegacyConfigFile.createSync(recursive: true);
+    devtoolsLegacyConfigFile.writeAsStringSync('''
+NOT VALID JSON
+{
+  "analyticsEnabled": true,
+  "isFirstRun": false,
+  "lastReleaseNotesVersion": "2.31.0",
+  "2023-Q4": {
+    "surveyActionTaken": false,
+    "surveyShownCount": 0
+  }
+}
+''');
+
+    // The main analytics instance, other instances can be spawned within tests
+    // to test how to instances running together work
+    analytics = Analytics.test(
+      tool: initialTool,
+      homeDirectory: home,
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+    );
+
+    expect(analytics.telemetryEnabled, false);
+  });
+
+  test('Telemetry disabled if devtools config file corrupted', () {
+    // Create the file for the devtools legacy opt out with text that
     // is not valid JSON
     final fluttterLegacyConfigFile =
         home.childDirectory('.dart').childFile('dartdev.json');


### PR DESCRIPTION
This PR will make sure that when the config file for `package:unified_analytics` is being created the first time, it will check in the devtools config file for previous opt out status. If the user has already opted out in the past but haven't interacted with `package:unified_analytics` yet, then it will pass that information and opt out the user from `package:unified_analytics` collection.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
