### PR TITLE
Limit writes to session file

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.8.6
+## 5.8.6-wip
 
 - Refactored session handler class to use the last modified timestamp as the last ping value
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.6
+
+- Refactored session handler class to use the last modified timestamp as the last ping value
+
 ## 5.8.5
 
 - Fix late initialization error for `Analytics.userProperty` [bug](https://github.com/dart-lang/tools/issues/238)

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -454,7 +454,7 @@ class AnalyticsImpl implements Analytics {
       errorHandler: _errorHandler,
     );
 
-    // Initialize the session handler with the session_id 
+    // Initialize the session handler with the session_id
     // by parsing the json file
     _sessionHandler.initialize(telemetryEnabled);
   }

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -430,11 +430,6 @@ class AnalyticsImpl implements Analytics {
       homeDirectory: homeDirectory,
       fs: fs,
       errorHandler: _errorHandler,
-      sessionFile: fs.file(p.join(
-        homeDirectory.path,
-        kDartToolDirectoryName,
-        kSessionFileName,
-      )),
     );
     userProperty = UserProperty(
       session: _sessionHandler,

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -430,6 +430,11 @@ class AnalyticsImpl implements Analytics {
       homeDirectory: homeDirectory,
       fs: fs,
       errorHandler: _errorHandler,
+      sessionFile: fs.file(p.join(
+        homeDirectory.path,
+        kDartToolDirectoryName,
+        kSessionFileName,
+      )),
     );
     userProperty = UserProperty(
       session: _sessionHandler,

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -454,8 +454,8 @@ class AnalyticsImpl implements Analytics {
       errorHandler: _errorHandler,
     );
 
-    // Initialize the session handler with the session_id and last_ping
-    // variables by parsing the json file
+    // Initialize the session handler with the session_id 
+    // by parsing the json file
     _sessionHandler.initialize(telemetryEnabled);
   }
 

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -88,7 +88,7 @@ const String kPackageVersion = '5.8.5';
 const int kSessionDurationMinutes = 30;
 
 /// Name for the json file where the session details will be stored.
-const String kSessionFileName = 'dart-flutter-telemetry-session.json';
+const String kSessionFileName = 'dart-flutter-telemetry.session';
 
 /// The message that should be shown to the user.
 const String kToolsMessage = '''

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -88,7 +88,7 @@ const String kPackageVersion = '5.8.6';
 const int kSessionDurationMinutes = 30;
 
 /// Name for the json file where the session details will be stored.
-const String kSessionFileName = 'dart-flutter-telemetry.session';
+const String kSessionFileName = 'dart-flutter-telemetry-session.json';
 
 /// The message that should be shown to the user.
 const String kToolsMessage = '''

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.8.5';
+const String kPackageVersion = '5.8.6';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '5.8.6';
+const String kPackageVersion = '5.8.6-wip';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -75,10 +75,17 @@ class Initializer {
 
   /// Creates the session file which will contain
   /// the current session id which is the current timestamp.
-  static void createSessionFile({required File sessionFile}) {
-    final now = clock.now();
+  ///
+  /// [sessionIdOverride] can be provided as an override, otherwise it
+  /// will use the current timestamp from [Clock.now].
+  static void createSessionFile({
+    required File sessionFile,
+    DateTime? sessionIdOverride,
+  }) {
+    final now = sessionIdOverride ?? clock.now();
     sessionFile.createSync(recursive: true);
-    sessionFile.writeAsStringSync('${now.millisecondsSinceEpoch}');
+    sessionFile
+        .writeAsStringSync('{"session_id": ${now.millisecondsSinceEpoch}}');
   }
 
   /// This will check that there is a client ID populated in

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -73,10 +73,8 @@ class Initializer {
     logFile.createSync(recursive: true);
   }
 
-  /// Creates the session json file which will contain
-  /// the current session id along with the timestamp for
-  /// the last ping which will be used to increment the session
-  /// if current timestamp is greater than the session window.
+  /// Creates the session file which will contain
+  /// the current session id which is the current timestamp.
   static void createSessionFile({required File sessionFile}) {
     final now = clock.now();
     sessionFile.createSync(recursive: true);

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:clock/clock.dart';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
@@ -82,10 +80,7 @@ class Initializer {
   static void createSessionFile({required File sessionFile}) {
     final now = clock.now();
     sessionFile.createSync(recursive: true);
-    sessionFile.writeAsStringSync(jsonEncode(<String, int>{
-      'session_id': now.millisecondsSinceEpoch,
-      'last_ping': now.millisecondsSinceEpoch,
-    }));
+    sessionFile.writeAsStringSync('${now.millisecondsSinceEpoch}');
   }
 
   /// This will check that there is a client ID populated in

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -19,7 +19,7 @@ class Session {
   final File sessionFile;
   final ErrorHandler _errorHandler;
 
-  int _sessionId;
+  int? _sessionId;
 
   Session({
     required this.homeDirectory,
@@ -27,7 +27,6 @@ class Session {
     required ErrorHandler errorHandler,
   })  : sessionFile = fs.file(p.join(
             homeDirectory.path, kDartToolDirectoryName, kSessionFileName)),
-        _sessionId = DateTime.now().millisecondsSinceEpoch,
         _errorHandler = errorHandler;
 
   /// This will use the data parsed from the
@@ -40,7 +39,7 @@ class Session {
   ///
   /// Note, the file will always be updated when calling this method
   /// because the last ping variable will always need to be persisted.
-  int getSessionId() {
+  int? getSessionId() {
     _refreshSessionData();
     final now = clock.now();
 

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -50,11 +50,11 @@ class Session {
       // Update the session file with the latest session id
       _sessionId = now.millisecondsSinceEpoch;
       sessionFile.writeAsStringSync('{"session_id": $_sessionId}');
+    } else {
+      // Update the last modified timestamp with the current timestamp so that
+      // we can use it for the next _lastPing calculation
+      sessionFile.setLastModifiedSync(now);
     }
-
-    // Update the last modified timestamp with the current timestamp so that
-    // we can use it for the next _lastPing calculation
-    sessionFile.setLastModifiedSync(now);
 
     return _sessionId;
   }

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -4,6 +4,7 @@
 
 import 'package:clock/clock.dart';
 import 'package:file/file.dart';
+import 'package:path/path.dart' as p;
 
 import 'constants.dart';
 import 'error_handler.dart';
@@ -22,8 +23,9 @@ class Session {
     required this.homeDirectory,
     required this.fs,
     required ErrorHandler errorHandler,
-    required this.sessionFile,
-  })  : _sessionId = DateTime.now().millisecondsSinceEpoch,
+  })  : sessionFile = fs.file(p.join(
+            homeDirectory.path, kDartToolDirectoryName, kSessionFileName)),
+        _sessionId = DateTime.now().millisecondsSinceEpoch,
         _errorHandler = errorHandler;
 
   /// This will use the data parsed from the

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -44,8 +44,7 @@ class Session {
 
     // Convert the epoch time from the last ping into datetime and check if we
     // are within the kSessionDurationMinutes.
-    final lastPingDateTime = DateTime.fromMillisecondsSinceEpoch(
-        sessionFile.lastModifiedSync().millisecondsSinceEpoch);
+    final lastPingDateTime = sessionFile.lastModifiedSync();
     if (now.difference(lastPingDateTime).inMinutes > kSessionDurationMinutes) {
       // Update the session file with the latest session id
       _sessionId = now.millisecondsSinceEpoch;

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -23,7 +23,7 @@ class Session {
     required this.fs,
     required ErrorHandler errorHandler,
     required this.sessionFile,
-  })  : _sessionId = int.parse(sessionFile.readAsStringSync()),
+  })  : _sessionId = DateTime.now().millisecondsSinceEpoch,
         _errorHandler = errorHandler;
 
   /// This will use the data parsed from the

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.8.6
+version: 5.8.6-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 5.8.5
+version: 5.8.6
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -739,7 +739,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
               'within the duration');
       expect(sessionFile.lastModifiedSync().millisecondsSinceEpoch,
           end.millisecondsSinceEpoch,
-          reason: 'The last_ping value should have been updated');
+          reason: 'The last modified value should have been updated');
     });
   });
 
@@ -814,7 +814,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
               'outside the duration');
       expect(sessionFile.lastModifiedSync().millisecondsSinceEpoch,
           end.millisecondsSinceEpoch,
-          reason: 'The last_ping value should have been updated');
+          reason: 'The last modified value should have been updated');
     });
   });
 

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -143,7 +143,7 @@ void main() {
       final timestamp = clock.now().millisecondsSinceEpoch.toString();
       expect(sessionFile.readAsStringSync(), 'contents');
       analytics.userProperty.preparePayload();
-      expect(sessionFile.readAsStringSync(), timestamp);
+      expect(sessionFile.readAsStringSync(), '{"session_id": $timestamp}');
 
       // Attempting to fetch the session id when malformed should also
       // send an error event while parsing
@@ -184,7 +184,7 @@ void main() {
     expect(errorEvent!.eventData['workflow'], 'Session._refreshSessionData');
     expect(errorEvent.eventData['error'], 'FormatException');
     expect(errorEvent.eventData['description'],
-        'message: Invalid radix-10 number\nsource: not a valid session id');
+        'message: Unexpected character\nsource: not a valid session id');
   });
 
   test('Resetting session file when file is removed', () {
@@ -199,7 +199,7 @@ void main() {
       final timestamp = clock.now().millisecondsSinceEpoch.toString();
       expect(sessionFile.existsSync(), false);
       analytics.userProperty.preparePayload();
-      expect(sessionFile.readAsStringSync(), timestamp);
+      expect(sessionFile.readAsStringSync(), '{"session_id": $timestamp}');
 
       // Attempting to fetch the session id when malformed should also
       // send an error event while parsing

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -132,7 +132,7 @@ void main() {
 
   test('Resetting session file when data is malformed', () {
     // Purposefully write content to the session file that
-    // can't be decoded as json
+    // can't be decoded as an integer
     sessionFile.writeAsStringSync('contents');
 
     // Define the initial time to start
@@ -143,8 +143,7 @@ void main() {
       final timestamp = clock.now().millisecondsSinceEpoch.toString();
       expect(sessionFile.readAsStringSync(), 'contents');
       analytics.userProperty.preparePayload();
-      expect(sessionFile.readAsStringSync(),
-          '{"session_id":$timestamp,"last_ping":$timestamp}');
+      expect(sessionFile.readAsStringSync(), timestamp);
 
       // Attempting to fetch the session id when malformed should also
       // send an error event while parsing
@@ -158,9 +157,9 @@ void main() {
 
   test('Handles malformed session file on startup', () {
     // Ensure that we are able to send an error message on startup if
-    // we encounter an error while parsing the contents of the json file
+    // we encounter an error while parsing the contents of the session file
     // for session data
-    sessionFile.writeAsStringSync('contents');
+    sessionFile.writeAsStringSync('not a valid session id');
 
     analytics = Analytics.test(
       tool: initialTool,
@@ -185,7 +184,7 @@ void main() {
     expect(errorEvent!.eventData['workflow'], 'Session._refreshSessionData');
     expect(errorEvent.eventData['error'], 'FormatException');
     expect(errorEvent.eventData['description'],
-        'message: Unexpected character\nsource: contents');
+        'message: Invalid radix-10 number\nsource: not a valid session id');
   });
 
   test('Resetting session file when file is removed', () {
@@ -200,8 +199,7 @@ void main() {
       final timestamp = clock.now().millisecondsSinceEpoch.toString();
       expect(sessionFile.existsSync(), false);
       analytics.userProperty.preparePayload();
-      expect(sessionFile.readAsStringSync(),
-          '{"session_id":$timestamp,"last_ping":$timestamp}');
+      expect(sessionFile.readAsStringSync(), timestamp);
 
       // Attempting to fetch the session id when malformed should also
       // send an error event while parsing
@@ -701,14 +699,10 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       );
       secondAnalytics.clientShowedMessage();
 
-      // Read the contents of the session file
-      final sessionFileContents = sessionFile.readAsStringSync();
-      final sessionObj =
-          jsonDecode(sessionFileContents) as Map<String, Object?>;
-
       expect(secondAnalytics.userPropertyMap['session_id']?['value'],
           start.millisecondsSinceEpoch);
-      expect(sessionObj['last_ping'], start.millisecondsSinceEpoch);
+      expect(sessionFile.lastModifiedSync().millisecondsSinceEpoch,
+          start.millisecondsSinceEpoch);
     });
 
     // Add time to the start time that is less than the duration
@@ -739,16 +733,12 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       // no events will be sent
       thirdAnalytics.send(testEvent);
 
-      // Read the contents of the session file
-      final sessionFileContents = sessionFile.readAsStringSync();
-      final sessionObj =
-          jsonDecode(sessionFileContents) as Map<String, Object?>;
-
       expect(thirdAnalytics.userPropertyMap['session_id']?['value'],
           start.millisecondsSinceEpoch,
           reason: 'The session id should not have changed since it was made '
               'within the duration');
-      expect(sessionObj['last_ping'], end.millisecondsSinceEpoch,
+      expect(sessionFile.lastModifiedSync().millisecondsSinceEpoch,
+          end.millisecondsSinceEpoch,
           reason: 'The last_ping value should have been updated');
     });
   });
@@ -782,14 +772,10 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       );
       secondAnalytics.clientShowedMessage();
 
-      // Read the contents of the session file
-      final sessionFileContents = sessionFile.readAsStringSync();
-      final sessionObj =
-          jsonDecode(sessionFileContents) as Map<String, Object?>;
-
       expect(secondAnalytics.userPropertyMap['session_id']?['value'],
           start.millisecondsSinceEpoch);
-      expect(sessionObj['last_ping'], start.millisecondsSinceEpoch);
+      expect(sessionFile.lastModifiedSync().millisecondsSinceEpoch,
+          start.millisecondsSinceEpoch);
 
       secondAnalytics.send(testEvent);
     });
@@ -822,16 +808,12 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       // no events will be sent
       thirdAnalytics.send(testEvent);
 
-      // Read the contents of the session file
-      final sessionFileContents = sessionFile.readAsStringSync();
-      final sessionObj =
-          jsonDecode(sessionFileContents) as Map<String, Object?>;
-
       expect(thirdAnalytics.userPropertyMap['session_id']?['value'],
           end.millisecondsSinceEpoch,
           reason: 'The session id should have changed since it was made '
               'outside the duration');
-      expect(sessionObj['last_ping'], end.millisecondsSinceEpoch,
+      expect(sessionFile.lastModifiedSync().millisecondsSinceEpoch,
+          end.millisecondsSinceEpoch,
           reason: 'The last_ping value should have been updated');
     });
   });


### PR DESCRIPTION
Fixes:
- https://github.com/dart-lang/tools/issues/240

Related to:
- https://github.com/dart-lang/tools/issues/166

This update makes it so that we only write to the session file only when the session id needs to be updated. Previously, we were writing with every event in order to keep track of when the last ping was so that we can keep the session alive or start a new one.

We now instead use the last modified timestamp for the session file as a stand in for when the last ping happened.

The file's format has also changed
```jsonc
// OLD
{"session_id": 123, "last_ping": 123}

// NEW
{"session_id": 123}
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
