### PR TITLE
Remove unused parameters for test constructor

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Any error events (`Event.analyticsException`) encountered within package will be sent when invoking `Analytics.close`; replacing `ErrorHandler` functionality
 - Exposing new method for `FakeAnalytics.sendPendingErrorEvents` to send error events on command
 - Added `Event.fromJson` static method to generate instance of `Event` from JSON
+- Remove unused parameters `measurementId` and `apiSecret` from the `Analytics.test` constructor
 
 ## 5.8.8
 

--- a/pkgs/unified_analytics/example/serving_surveys.dart
+++ b/pkgs/unified_analytics/example/serving_surveys.dart
@@ -39,8 +39,6 @@ void main() async {
     final initialAnalytics = Analytics.test(
       tool: DashTool.flutterTool,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       dartVersion: 'dartVersion',
       fs: fs,
       platform: DevicePlatform.macos,
@@ -52,8 +50,6 @@ void main() async {
     analytics = Analytics.test(
         tool: DashTool.flutterTool,
         homeDirectory: home,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
         dartVersion: 'dartVersion',
         fs: fs,
         platform: DevicePlatform.macos,

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -190,8 +190,6 @@ abstract class Analytics {
   factory Analytics.test({
     required DashTool tool,
     required Directory homeDirectory,
-    required String measurementId,
-    required String apiSecret,
     required String dartVersion,
     required FileSystem fs,
     required DevicePlatform platform,

--- a/pkgs/unified_analytics/test/error_handler_test.dart
+++ b/pkgs/unified_analytics/test/error_handler_test.dart
@@ -22,8 +22,6 @@ void main() {
 
   const homeDirName = 'home';
   const initialTool = DashTool.flutterTool;
-  const measurementId = 'measurementId';
-  const apiSecret = 'apiSecret';
   const toolsMessageVersion = 1;
   const toolsMessage = 'toolsMessage';
   const flutterChannel = 'flutterChannel';
@@ -46,8 +44,6 @@ void main() {
     initializationAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -68,8 +64,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -102,8 +96,6 @@ void main() {
       final secondAnalytics = Analytics.test(
         tool: initialTool,
         homeDirectory: home,
-        measurementId: measurementId,
-        apiSecret: apiSecret,
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,

--- a/pkgs/unified_analytics/test/events_with_fake_test.dart
+++ b/pkgs/unified_analytics/test/events_with_fake_test.dart
@@ -61,8 +61,6 @@ void main() {
     final initialAnalytics = Analytics.test(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       dartVersion: 'dartVersion',
       toolsMessageVersion: 1,
       fs: fs,

--- a/pkgs/unified_analytics/test/legacy_analytics_test.dart
+++ b/pkgs/unified_analytics/test/legacy_analytics_test.dart
@@ -18,8 +18,6 @@ void main() {
 
   const homeDirName = 'home';
   const initialTool = DashTool.flutterTool;
-  const measurementId = 'measurementId';
-  const apiSecret = 'apiSecret';
   const toolsMessageVersion = 1;
   const toolsMessage = 'toolsMessage';
   const flutterChannel = 'flutterChannel';
@@ -54,8 +52,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -87,8 +83,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -119,8 +113,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -151,8 +143,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -187,8 +177,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -223,8 +211,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -257,8 +243,6 @@ NOT VALID JSON
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -295,8 +279,6 @@ NOT VALID JSON
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -329,8 +311,6 @@ NOT VALID JSON
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,

--- a/pkgs/unified_analytics/test/log_handler_test.dart
+++ b/pkgs/unified_analytics/test/log_handler_test.dart
@@ -33,8 +33,6 @@ void main() {
     final initializationAnalytics = Analytics.test(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       dartVersion: 'dartVersion',
       fs: fs,
       platform: DevicePlatform.macos,
@@ -46,8 +44,6 @@ void main() {
     analytics = Analytics.test(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       dartVersion: 'dartVersion',
       fs: fs,
       platform: DevicePlatform.macos,

--- a/pkgs/unified_analytics/test/suppression_test.dart
+++ b/pkgs/unified_analytics/test/suppression_test.dart
@@ -18,8 +18,6 @@ void main() {
 
   const homeDirName = 'home';
   const initialTool = DashTool.flutterTool;
-  const measurementId = 'measurementId';
-  const apiSecret = 'apiSecret';
   const toolsMessageVersion = 1;
   const toolsMessage = 'toolsMessage';
   const flutterChannel = 'flutterChannel';
@@ -41,8 +39,6 @@ void main() {
     initializationAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -61,8 +57,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -97,8 +91,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,

--- a/pkgs/unified_analytics/test/survey_handler_test.dart
+++ b/pkgs/unified_analytics/test/survey_handler_test.dart
@@ -298,8 +298,6 @@ void main() {
       final initialAnalyticsFlutter = Analytics.test(
         tool: DashTool.flutterTool,
         homeDirectory: homeDirectory,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
         dartVersion: 'dartVersion',
         fs: fs,
         platform: DevicePlatform.macos,
@@ -307,8 +305,6 @@ void main() {
       final initialAnalyticsDart = Analytics.test(
         tool: DashTool.dartTool,
         homeDirectory: homeDirectory,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
         dartVersion: 'dartVersion',
         fs: fs,
         platform: DevicePlatform.macos,
@@ -322,8 +318,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -375,8 +369,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -417,8 +409,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -462,8 +452,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -564,8 +552,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -628,8 +614,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -711,8 +695,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -787,8 +769,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -832,8 +812,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -879,8 +857,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -908,8 +884,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -929,8 +903,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -975,8 +947,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1003,8 +973,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1051,8 +1019,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1083,8 +1049,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1131,8 +1095,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1160,8 +1122,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1184,8 +1144,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1231,8 +1189,6 @@ void main() {
         analytics = Analytics.test(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
-          measurementId: 'measurementId',
-          apiSecret: 'apiSecret',
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -33,8 +33,6 @@ void main() {
   const homeDirName = 'home';
   const initialTool = DashTool.flutterTool;
   const secondTool = DashTool.dartTool;
-  const measurementId = 'measurementId';
-  const apiSecret = 'apiSecret';
   const toolsMessageVersion = 1;
   const toolsMessage = 'toolsMessage';
   const flutterChannel = 'flutterChannel';
@@ -58,8 +56,6 @@ void main() {
     initializationAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -80,8 +76,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -168,8 +162,6 @@ void main() {
     analytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -232,8 +224,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: secondTool,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       flutterChannel: 'ey-test-channel',
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -325,8 +315,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -369,8 +357,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: secondTool,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       flutterChannel: 'ey-test-channel',
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -393,8 +379,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: secondTool,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       flutterChannel: 'ey-test-channel',
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -447,8 +431,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: secondTool,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       flutterChannel: 'ey-test-channel',
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -478,8 +460,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1,
       toolsMessage: toolsMessage,
@@ -605,8 +585,6 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     final secondAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1,
       toolsMessage: toolsMessage,
@@ -630,8 +608,6 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     final thirdAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1,
       toolsMessage: toolsMessage,
@@ -703,8 +679,6 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       final secondAnalytics = Analytics.test(
         tool: secondTool,
         homeDirectory: home,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,
@@ -732,8 +706,6 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       final thirdAnalytics = Analytics.test(
         tool: secondTool,
         homeDirectory: home,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,
@@ -776,8 +748,6 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       final secondAnalytics = Analytics.test(
         tool: secondTool,
         homeDirectory: home,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,
@@ -809,8 +779,6 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       final thirdAnalytics = Analytics.test(
         tool: secondTool,
         homeDirectory: home,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,
@@ -960,8 +928,6 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       secondAnalytics = Analytics.test(
         tool: secondTool,
         homeDirectory: home,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,
@@ -1067,8 +1033,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       secondAnalytics = Analytics.test(
         tool: secondTool,
         homeDirectory: home,
-        measurementId: 'measurementId',
-        apiSecret: 'apiSecret',
+
         // flutterChannel: flutterChannel,  THIS NEEDS TO REMAIN REMOVED
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,
@@ -1218,8 +1183,6 @@ Privacy Policy (https://policies.google.com/privacy).
     final secondAnalytics = Analytics.test(
       tool: secondTool,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       flutterChannel: 'ey-test-channel',
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -25,8 +25,6 @@ void main() {
   const homeDirName = 'home';
   const initialTool = DashTool.flutterTool;
   const secondTool = DashTool.dartTool;
-  const measurementId = 'measurementId';
-  const apiSecret = 'apiSecret';
   const toolsMessageVersion = 1;
   const toolsMessage = 'toolsMessage';
   const flutterChannel = 'flutterChannel';
@@ -63,8 +61,6 @@ void main() {
     final firstAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -100,8 +96,6 @@ void main() {
     final firstAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -117,8 +111,7 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
+
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
@@ -136,8 +129,7 @@ void main() {
     final thirdAnalytics = Analytics.test(
       tool: secondTool, // Different tool
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
+
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
@@ -156,8 +148,6 @@ void main() {
     final firstAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -213,8 +203,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -246,8 +234,7 @@ void main() {
     final thirdAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
+
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
@@ -277,8 +264,7 @@ void main() {
     final fourthAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
+
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
@@ -303,8 +289,6 @@ void main() {
     final firstAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -319,8 +303,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -337,8 +319,6 @@ void main() {
     final thirdAnalytics = Analytics.test(
       tool: initialTool,
       homeDirectory: home,
-      measurementId: measurementId,
-      apiSecret: apiSecret,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -356,8 +336,6 @@ void main() {
     final secondAnalytics = Analytics.test(
       tool: secondTool,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       flutterChannel: flutterChannel,
       toolsMessageVersion: firstVersion,
       toolsMessage: toolsMessage,
@@ -380,8 +358,6 @@ void main() {
     final thirdAnalytics = Analytics.test(
       tool: secondTool,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
       flutterChannel: flutterChannel,
       toolsMessageVersion: secondVersion,
       toolsMessage: toolsMessage,


### PR DESCRIPTION
The `measurementId` and `apiSecret` parameters are no longer necessary for the `Analytics.test` constructor

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
