### PR TITLE
Patch tests for unified_analytics 5.8.8+2 fixes

### DIFF
--- a/.github/workflows/cli_config.yml
+++ b/.github/workflows/cli_config.yml
@@ -3,7 +3,6 @@ permissions: read-all
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - ".github/workflows/cli_config.yml"
       - "pkgs/cli_config/**"

--- a/.github/workflows/cli_config.yml
+++ b/.github/workflows/cli_config.yml
@@ -3,6 +3,7 @@ permissions: read-all
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - ".github/workflows/cli_config.yml"
       - "pkgs/cli_config/**"

--- a/.github/workflows/unified_analytics.yml
+++ b/.github/workflows/unified_analytics.yml
@@ -3,7 +3,6 @@ permissions: read-all
 
 on:
   pull_request:
-    branches: [ main ]
     paths:
       - '.github/workflows/unified_analytics.yml'
       - 'pkgs/unified_analytics/**'

--- a/pkgs/unified_analytics/test/log_handler_test.dart
+++ b/pkgs/unified_analytics/test/log_handler_test.dart
@@ -12,6 +12,7 @@ import 'package:test/test.dart';
 
 import 'package:unified_analytics/src/constants.dart';
 import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/src/error_handler.dart';
 import 'package:unified_analytics/src/log_handler.dart';
 import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -207,19 +208,20 @@ void main() {
   test(
       'Catches and discards any FileSystemException raised from attempting '
       'to write to the log file', () async {
-    final logFilePath = 'log.txt';
     final fs = MemoryFileSystem.test(opHandle: (context, operation) {
-      if (context == logFilePath && operation == FileSystemOp.write) {
+      if (context.endsWith(kLogFileName) && operation == FileSystemOp.write) {
         throw FileSystemException(
           'writeFrom failed',
-          logFilePath,
+          context,
           const OSError('No space left on device', 28),
         );
       }
     });
-    final logFile = fs.file(logFilePath);
-    logFile.createSync();
-    final logHandler = LogHandler(logFile: logFile);
+    final logHandler = LogHandler(
+      fs: fs,
+      homeDirectory: fs.currentDirectory,
+      errorHandler: ErrorHandler(sendFunction: (_) {}),
+    );
 
     logHandler.save(data: {});
   });
@@ -228,7 +230,13 @@ void main() {
     var deletedLargeLogFile = false;
     var wroteDataToLogFile = false;
     const data = <String, Object?>{};
-    final logFile = _FakeFile('log.txt')
+
+    final logHandler = LogHandler(
+      fs: fs,
+      homeDirectory: fs.currentDirectory,
+      errorHandler: ErrorHandler(sendFunction: (_) {}),
+    );
+    logHandler.logFile = _FakeFile('log.txt')
       .._deleteSyncImpl = (() => deletedLargeLogFile = true)
       .._createSyncImpl = () {}
       .._statSyncImpl = (() => _FakeFileStat(kMaxLogFileSize + 1))
@@ -237,7 +245,6 @@ void main() {
         expect(mode, FileMode.writeOnlyAppend);
         wroteDataToLogFile = true;
       };
-    final logHandler = LogHandler(logFile: logFile);
 
     logHandler.save(data: data);
     expect(deletedLargeLogFile, isTrue);
@@ -247,7 +254,7 @@ void main() {
   test('does not delete log file if smaller than kMaxLogFileSize', () async {
     var wroteDataToLogFile = false;
     const data = <String, Object?>{};
-    final logFile = _FakeFile('log.txt')
+    final fakeLogFile = _FakeFile('log.txt')
       .._deleteSyncImpl =
           (() => fail('called logFile.deleteSync() when file was less than '
               'kMaxLogFileSize'))
@@ -259,7 +266,12 @@ void main() {
         expect(mode, FileMode.writeOnlyAppend);
         wroteDataToLogFile = true;
       };
-    final logHandler = LogHandler(logFile: logFile);
+    final logHandler = LogHandler(
+      fs: fs,
+      homeDirectory: fs.currentDirectory,
+      errorHandler: ErrorHandler(sendFunction: (_) {}),
+    );
+    logHandler.logFile = fakeLogFile;
 
     logHandler.save(data: data);
     expect(wroteDataToLogFile, isTrue);


### PR DESCRIPTION
This is a follow-up to https://github.com/dart-lang/tools/pull/280. Basically, that PR cherry-picked some fixes from main (unified_analytics v6) to a new branch meant to eventually be published as unified_analytics v5.8.8+2. However, since there were some API changes in v6, the tests didn't work (I already remembered to verify the tests right after I merged 😛).

This PR patches these tests. It makes `LogHandler::logFile` writable via a `@visibleForTestingOnly` setter, which I think is okay for patching an old major version.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
