### PR TITLE
Fix late initialization error for `Analytics.userProperty`

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.5
+
+- Fix late initialization error for `Analytics.userProperty` [bug](https://github.com/dart-lang/tools/issues/238)
+
 ## 5.8.4
 
 - Exporting all enums from [`enums.dart`](https://github.com/dart-lang/tools/blob/main/pkgs/unified_analytics/lib/src/enums.dart) through `lib/testing.dart`

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -430,7 +430,6 @@ class AnalyticsImpl implements Analytics {
       homeDirectory: homeDirectory,
       fs: fs,
       errorHandler: _errorHandler,
-      telemetryEnabled: telemetryEnabled,
     );
     userProperty = UserProperty(
       session: _sessionHandler,
@@ -454,6 +453,10 @@ class AnalyticsImpl implements Analytics {
       homeDirectory: homeDirectory,
       errorHandler: _errorHandler,
     );
+
+    // Initialize the session handler with the session_id and last_ping
+    // variables by parsing the json file
+    _sessionHandler.initialize(telemetryEnabled);
   }
 
   @override

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.8.4';
+const String kPackageVersion = '5.8.5';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -26,16 +26,9 @@ class Session {
     required this.homeDirectory,
     required this.fs,
     required ErrorHandler errorHandler,
-    required bool telemetryEnabled,
   })  : sessionFile = fs.file(p.join(
             homeDirectory.path, kDartToolDirectoryName, kSessionFileName)),
-        _errorHandler = errorHandler {
-    // We must check if telemetry is enabled to refresh the session data
-    // because the refresh method will write to the session file and for
-    // users that have opted out, we have to leave the session file empty
-    // per the privacy document
-    if (telemetryEnabled) _refreshSessionData();
-  }
+        _errorHandler = errorHandler;
 
   /// This will use the data parsed from the
   /// session json file in the dart-tool directory
@@ -68,6 +61,16 @@ class Session {
     sessionFile.writeAsStringSync(toJson());
 
     return _sessionId;
+  }
+
+  /// Preps the [Session] class with the data found in the session json file.
+  ///
+  /// We must check if telemetry is enabled to refresh the session data
+  /// because the refresh method will write to the session file and for
+  /// users that have opted out, we have to leave the session file empty
+  /// per the privacy document
+  void initialize(bool telemetryEnabled) {
+    if (telemetryEnabled) _refreshSessionData();
   }
 
   /// Return a json formatted representation of the class.

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.8.4
+version: 5.8.5
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -14,7 +14,6 @@ import 'package:file/memory.dart';
 import 'package:test/test.dart';
 import 'package:unified_analytics/src/constants.dart';
 import 'package:unified_analytics/src/enums.dart';
-import 'package:unified_analytics/src/user_property.dart';
 import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 import 'package:yaml/yaml.dart';
@@ -30,7 +29,6 @@ void main() {
   late File configFile;
   late File logFile;
   late File dismissedSurveyFile;
-  late UserProperty userProperty;
 
   const homeDirName = 'home';
   const initialTool = DashTool.flutterTool;

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -182,8 +182,7 @@ void main() {
         .where((element) => element.eventName == DashEvent.analyticsException)
         .firstOrNull;
     expect(errorEvent, isNotNull);
-    errorEvent!;
-    expect(errorEvent.eventData['workflow'], 'Session._refreshSessionData');
+    expect(errorEvent!.eventData['workflow'], 'Session._refreshSessionData');
     expect(errorEvent.eventData['error'], 'FormatException');
     expect(errorEvent.eventData['description'],
         'message: Unexpected character\nsource: contents');

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -1110,7 +1110,8 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // 4. Event names must be 40 characters or fewer, may only contain alpha-numeric
     //    characters and underscores, and must start with an alphabetic character
     test('max 25 user properties per event', () {
-      final Map<String, Object> userPropPayload = analytics.userProperty.preparePayload();
+      final Map<String, Object> userPropPayload =
+          analytics.userProperty.preparePayload();
       const maxUserPropKeys = 25;
 
       expect(userPropPayload.keys.length < maxUserPropKeys, true,
@@ -1118,7 +1119,8 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     });
 
     test('max 24 characters for user prop keys', () {
-      final Map<String, Object> userPropPayload = analytics.userProperty.preparePayload();
+      final Map<String, Object> userPropPayload =
+          analytics.userProperty.preparePayload();
       const maxUserPropLength = 24;
 
       var userPropLengthValid = true;


### PR DESCRIPTION
Fixes:
- https://github.com/dart-lang/tools/issues/238

TLDR: initialization logic within the `Session` class's constructor body expects `Analytics.userProperty` to be initialized, this moves that constructor body logic from `Session` into a separate method (`Session.initialize`) we will call at the end of the `Analytics` class's constructor after we are sure all necessary fields have been initialized

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
