### PR TITLE
Fix doc comment references with backticks

### DIFF
--- a/pkgs/file/lib/src/interface/file_system.dart
+++ b/pkgs/file/lib/src/interface/file_system.dart
@@ -24,17 +24,17 @@ abstract class FileSystem {
 
   /// Returns a reference to a [Directory] at [path].
   ///
-  /// [path] can be either a [`String`], a [`Uri`], or a [`FileSystemEntity`].
+  /// [path] can be either a [String], a [Uri], or a [FileSystemEntity].
   Directory directory(dynamic path);
 
   /// Returns a reference to a [File] at [path].
   ///
-  /// [path] can be either a [`String`], a [`Uri`], or a [`FileSystemEntity`].
+  /// [path] can be either a [String], a [Uri], or a [FileSystemEntity].
   File file(dynamic path);
 
   /// Returns a reference to a [Link] at [path].
   ///
-  /// [path] can be either a [`String`], a [`Uri`], or a [`FileSystemEntity`].
+  /// [path] can be either a [String], a [Uri], or a [FileSystemEntity].
   Link link(dynamic path);
 
   /// An object for manipulating paths in this file system.


### PR DESCRIPTION
These backticks break the references.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
