### PR TITLE
Helper to resolve dart version for clients of analytics

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added new event `Event.analyticsException` to track internal errors for this package
 - Redirecting the `Analytics.test` factory to return an instance of `FakeAnalytics`
+- Exposing new helper function that can be used to parse the Dart SDK version
 
 ## 5.8.1
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.8.2-wip
+## 5.8.2
 
 - Added new event `Event.analyticsException` to track internal errors for this package
 - Redirecting the `Analytics.test` factory to return an instance of `FakeAnalytics`

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.8.2-wip';
+const String kPackageVersion = '5.8.2';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -235,7 +235,7 @@ String parseDartSDKVersion(String versionString) {
   versionString = versionString.trim();
   final justVersion = versionString.split(' ')[0];
 
-  // For non-stable versions, this regex will include build information 
+  // For non-stable versions, this regex will include build information
   return justVersion.replaceFirstMapped(RegExp(r'(\d+\.\d+\.\d+)(.+)'),
       (Match match) {
     final noFlutter = match[2]!.replaceAll('.flutter-', ' ');

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -215,6 +215,32 @@ bool legacyOptOut({required FileSystem fs, required Directory home}) {
   return false;
 }
 
+/// Helper method that can be used to resolve the Dart SDK version for clients
+/// of package:unified_analytics.
+///
+/// Input [versionString] for this method should be the returned string from
+/// [io.Platform.version].
+///
+/// For tools that don't already have a method for resolving the Dart
+/// SDK version in semver notation, this helper can be used. This uses
+/// the [io.Platform.version] to parse the semver.
+///
+/// Example for stable version:
+/// `3.3.0 (stable) (Tue Feb 13 10:25:19 2024 +0000) on "macos_arm64"` into
+/// `3.3.0`.
+///
+/// Example for non-stable version:
+/// `2.1.0-dev.8.0.flutter-312ae32` into `2.1.0 (build 2.1.0-dev.8.0 312ae32)`.
+String parseDartSDKVersion(String versionString) {
+  versionString = versionString.trim();
+  final justVersion = versionString.split(' ')[0];
+  return justVersion.replaceFirstMapped(RegExp(r'(\d+\.\d+\.\d+)(.+)'),
+      (Match match) {
+    final noFlutter = match[2]!.replaceAll('.flutter-', ' ');
+    return '${match[1]} (build ${match[1]}$noFlutter)'.trim();
+  });
+}
+
 /// Will use two strings to produce a double for applying a sampling
 /// rate for [Survey] to be returned to the user.
 double sampleRate(String string1, String string2) =>

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -234,6 +234,8 @@ bool legacyOptOut({required FileSystem fs, required Directory home}) {
 String parseDartSDKVersion(String versionString) {
   versionString = versionString.trim();
   final justVersion = versionString.split(' ')[0];
+
+  // For non-stable versions, this regex will include build information 
   return justVersion.replaceFirstMapped(RegExp(r'(\d+\.\d+\.\d+)(.+)'),
       (Match match) {
     final noFlutter = match[2]!.replaceAll('.flutter-', ' ');

--- a/pkgs/unified_analytics/lib/unified_analytics.dart
+++ b/pkgs/unified_analytics/lib/unified_analytics.dart
@@ -8,3 +8,4 @@ export 'src/enums.dart' show DashTool;
 export 'src/event.dart' show Event;
 export 'src/log_handler.dart' show LogFileStats;
 export 'src/survey_handler.dart' show Survey, SurveyButton, SurveyHandler;
+export 'src/utils.dart' show parseDartSDKVersion;

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.8.2-wip
+version: 5.8.2
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -1276,4 +1276,21 @@ Privacy Policy (https://policies.google.com/privacy).
     expect(eventList.contains(eventToMatch), true);
     expect(eventList.where((element) => element == eventToMatch).length, 1);
   });
+
+  group('Unit tests for util dartSDKVersion', () {
+    test('parses correctly for non-stable version', () {
+      final originalVersion =
+          '3.4.0-148.0.dev (dev) (Thu Feb 15 12:05:45 2024 -0800) on "macos_arm64"';
+
+      expect(parseDartSDKVersion(originalVersion),
+          '3.4.0 (build 3.4.0-148.0.dev)');
+    });
+
+    test('parses correctly for stable version', () {
+      final originalVersion =
+          '3.3.0 (stable) (Tue Feb 13 10:25:19 2024 +0000) on "macos_arm64"';
+
+      expect(parseDartSDKVersion(originalVersion), '3.3.0');
+    });
+  });
 }


### PR DESCRIPTION
This PR provides a helper method that can be used by clients of package:unified_analytics to resolve the dart sdk version from the `Platform.version` string provided by `dart:io`.

Additional parsing is necessary because we want to remove the extra information that is returned from this string.

```
Original from Platform.version: 3.3.0 (stable) (Tue Feb 13 10:25:19 2024 +0000) on "macos_arm64"

After parsing with helper:      3.3.0
```

The above is for dart sdks on the stable channel, the below is for non-stable

```
Original from Platform.version: 2.1.0-dev.8.0.flutter-312ae32

After parsing with helper:      2.1.0 (build 2.1.0-dev.8.0 312ae32)
```

The logic for this regex was borrowed from the logic that exists within the flutter/flutter repo

https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/lib/src/cache.dart#L410-L423

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
