### PR TITLE
Use static method for fake instance

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Exposing new method for `FakeAnalytics.sendPendingErrorEvents` to send error events on command
 - Added `Event.fromJson` static method to generate instance of `Event` from JSON
 - Remove unused parameters `measurementId` and `apiSecret` from the `Analytics.test` constructor
+- Remove `Analytics.test` factory constructor in favor of `Analytics.fake` static method to return a `FakeAnalytics` instance
 
 ## 5.8.8
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `Event.fromJson` static method to generate instance of `Event` from JSON
 - Remove unused parameters `measurementId` and `apiSecret` from the `Analytics.test` constructor
 - Remove `Analytics.test` factory constructor in favor of `Analytics.fake` static method to return a `FakeAnalytics` instance
+- Remove `FakeAnalytics` default constructor in favor of `Analytics.fake`
 
 ## 5.8.8
 

--- a/pkgs/unified_analytics/example/serving_surveys.dart
+++ b/pkgs/unified_analytics/example/serving_surveys.dart
@@ -14,7 +14,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 
 /// This example code is intended to only be used as guidance for
 /// clients using this package. Clients using this package should avoid
-/// the use of the [Analytics.fake] constructor.
+/// the use of the [Analytics.fake] static method.
 ///
 /// It was used in this example file so that the real [FileSystem] was swapped
 /// out for a [MemoryFileSystem] so that repeated runs of this script yield

--- a/pkgs/unified_analytics/example/serving_surveys.dart
+++ b/pkgs/unified_analytics/example/serving_surveys.dart
@@ -14,7 +14,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 
 /// This example code is intended to only be used as guidance for
 /// clients using this package. Clients using this package should avoid
-/// the use of the [Analytics.test] constructor.
+/// the use of the [Analytics.fake] constructor.
 ///
 /// It was used in this example file so that the real [FileSystem] was swapped
 /// out for a [MemoryFileSystem] so that repeated runs of this script yield
@@ -36,7 +36,7 @@ void main() async {
     // send events after its first run; this instance won't be used below
     //
     // ignore: invalid_use_of_visible_for_testing_member
-    final initialAnalytics = Analytics.test(
+    final initialAnalytics = Analytics.fake(
       tool: DashTool.flutterTool,
       homeDirectory: home,
       dartVersion: 'dartVersion',
@@ -47,7 +47,7 @@ void main() async {
     initialAnalytics.clientShowedMessage();
 
     // ignore: invalid_use_of_visible_for_testing_member
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
         tool: DashTool.flutterTool,
         homeDirectory: home,
         dartVersion: 'dartVersion',

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -184,51 +184,6 @@ abstract class Analytics {
     );
   }
 
-  /// Factory constructor to return the [AnalyticsImpl] class with a
-  /// [MemoryFileSystem] to use for testing.
-  @visibleForTesting
-  factory Analytics.test({
-    required DashTool tool,
-    required Directory homeDirectory,
-    required String dartVersion,
-    required FileSystem fs,
-    required DevicePlatform platform,
-    String? flutterChannel,
-    String? flutterVersion,
-    String? clientIde,
-    String? enabledFeatures,
-    SurveyHandler? surveyHandler,
-    GAClient? gaClient,
-    int toolsMessageVersion = kToolsMessageVersion,
-    String toolsMessage = kToolsMessage,
-  }) {
-    final firstRun = runInitialization(homeDirectory: homeDirectory, fs: fs);
-
-    return FakeAnalytics(
-      tool: tool,
-      homeDirectory: homeDirectory,
-      flutterChannel: flutterChannel,
-      toolsMessageVersion: toolsMessageVersion,
-      flutterVersion: flutterVersion,
-      dartVersion: dartVersion,
-      platform: platform,
-      fs: fs,
-      surveyHandler: surveyHandler ??
-          FakeSurveyHandler.fromList(
-            dismissedSurveyFile: fs.file(p.join(
-              homeDirectory.path,
-              kDartToolDirectoryName,
-              kDismissedSurveyFileName,
-            )),
-            initializedSurveys: [],
-          ),
-      gaClient: gaClient ?? const FakeGAClient(),
-      clientIde: clientIde,
-      enabledFeatures: enabledFeatures,
-      firstRun: firstRun,
-    );
-  }
-
   /// The shared identifier for Flutter and Dart related tooling using
   /// package:unified_analytics.
   String get clientId;
@@ -333,6 +288,51 @@ abstract class Analytics {
   ///
   /// The snooze period is defined by the [Survey.snoozeForMinutes] field.
   void surveyShown(Survey survey);
+
+  /// Returns an instance of [FakeAnalytics] which can be used in tests to check
+  /// for certain [Event] instances within [FakeAnalytics.sentEvents].
+  @visibleForTesting
+  static FakeAnalytics fake({
+    required DashTool tool,
+    required Directory homeDirectory,
+    required String dartVersion,
+    required MemoryFileSystem fs,
+    required DevicePlatform platform,
+    String? flutterChannel,
+    String? flutterVersion,
+    String? clientIde,
+    String? enabledFeatures,
+    SurveyHandler? surveyHandler,
+    GAClient? gaClient,
+    int toolsMessageVersion = kToolsMessageVersion,
+    String toolsMessage = kToolsMessage,
+  }) {
+    final firstRun = runInitialization(homeDirectory: homeDirectory, fs: fs);
+
+    return FakeAnalytics(
+      tool: tool,
+      homeDirectory: homeDirectory,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      platform: platform,
+      fs: fs,
+      surveyHandler: surveyHandler ??
+          FakeSurveyHandler.fromList(
+            dismissedSurveyFile: fs.file(p.join(
+              homeDirectory.path,
+              kDartToolDirectoryName,
+              kDismissedSurveyFileName,
+            )),
+            initializedSurveys: [],
+          ),
+      gaClient: gaClient ?? const FakeGAClient(),
+      clientIde: clientIde,
+      enabledFeatures: enabledFeatures,
+      firstRun: firstRun,
+    );
+  }
 }
 
 class AnalyticsImpl implements Analytics {

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -297,19 +297,20 @@ abstract class Analytics {
     required Directory homeDirectory,
     required String dartVersion,
     required MemoryFileSystem fs,
-    required DevicePlatform platform,
     String? flutterChannel,
     String? flutterVersion,
     String? clientIde,
     String? enabledFeatures,
     SurveyHandler? surveyHandler,
     GAClient? gaClient,
+    DevicePlatform platform = DevicePlatform.linux,
     int toolsMessageVersion = kToolsMessageVersion,
     String toolsMessage = kToolsMessage,
+    bool enableAsserts = true,
   }) {
     final firstRun = runInitialization(homeDirectory: homeDirectory, fs: fs);
 
-    return FakeAnalytics(
+    return FakeAnalytics._(
       tool: tool,
       homeDirectory: homeDirectory,
       flutterChannel: flutterChannel,
@@ -331,6 +332,7 @@ abstract class Analytics {
       clientIde: clientIde,
       enabledFeatures: enabledFeatures,
       firstRun: firstRun,
+      enableAsserts: enableAsserts,
     );
   }
 }
@@ -763,7 +765,7 @@ class FakeAnalytics extends AnalyticsImpl {
   final List<Event> sentEvents = [];
 
   /// Class to use when you want to see which events were sent
-  FakeAnalytics({
+  FakeAnalytics._({
     required super.tool,
     required super.homeDirectory,
     required super.dartVersion,

--- a/pkgs/unified_analytics/test/error_handler_test.dart
+++ b/pkgs/unified_analytics/test/error_handler_test.dart
@@ -13,7 +13,7 @@ import 'package:unified_analytics/src/enums.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
-  late FileSystem fs;
+  late MemoryFileSystem fs;
   late Directory home;
   late FakeAnalytics initializationAnalytics;
   late FakeAnalytics analytics;
@@ -41,7 +41,7 @@ void main() {
 
     // This is the first analytics instance that will be used to demonstrate
     // that events will not be sent with the first run of analytics
-    initializationAnalytics = Analytics.test(
+    initializationAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -51,7 +51,7 @@ void main() {
       dartVersion: dartVersion,
       fs: fs,
       platform: platform,
-    ) as FakeAnalytics;
+    );
     expect(initializationAnalytics.shouldShowMessage, true);
     initializationAnalytics.clientShowedMessage();
     expect(initializationAnalytics.shouldShowMessage, false);
@@ -61,7 +61,7 @@ void main() {
     //
     // This instance should have the same parameters as the one above for
     // [initializationAnalytics]
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -72,7 +72,7 @@ void main() {
       fs: fs,
       platform: platform,
       clientIde: clientIde,
-    ) as FakeAnalytics;
+    );
     analytics.clientShowedMessage();
 
     // The files that should have been generated that will be used for tests
@@ -93,7 +93,7 @@ void main() {
       expect(analytics.telemetryEnabled, false);
       expect(sessionFile.readAsStringSync(), isEmpty);
 
-      final secondAnalytics = Analytics.test(
+      final secondAnalytics = Analytics.fake(
         tool: initialTool,
         homeDirectory: home,
         flutterChannel: flutterChannel,
@@ -104,7 +104,7 @@ void main() {
         fs: fs,
         platform: platform,
         clientIde: clientIde,
-      ) as FakeAnalytics;
+      );
       expect(sessionFile.readAsStringSync(), isEmpty);
       expect(secondAnalytics.telemetryEnabled, false);
 

--- a/pkgs/unified_analytics/test/events_with_fake_test.dart
+++ b/pkgs/unified_analytics/test/events_with_fake_test.dart
@@ -72,7 +72,7 @@ void main() {
     // the first run
     withClock(Clock.fixed(DateTime(2022, 3, 3)), () {
       final toolsMessageVersion = kToolsMessageVersion;
-      fakeAnalytics = FakeAnalytics(
+      fakeAnalytics = Analytics.fake(
         tool: DashTool.flutterTool,
         homeDirectory: homeDirectory,
         dartVersion: 'dartVersion',
@@ -83,7 +83,6 @@ void main() {
           dismissedSurveyFile: dismissedSurveyFile,
           initializedSurveys: [testSurvey],
         ),
-        firstRun: false,
       );
     });
   });

--- a/pkgs/unified_analytics/test/events_with_fake_test.dart
+++ b/pkgs/unified_analytics/test/events_with_fake_test.dart
@@ -18,7 +18,7 @@ void main() {
   // are being sent when invoking methods on the `Analytics` instance
 
   late FakeAnalytics fakeAnalytics;
-  late FileSystem fs;
+  late MemoryFileSystem fs;
   late Directory homeDirectory;
   late File dismissedSurveyFile;
 
@@ -58,7 +58,7 @@ void main() {
       kDismissedSurveyFileName,
     ));
 
-    final initialAnalytics = Analytics.test(
+    final initialAnalytics = Analytics.fake(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
       dartVersion: 'dartVersion',

--- a/pkgs/unified_analytics/test/legacy_analytics_test.dart
+++ b/pkgs/unified_analytics/test/legacy_analytics_test.dart
@@ -12,7 +12,7 @@ import 'package:unified_analytics/src/enums.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
-  late FileSystem fs;
+  late MemoryFileSystem fs;
   late Directory home;
   late Analytics analytics;
 
@@ -49,7 +49,7 @@ void main() {
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -80,7 +80,7 @@ void main() {
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -110,7 +110,7 @@ void main() {
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -140,7 +140,7 @@ void main() {
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -174,7 +174,7 @@ void main() {
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -208,7 +208,7 @@ void main() {
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -240,7 +240,7 @@ NOT VALID JSON
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -276,7 +276,7 @@ NOT VALID JSON
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -308,7 +308,7 @@ NOT VALID JSON
 
     // The main analytics instance, other instances can be spawned within tests
     // to test how to instances running together work
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,

--- a/pkgs/unified_analytics/test/log_handler_test.dart
+++ b/pkgs/unified_analytics/test/log_handler_test.dart
@@ -15,7 +15,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 void main() {
   late FakeAnalytics analytics;
   late Directory homeDirectory;
-  late FileSystem fs;
+  late MemoryFileSystem fs;
   late File logFile;
 
   final testEvent = Event.hotReloadTime(timeMs: 10);
@@ -30,7 +30,7 @@ void main() {
     ));
 
     // Create the initialization analytics instance to onboard the tool
-    final initializationAnalytics = Analytics.test(
+    final initializationAnalytics = Analytics.fake(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
       dartVersion: 'dartVersion',
@@ -41,13 +41,13 @@ void main() {
 
     // This instance is free to send events since the instance above
     // has confirmed that the client has shown the message
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
       dartVersion: 'dartVersion',
       fs: fs,
       platform: DevicePlatform.macos,
-    ) as FakeAnalytics;
+    );
   });
 
   test('Ensure that log file is created', () {

--- a/pkgs/unified_analytics/test/suppression_test.dart
+++ b/pkgs/unified_analytics/test/suppression_test.dart
@@ -11,7 +11,7 @@ import 'package:unified_analytics/src/enums.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
-  late FileSystem fs;
+  late MemoryFileSystem fs;
   late Directory home;
   late Analytics initializationAnalytics;
   late Analytics analytics;
@@ -36,7 +36,7 @@ void main() {
 
     // This is the first analytics instance that will be used to demonstrate
     // that events will not be sent with the first run of analytics
-    initializationAnalytics = Analytics.test(
+    initializationAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -54,7 +54,7 @@ void main() {
     //
     // This instance should have the same parameters as the one above for
     // [initializationAnalytics]
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -88,7 +88,7 @@ void main() {
         reason: 'Returns null because no records have been recorded');
 
     // The newly created instance will not be suppressed
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,

--- a/pkgs/unified_analytics/test/survey_handler_test.dart
+++ b/pkgs/unified_analytics/test/survey_handler_test.dart
@@ -263,7 +263,7 @@ void main() {
   group('Testing with FakeSurveyHandler', () {
     late Analytics analytics;
     late Directory homeDirectory;
-    late FileSystem fs;
+    late MemoryFileSystem fs;
     late File clientIdFile;
     late File dismissedSurveyFile;
 
@@ -295,14 +295,14 @@ void main() {
       //
       // This is especially useful when testing the "excludeDashTools" array
       // to prevent certain tools from getting a survey from this package
-      final initialAnalyticsFlutter = Analytics.test(
+      final initialAnalyticsFlutter = Analytics.fake(
         tool: DashTool.flutterTool,
         homeDirectory: homeDirectory,
         dartVersion: 'dartVersion',
         fs: fs,
         platform: DevicePlatform.macos,
       );
-      final initialAnalyticsDart = Analytics.test(
+      final initialAnalyticsDart = Analytics.fake(
         tool: DashTool.dartTool,
         homeDirectory: homeDirectory,
         dartVersion: 'dartVersion',
@@ -315,7 +315,7 @@ void main() {
 
     test('returns valid survey', () async {
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -366,7 +366,7 @@ void main() {
 
     test('does not return expired survey', () async {
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -406,7 +406,7 @@ void main() {
 
     test('does not return survey if opted out of telemetry', () async {
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -449,7 +449,7 @@ void main() {
 
     test('returns valid survey from json', () async {
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -549,7 +549,7 @@ void main() {
     test('no survey returned from malformed json', () async {
       // The date is not valid for the start date
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -611,7 +611,7 @@ void main() {
 
     test('returns two valid survey from json', () async {
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -692,7 +692,7 @@ void main() {
 
     test('valid survey not returned if opted out', () async {
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -766,7 +766,7 @@ void main() {
           ],
           buttonList: [],
         );
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -809,7 +809,7 @@ void main() {
           ],
           buttonList: [],
         );
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -854,7 +854,7 @@ void main() {
       );
 
       await withClock(Clock.fixed(DateTime(2023, 3, 3, 12, 0)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -881,7 +881,7 @@ void main() {
       // This analytics instance will be simulated to be shortly after the first
       // snooze, but before the snooze period has elapsed
       await withClock(Clock.fixed(DateTime(2023, 3, 3, 12, 15)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -900,7 +900,7 @@ void main() {
 
       // This analytics instance will be simulated to be after the snooze period
       await withClock(Clock.fixed(DateTime(2023, 3, 3, 12, 35)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -944,7 +944,7 @@ void main() {
       );
 
       await withClock(Clock.fixed(DateTime(2023, 3, 3, 12, 0)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -970,7 +970,7 @@ void main() {
 
       // Moving out a week
       await withClock(Clock.fixed(DateTime(2023, 3, 10, 12, 0)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -1016,7 +1016,7 @@ void main() {
       );
 
       await withClock(Clock.fixed(DateTime(2023, 3, 3, 12, 0)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -1046,7 +1046,7 @@ void main() {
 
       // Moving out a week
       await withClock(Clock.fixed(DateTime(2023, 3, 10, 12, 0)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -1092,7 +1092,7 @@ void main() {
       );
 
       await withClock(Clock.fixed(DateTime(2023, 3, 3, 12, 0)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -1119,7 +1119,7 @@ void main() {
 
       // Moving out a week
       await withClock(Clock.fixed(DateTime(2023, 3, 10, 12, 0)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -1141,7 +1141,7 @@ void main() {
 
     test('Filtering out with excludeDashTool array', () async {
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',
@@ -1186,7 +1186,7 @@ void main() {
         'Filter from excludeDashTool array does not '
         'apply for different tool', () async {
       await withClock(Clock.fixed(DateTime(2023, 3, 3)), () async {
-        analytics = Analytics.test(
+        analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
           dartVersion: 'dartVersion',

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -19,7 +19,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 import 'package:yaml/yaml.dart';
 
 void main() {
-  late FileSystem fs;
+  late MemoryFileSystem fs;
   late Directory home;
   late Directory dartToolDirectory;
   late Analytics initializationAnalytics;
@@ -53,7 +53,7 @@ void main() {
 
     // This is the first analytics instance that will be used to demonstrate
     // that events will not be sent with the first run of analytics
-    initializationAnalytics = Analytics.test(
+    initializationAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -73,7 +73,7 @@ void main() {
     //
     // This instance should have the same parameters as the one above for
     // [initializationAnalytics]
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -84,7 +84,7 @@ void main() {
       fs: fs,
       platform: platform,
       clientIde: clientIde,
-    ) as FakeAnalytics;
+    );
     analytics.clientShowedMessage();
 
     // The 5 files that should have been generated
@@ -159,7 +159,7 @@ void main() {
     // for session data
     sessionFile.writeAsStringSync('not a valid session id');
 
-    analytics = Analytics.test(
+    analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -170,7 +170,7 @@ void main() {
       fs: fs,
       platform: platform,
       clientIde: clientIde,
-    ) as FakeAnalytics;
+    );
     analytics.clientShowedMessage();
 
     // Invoking a send command should reset the session file to a good state
@@ -221,7 +221,7 @@ void main() {
 
   test('New tool is successfully added to config file', () {
     // Create a new instance of the analytics class with the new tool
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
       flutterChannel: 'ey-test-channel',
@@ -312,7 +312,7 @@ void main() {
 
     // Start up a second instance to simulate starting another
     // command being run
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -354,7 +354,7 @@ void main() {
 
     // Initialize a second analytics class, which simulates a second tool
     // Create a new instance of the analytics class with the new tool
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
       flutterChannel: 'ey-test-channel',
@@ -376,7 +376,7 @@ void main() {
       'Two concurrent instances are running '
       'and reflect an accurate up to date telemetry status', () async {
     // Initialize a second analytics class, which simulates a second tool
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
       flutterChannel: 'ey-test-channel',
@@ -428,7 +428,7 @@ void main() {
 
     // Initialize a second analytics class, which simulates a second tool
     // which should correct the missing trailing new line character
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
       flutterChannel: 'ey-test-channel',
@@ -457,7 +457,7 @@ void main() {
     // Initialize a second analytics class for the same tool as
     // the first analytics instance except with a newer version for
     // the tools message and version
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -582,7 +582,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     //
     // This second instance should reset the config file when it goes
     // to increment the version in the file
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -605,7 +605,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // Creating a third instance after the second instance
     // has reset the config file should include the newly added
     // tool again with its incremented version number
-    final thirdAnalytics = Analytics.test(
+    final thirdAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -676,7 +676,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // Set the clock to the start value defined above
     withClock(Clock.fixed(start), () {
       // This class will be constructed at a fixed time
-      final secondAnalytics = Analytics.test(
+      final secondAnalytics = Analytics.fake(
         tool: secondTool,
         homeDirectory: home,
         flutterChannel: flutterChannel,
@@ -703,7 +703,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       // A new instance will need to be created since the second
       // instance in the previous block is scoped - this new instance
       // should not reset the files generated by the second instance
-      final thirdAnalytics = Analytics.test(
+      final thirdAnalytics = Analytics.fake(
         tool: secondTool,
         homeDirectory: home,
         flutterChannel: flutterChannel,
@@ -717,7 +717,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       thirdAnalytics.clientShowedMessage();
 
       // Calling the send event method will result in the session file
-      // getting updated but because we use the `Analytics.test()` constructor
+      // getting updated but because we use the `Analytics.fake()` constructor
       // no events will be sent
       thirdAnalytics.send(testEvent);
 
@@ -745,7 +745,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // Set the clock to the start value defined above
     withClock(Clock.fixed(start), () {
       // This class will be constructed at a fixed time
-      final secondAnalytics = Analytics.test(
+      final secondAnalytics = Analytics.fake(
         tool: secondTool,
         homeDirectory: home,
         flutterChannel: flutterChannel,
@@ -776,7 +776,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       // A new instance will need to be created since the second
       // instance in the previous block is scoped - this new instance
       // should not reset the files generated by the second instance
-      final thirdAnalytics = Analytics.test(
+      final thirdAnalytics = Analytics.fake(
         tool: secondTool,
         homeDirectory: home,
         flutterChannel: flutterChannel,
@@ -790,7 +790,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       thirdAnalytics.clientShowedMessage();
 
       // Calling the send event method will result in the session file
-      // getting updated but because we use the `Analytics.test()` constructor
+      // getting updated but because we use the `Analytics.fake()` constructor
       // no events will be sent
       thirdAnalytics.send(testEvent);
 
@@ -925,7 +925,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // run for a given tool
     Analytics? secondAnalytics;
     for (var i = 0; i < 2; i++) {
-      secondAnalytics = Analytics.test(
+      secondAnalytics = Analytics.fake(
         tool: secondTool,
         homeDirectory: home,
         flutterChannel: flutterChannel,
@@ -1030,7 +1030,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // run for a given tool
     Analytics? secondAnalytics;
     for (var i = 0; i < 2; i++) {
-      secondAnalytics = Analytics.test(
+      secondAnalytics = Analytics.fake(
         tool: secondTool,
         homeDirectory: home,
         // flutterChannel: flutterChannel,  THIS NEEDS TO REMAIN REMOVED
@@ -1179,7 +1179,7 @@ Privacy Policy (https://policies.google.com/privacy).
   test('Consent message is formatted correctly for any tool other than flutter',
       () {
     // Create a new instance of the analytics class with the new tool
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
       flutterChannel: 'ey-test-channel',

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -13,7 +13,7 @@ import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
-  late FileSystem fs;
+  late MemoryFileSystem fs;
   late Directory home;
   late Directory dartToolDirectory;
   late File clientIdFile;
@@ -58,7 +58,7 @@ void main() {
   });
 
   test('Confirm workflow for first run', () {
-    final firstAnalytics = Analytics.test(
+    final firstAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -93,7 +93,7 @@ void main() {
               'to send any events, even if the user accepts');
     }
 
-    final firstAnalytics = Analytics.test(
+    final firstAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -108,7 +108,7 @@ void main() {
     checkAnalyticsInstance(firstAnalytics);
 
     // Instance where we increment the version of the message
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -125,7 +125,7 @@ void main() {
     checkAnalyticsInstance(secondAnalytics);
 
     // Instance for a different tool with the incremented version
-    final thirdAnalytics = Analytics.test(
+    final thirdAnalytics = Analytics.fake(
       tool: secondTool, // Different tool
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -143,7 +143,7 @@ void main() {
   });
 
   test('Confirm workflow for checking tools into the config file', () {
-    final firstAnalytics = Analytics.test(
+    final firstAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -198,7 +198,7 @@ void main() {
 
     // Creating a second analytics instance from the same tool now should
     // allow for events to be sent
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -229,7 +229,7 @@ void main() {
 
     // Delete the log file to reset the counter of events sent
     logFile.deleteSync();
-    final thirdAnalytics = Analytics.test(
+    final thirdAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -258,7 +258,7 @@ void main() {
 
     // The fourth instance of the analytics class with the consent message
     // version incremented should now be able to send messages
-    final fourthAnalytics = Analytics.test(
+    final fourthAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -282,7 +282,7 @@ void main() {
   });
 
   test('Disable second instance if first one did not show message', () {
-    final firstAnalytics = Analytics.test(
+    final firstAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -296,7 +296,7 @@ void main() {
 
     expect(firstAnalytics.shouldShowMessage, true);
 
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -312,7 +312,7 @@ void main() {
 
     secondAnalytics.clientShowedMessage();
 
-    final thirdAnalytics = Analytics.test(
+    final thirdAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -329,7 +329,7 @@ void main() {
 
   test('Passing large version number gets logged in config', () {
     final firstVersion = toolsMessageVersion + 3;
-    final secondAnalytics = Analytics.test(
+    final secondAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,
@@ -351,7 +351,7 @@ void main() {
     // Create a new instane of the secondTool with an even
     // bigger version
     final secondVersion = firstVersion + 3;
-    final thirdAnalytics = Analytics.test(
+    final thirdAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
       flutterChannel: flutterChannel,


### PR DESCRIPTION
This PR swaps out the `Analytics.test` factory constructor for static method `Analytics.fake`. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
