### PR TITLE
Rewrite the `last_ping` key again

### DIFF
--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -84,8 +84,8 @@ class Initializer {
   }) {
     final now = sessionIdOverride ?? clock.now();
     sessionFile.createSync(recursive: true);
-    sessionFile
-        .writeAsStringSync('{"session_id": ${now.millisecondsSinceEpoch}}');
+    sessionFile.writeAsStringSync(
+        '{"session_id": ${now.millisecondsSinceEpoch}, "last_ping": null}');
   }
 
   /// This will check that there is a client ID populated in

--- a/pkgs/unified_analytics/lib/src/session.dart
+++ b/pkgs/unified_analytics/lib/src/session.dart
@@ -120,6 +120,21 @@ class Session {
 
       // Fallback to setting the session id as the current time
       _sessionId = now.millisecondsSinceEpoch;
+      // ignore: avoid_catching_errors
+    } on TypeError catch (err) {
+      final now = clock.now();
+      Initializer.createSessionFile(
+        sessionFile: sessionFile,
+        sessionIdOverride: now,
+      );
+
+      _errorHandler.log(Event.analyticsException(
+        workflow: 'Session._refreshSessionData',
+        error: err.runtimeType.toString(),
+      ));
+
+      // Fallback to setting the session id as the current time
+      _sessionId = now.millisecondsSinceEpoch;
     }
   }
 }

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -143,7 +143,8 @@ void main() {
       final timestamp = clock.now().millisecondsSinceEpoch.toString();
       expect(sessionFile.readAsStringSync(), 'contents');
       analytics.userProperty.preparePayload();
-      expect(sessionFile.readAsStringSync(), '{"session_id": $timestamp}');
+      expect(sessionFile.readAsStringSync(),
+          '{"session_id": $timestamp, "last_ping": null}');
 
       // Attempting to fetch the session id when malformed should also
       // send an error event while parsing
@@ -199,7 +200,8 @@ void main() {
       final timestamp = clock.now().millisecondsSinceEpoch.toString();
       expect(sessionFile.existsSync(), false);
       analytics.userProperty.preparePayload();
-      expect(sessionFile.readAsStringSync(), '{"session_id": $timestamp}');
+      expect(sessionFile.readAsStringSync(),
+          '{"session_id": $timestamp, "last_ping": null}');
 
       // Attempting to fetch the session id when malformed should also
       // send an error event while parsing


### PR DESCRIPTION
Fixes:
- https://github.com/dart-lang/tools/issues/252

Not having the `last_ping` key in the session json file will cause issues if a user chooses to downgrade to a previous version

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
