### PR TITLE
Remove dependency on `package:intl`

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.4-wip
+
+- Fix formatting and remove dependency on `package:intl`.
+
 ## 6.1.3
 
 - Require Dart 3.4.

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -8,7 +8,6 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:file/memory.dart';
 import 'package:http/http.dart';
-import 'package:intl/date_symbol_data_local.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
@@ -436,10 +435,6 @@ class AnalyticsImpl implements Analytics {
             kLogFileName,
           )),
         ) {
-    // Initialize date formatting for `package:intl` within constructor
-    // so clients using this package won't need to
-    initializeDateFormatting();
-
     // This initializer class will let the instance know
     // if it was the first run; if it is, nothing will be sent
     // on the first run

--- a/pkgs/unified_analytics/lib/src/config_handler.dart
+++ b/pkgs/unified_analytics/lib/src/config_handler.dart
@@ -5,8 +5,8 @@
 import 'dart:convert';
 
 import 'package:clock/clock.dart';
+import 'package:convert/convert.dart';
 import 'package:file/file.dart';
-import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 
 import 'constants.dart';
@@ -226,7 +226,7 @@ class ToolInfo {
   @override
   String toString() {
     return json.encode(<String, Object?>{
-      'lastRun': DateFormat('yyyy-MM-dd').format(lastRun),
+      'lastRun': FixedDateTimeFormatter('YYYY-MM-DD').encode(lastRun),
       'versionNumber': versionNumber,
     });
   }

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '6.1.3';
+const String kPackageVersion = '6.1.4-wip';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -7,8 +7,8 @@ import 'dart:io' as io;
 import 'dart:math' show Random;
 
 import 'package:clock/clock.dart';
+import 'package:convert/convert.dart';
 import 'package:file/file.dart';
-import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 
 import 'enums.dart';
@@ -21,7 +21,7 @@ import 'user_property.dart';
 /// yyyy-MM-dd (2023-01-09)
 /// ```
 String get dateStamp {
-  return DateFormat('yyyy-MM-dd').format(clock.now());
+  return FixedDateTimeFormatter('YYYY-MM-DD').encode(clock.now());
 }
 
 /// Reads in a directory and returns `true` if write permissions are enabled.

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 
 dependencies:
   clock: ^1.1.1
+  convert: ^3.1.1
   file: '>=6.1.4 <8.0.0'
   http: '>=0.13.5 <2.0.0'
-  intl: '>=0.18.0 <0.20.0'
   meta: ^1.9.0
   path: ^1.8.0
 

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   to Google Analytics.
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 6.1.3
+version: 6.1.4-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -2,9 +2,11 @@ name: unified_analytics
 description: >-
   A package for logging analytics for all Dart and Flutter related tooling
   to Google Analytics.
+# LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
 version: 6.1.4-wip
+# LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 
 environment:


### PR DESCRIPTION
As I assume the datetime strings need not be localized. If they should be, then ignore this PR, and we should change the documentation instead.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
