### PR TITLE
Fallback to current datetime when failing on parse session json file

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.3
+
+- Fix bug when parsing session json file
+
 ## 5.8.2
 
 - Added new event `Event.analyticsException` to track internal errors for this package

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.8.3
 
-- Fix bug when parsing session json file
+- [Fix bug](https://github.com/flutter/flutter/issues/143792) when parsing session json file
 
 ## 5.8.2
 

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.8.2';
+const String kPackageVersion = '5.8.3';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -105,7 +105,10 @@ class Session {
         description: 'message: ${err.message}\nsource: ${err.source}',
       ));
 
-      parseContents();
+      // Fallback to setting the session id as the current time
+      final now = clock.now();
+      _sessionId = now.millisecondsSinceEpoch;
+      _lastPing = now.millisecondsSinceEpoch;
     } on FileSystemException catch (err) {
       Initializer.createSessionFile(sessionFile: sessionFile);
 
@@ -115,7 +118,10 @@ class Session {
         description: err.osError?.toString(),
       ));
 
-      parseContents();
+      // Fallback to setting the session id as the current time
+      final now = clock.now();
+      _sessionId = now.millisecondsSinceEpoch;
+      _lastPing = now.millisecondsSinceEpoch;
     }
   }
 }

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.8.2
+version: 5.8.3
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:


### PR DESCRIPTION
Fixes:
- https://github.com/flutter/flutter/issues/143792

This PR changes the error handling behavior when attempting to parse the json file for session data. Instead of trying to parse the newly created file, it will set the current session to the current datetime. This is possibly a race condition issue that will be investigated further in the below issue.
- https://github.com/dart-lang/tools/issues/166

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
