### PR TITLE
`Event` Constructor added for devtools event

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.0
+
+- Added new event constructor `Event.devtoolsEvent` for the single devtools event with a new enum value `DashEvent.devtoolsEvent`
+
 ## 6.0.0
 
 - Consolidate `Session` functionality into `UserProperty` to prevent race condition crash where session logic crashed before initializing `UserProperty`

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -82,7 +82,7 @@ const int kLogFileLength = 2500;
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '6.0.0';
+const String kPackageVersion = '6.1.0';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -56,6 +56,14 @@ enum DashEvent {
     toolOwner: DashTool.dartTool,
   ),
 
+  // Events for Flutter devtools
+
+  devtoolsAction(
+    label: 'devtools_action',
+    description: 'Information for various devtools actions',
+    toolOwner: DashTool.devtools,
+  ),
+
   // Events for the Flutter CLI
 
   appleUsageEvent(

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -58,9 +58,9 @@ enum DashEvent {
 
   // Events for Flutter devtools
 
-  devtoolsAction(
-    label: 'devtools_action',
-    description: 'Information for various devtools actions',
+  devtoolsEvent(
+    label: 'devtools_event',
+    description: 'Information for various devtools events',
     toolOwner: DashTool.devtools,
   ),
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -363,20 +363,22 @@ final class Event {
     required String eventCategory,
     required String label,
     required int value,
-    required bool nonInteraction,
-    required String userApp,
-    required String userBuild,
-    required String userPlatform,
-    required String devtoolsPlatform,
-    required String devtoolsChrome,
-    required String devtoolsVersion,
-    required String ideLaunched,
-    required String isExternalBuild,
-    required String isEmbedded,
-    required String ideLaunchedFeature,
+
+    // Defaulted values
+    bool userInitiatedInteraction = true,
 
     // Optional parameters
     String? g3Username,
+    String? userApp,
+    String? userBuild,
+    String? userPlatform,
+    String? devtoolsPlatform,
+    String? devtoolsChrome,
+    String? devtoolsVersion,
+    String? ideLaunched,
+    String? isExternalBuild,
+    String? isEmbedded,
+    String? ideLaunchedFeature,
 
     // PerformanceScreenMetrics
     int? uiDurationMicros,
@@ -397,25 +399,27 @@ final class Event {
     int? rootSetCount,
     int? rowCount,
     int? inspectorTreeControllerId,
-  })  : eventName = DashEvent.devtoolsAction,
+  })  : eventName = DashEvent.devtoolsEvent,
         eventData = {
           'eventCategory': eventCategory,
           'label': label,
           'value': value,
-          'nonInteraction': nonInteraction,
-          'userApp': userApp,
-          'userBuild': userBuild,
-          'userPlatform': userPlatform,
-          'devtoolsPlatform': devtoolsPlatform,
-          'devtoolsChrome': devtoolsChrome,
-          'devtoolsVersion': devtoolsVersion,
-          'ideLaunched': ideLaunched,
-          'isExternalBuild': isExternalBuild,
-          'isEmbedded': isEmbedded,
-          'ideLaunchedFeature': ideLaunchedFeature,
+
+          'userInitiatedInteraction': userInitiatedInteraction,
 
           // Optional parameters
           if (g3Username != null) 'g3Username': g3Username,
+          if (userApp != null) 'userApp': userApp,
+          if (userBuild != null) 'userBuild': userBuild,
+          if (userPlatform != null) 'userPlatform': userPlatform,
+          if (devtoolsPlatform != null) 'devtoolsPlatform': devtoolsPlatform,
+          if (devtoolsChrome != null) 'devtoolsChrome': devtoolsChrome,
+          if (devtoolsVersion != null) 'devtoolsVersion': devtoolsVersion,
+          if (ideLaunched != null) 'ideLaunched': ideLaunched,
+          if (isExternalBuild != null) 'isExternalBuild': isExternalBuild,
+          if (isEmbedded != null) 'isEmbedded': isEmbedded,
+          if (ideLaunchedFeature != null)
+            'ideLaunchedFeature': ideLaunchedFeature,
 
           // PerformanceScreenMetrics
           if (uiDurationMicros != null) 'uiDurationMicros': uiDurationMicros,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -357,6 +357,92 @@ final class Event {
           if (exitCode != null) 'exitCode': exitCode,
         };
 
+  /// Event that is sent from devtools for various different actions as
+  /// indicated by the [eventCategory].
+  Event.devtoolsAction({
+    required String eventCategory,
+    required String label,
+    required int value,
+    required bool nonInteraction,
+    required String userApp,
+    required String userBuild,
+    required String userPlatform,
+    required String devtoolsPlatform,
+    required String devtoolsChrome,
+    required String devtoolsVersion,
+    required String ideLaunched,
+    required String isExternalBuild,
+    required String isEmbedded,
+    required String ideLaunchedFeature,
+
+    // Optional parameters
+    String? g3Username,
+
+    // PerformanceScreenMetrics
+    int? uiDurationMicros,
+    int? rasterDurationMicros,
+    int? shaderCompilationDurationMicros,
+    int? traceEventCount,
+
+    // ProfilerScreenMetrics
+    int? cpuSampleCount,
+    int? cpuStackDepth,
+
+    // MemoryScreenMetrics
+    int? heapDiffObjectsBefore,
+    int? heapDiffObjectsAfter,
+    int? heapObjectsTotal,
+
+    // InspectorScreenMetrics
+    int? rootSetCount,
+    int? rowCount,
+    int? inspectorTreeControllerId,
+  })  : eventName = DashEvent.devtoolsAction,
+        eventData = {
+          'eventCategory': eventCategory,
+          'label': label,
+          'value': value,
+          'nonInteraction': nonInteraction,
+          'userApp': userApp,
+          'userBuild': userBuild,
+          'userPlatform': userPlatform,
+          'devtoolsPlatform': devtoolsPlatform,
+          'devtoolsChrome': devtoolsChrome,
+          'devtoolsVersion': devtoolsVersion,
+          'ideLaunched': ideLaunched,
+          'isExternalBuild': isExternalBuild,
+          'isEmbedded': isEmbedded,
+          'ideLaunchedFeature': ideLaunchedFeature,
+
+          // Optional parameters
+          if (g3Username != null) 'g3Username': g3Username,
+
+          // PerformanceScreenMetrics
+          if (uiDurationMicros != null) 'uiDurationMicros': uiDurationMicros,
+          if (rasterDurationMicros != null)
+            'rasterDurationMicros': rasterDurationMicros,
+          if (shaderCompilationDurationMicros != null)
+            'shaderCompilationDurationMicros': shaderCompilationDurationMicros,
+          if (traceEventCount != null) 'traceEventCount': traceEventCount,
+
+          // ProfilerScreenMetrics
+          if (cpuSampleCount != null) 'cpuSampleCount': cpuSampleCount,
+          if (cpuStackDepth != null) 'cpuStackDepth': cpuStackDepth,
+
+          // MemoryScreenMetrics
+          if (heapDiffObjectsBefore != null)
+            'heapDiffObjectsBefore': heapDiffObjectsBefore,
+          if (heapDiffObjectsAfter != null)
+            'heapDiffObjectsAfter': heapDiffObjectsAfter,
+          if (heapObjectsTotal != null) 'heapObjectsTotal': heapObjectsTotal,
+
+          // InspectorScreenMetrics
+          if (rootSetCount != null) 'rootSetCount': rootSetCount,
+          if (rowCount != null) 'rowCount': rowCount,
+          if (inspectorTreeControllerId != null)
+            'inspectorTreeControllerId': inspectorTreeControllerId,
+        };
+
   /// Event that contains the results for a specific doctor validator.
   ///
   /// [validatorName] - the name for the doctor validator.

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -359,7 +359,7 @@ final class Event {
 
   /// Event that is sent from devtools for various different actions as
   /// indicated by the [eventCategory].
-  Event.devtoolsAction({
+  Event.devtoolsEvent({
     required String eventCategory,
     required String label,
     required int value,

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 6.0.0
+version: 6.1.0
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -553,6 +553,71 @@ void main() {
     expect(constructedEvent.eventData.length, 3);
   });
 
+  test('Event.devtoolsEvent constructed', () {
+    Event generateEvent() => Event.devtoolsEvent(
+          eventCategory: 'eventCategory',
+          label: 'label',
+          value: 1,
+          userInitiatedInteraction: true,
+          g3Username: 'g3Username',
+          userApp: 'userApp',
+          userBuild: 'userBuild',
+          userPlatform: 'userPlatform',
+          devtoolsPlatform: 'devtoolsPlatform',
+          devtoolsChrome: 'devtoolsChrome',
+          devtoolsVersion: 'devtoolsVersion',
+          ideLaunched: 'ideLaunched',
+          isExternalBuild: 'isExternalBuild',
+          isEmbedded: 'isEmbedded',
+          ideLaunchedFeature: 'ideLaunchedFeature',
+          uiDurationMicros: 123,
+          rasterDurationMicros: 123,
+          shaderCompilationDurationMicros: 123,
+          traceEventCount: 123,
+          cpuSampleCount: 123,
+          cpuStackDepth: 123,
+          heapDiffObjectsBefore: 123,
+          heapDiffObjectsAfter: 123,
+          heapObjectsTotal: 123,
+          rootSetCount: 123,
+          rowCount: 123,
+          inspectorTreeControllerId: 123,
+        );
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventData['eventCategory'], 'eventCategory');
+    expect(constructedEvent.eventData['label'], 'label');
+    expect(constructedEvent.eventData['value'], 1);
+    expect(constructedEvent.eventData['userInitiatedInteraction'], true);
+    expect(constructedEvent.eventData['g3Username'], 'g3Username');
+    expect(constructedEvent.eventData['userApp'], 'userApp');
+    expect(constructedEvent.eventData['userBuild'], 'userBuild');
+    expect(constructedEvent.eventData['userPlatform'], 'userPlatform');
+    expect(constructedEvent.eventData['devtoolsPlatform'], 'devtoolsPlatform');
+    expect(constructedEvent.eventData['devtoolsChrome'], 'devtoolsChrome');
+    expect(constructedEvent.eventData['devtoolsVersion'], 'devtoolsVersion');
+    expect(constructedEvent.eventData['ideLaunched'], 'ideLaunched');
+    expect(constructedEvent.eventData['isExternalBuild'], 'isExternalBuild');
+    expect(constructedEvent.eventData['isEmbedded'], 'isEmbedded');
+    expect(
+        constructedEvent.eventData['ideLaunchedFeature'], 'ideLaunchedFeature');
+    expect(constructedEvent.eventData['uiDurationMicros'], 123);
+    expect(constructedEvent.eventData['rasterDurationMicros'], 123);
+    expect(constructedEvent.eventData['shaderCompilationDurationMicros'], 123);
+    expect(constructedEvent.eventData['traceEventCount'], 123);
+    expect(constructedEvent.eventData['cpuSampleCount'], 123);
+    expect(constructedEvent.eventData['cpuStackDepth'], 123);
+    expect(constructedEvent.eventData['heapDiffObjectsBefore'], 123);
+    expect(constructedEvent.eventData['heapDiffObjectsAfter'], 123);
+    expect(constructedEvent.eventData['heapObjectsTotal'], 123);
+    expect(constructedEvent.eventData['rootSetCount'], 123);
+    expect(constructedEvent.eventData['rowCount'], 123);
+    expect(constructedEvent.eventData['inspectorTreeControllerId'], 123);
+    expect(constructedEvent.eventData.length, 27);
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (var declaration in reflectClass(Event).declarations.keys) {
@@ -563,7 +628,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 26;
+    final eventsAccountedForInTests = 27;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '


### PR DESCRIPTION
Part of tracker issue:
- https://github.com/flutter/devtools/issues/7083

Devtools uses one large data class for all of their events. This PR is adding that data class as a named constructor under `Event` called `Event.devtoolsAction`

The singular data class can be found [here in devtools source code](https://github.com/flutter/devtools/blob/master/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart#L52-L112).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
