### PR TITLE
feat: use XDG directories on Linux

### DIFF
--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -57,7 +57,7 @@ const String kContextualSurveyUrl =
 
 /// Name of the directory where all of the files necessary for this package
 /// will be located.
-const String kDartToolDirectoryName = '.dart-tool';
+const String kDartToolDirectoryName = 'dart-tool';
 
 /// The default time to wait before closing the http connection to allow for
 /// pending events to be sent.

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -73,14 +73,14 @@ DateTime createSessionFile({required File sessionFile}) {
 /// - Dismissed survey JSON file
 bool runInitialization({
   required Directory homeDirectory,
+  required Directory configDirectory,
+  required Directory dataDirectory,
 }) {
   var firstRun = false;
-  final dartToolDirectory =
-      homeDirectory.childDirectory(kDartToolDirectoryName);
 
   // When the config file doesn't exist, initialize it with the default tools
   // and the current date.
-  final configFile = dartToolDirectory.childFile(kConfigFileName);
+  final configFile = configDirectory.childFile(kConfigFileName);
   if (!configFile.existsSync()) {
     firstRun = true;
     createConfigFile(
@@ -90,26 +90,25 @@ bool runInitialization({
   }
 
   // Begin initialization checks for the client id.
-  final clientFile = dartToolDirectory.childFile(kClientIdFileName);
+  final clientFile = dataDirectory.childFile(kClientIdFileName);
   if (!clientFile.existsSync()) {
     createClientIdFile(clientIdFile: clientFile);
   }
 
   // Begin initialization checks for the session file.
-  final sessionFile = dartToolDirectory.childFile(kSessionFileName);
+  final sessionFile = dataDirectory.childFile(kSessionFileName);
   if (!sessionFile.existsSync()) {
     createSessionFile(sessionFile: sessionFile);
   }
 
   // Begin initialization checks for the log file to persist events locally.
-  final logFile = dartToolDirectory.childFile(kLogFileName);
+  final logFile = dataDirectory.childFile(kLogFileName);
   if (!logFile.existsSync()) {
     createLogFile(logFile: logFile);
   }
 
   // Begin initialization checks for the dismissed survey file.
-  final dismissedSurveyFile =
-      dartToolDirectory.childFile(kDismissedSurveyFileName);
+  final dismissedSurveyFile = dataDirectory.childFile(kDismissedSurveyFileName);
   if (!dismissedSurveyFile.existsSync()) {
     createDismissedSurveyFile(dismissedSurveyFile: dismissedSurveyFile);
   }

--- a/pkgs/unified_analytics/test/error_handler_test.dart
+++ b/pkgs/unified_analytics/test/error_handler_test.dart
@@ -10,11 +10,14 @@ import 'package:test/test.dart';
 
 import 'package:unified_analytics/src/constants.dart';
 import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
   late MemoryFileSystem fs;
   late Directory home;
+  late Directory dataDirectory;
+  late Directory configDirectory;
   late FakeAnalytics initializationAnalytics;
   late FakeAnalytics analytics;
   late File sessionFile;
@@ -38,12 +41,15 @@ void main() {
         io.Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
     fs = MemoryFileSystem.test(style: fsStyle);
     home = fs.directory(homeDirName);
+    (dataDirectory, configDirectory) = getToolDirectories(fs)!;
 
     // This is the first analytics instance that will be used to demonstrate
     // that events will not be sent with the first run of analytics
     initializationAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -64,6 +70,8 @@ void main() {
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -76,10 +84,8 @@ void main() {
     analytics.clientShowedMessage();
 
     // The files that should have been generated that will be used for tests
-    sessionFile =
-        home.childDirectory(kDartToolDirectoryName).childFile(kSessionFileName);
-    logFile =
-        home.childDirectory(kDartToolDirectoryName).childFile(kLogFileName);
+    sessionFile = dataDirectory.childFile(kSessionFileName);
+    logFile = dataDirectory.childFile(kLogFileName);
   });
 
   group('Session handler:', () {
@@ -96,6 +102,8 @@ void main() {
       final secondAnalytics = Analytics.fake(
         tool: initialTool,
         homeDirectory: home,
+        dataDirectory: dataDirectory,
+        configDirectory: configDirectory,
         flutterChannel: flutterChannel,
         toolsMessageVersion: toolsMessageVersion,
         toolsMessage: toolsMessage,

--- a/pkgs/unified_analytics/test/events_with_fake_test.dart
+++ b/pkgs/unified_analytics/test/events_with_fake_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'package:unified_analytics/src/constants.dart';
 import 'package:unified_analytics/src/enums.dart';
 import 'package:unified_analytics/src/survey_handler.dart';
+import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
@@ -19,6 +20,8 @@ void main() {
   late FakeAnalytics fakeAnalytics;
   late MemoryFileSystem fs;
   late Directory homeDirectory;
+  late Directory dataDirectory;
+  late Directory configDirectory;
   late File dismissedSurveyFile;
 
   /// Survey to load into the fake instance to fetch
@@ -51,13 +54,14 @@ void main() {
   setUp(() async {
     fs = MemoryFileSystem.test(style: FileSystemStyle.posix);
     homeDirectory = fs.directory('home');
-    dismissedSurveyFile = homeDirectory
-        .childDirectory(kDartToolDirectoryName)
-        .childFile(kDismissedSurveyFileName);
+    (dataDirectory, configDirectory) = getToolDirectories(fs)!;
+    dismissedSurveyFile = dataDirectory.childFile(kDismissedSurveyFileName);
 
     final initialAnalytics = Analytics.fake(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       dartVersion: 'dartVersion',
       toolsMessageVersion: 1,
       fs: fs,
@@ -72,6 +76,8 @@ void main() {
       fakeAnalytics = Analytics.fake(
         tool: DashTool.flutterTool,
         homeDirectory: homeDirectory,
+        dataDirectory: dataDirectory,
+        configDirectory: configDirectory,
         dartVersion: 'dartVersion',
         platform: DevicePlatform.macos,
         fs: fs,

--- a/pkgs/unified_analytics/test/legacy_analytics_test.dart
+++ b/pkgs/unified_analytics/test/legacy_analytics_test.dart
@@ -9,11 +9,14 @@ import 'package:file/memory.dart';
 import 'package:test/test.dart';
 
 import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
   late MemoryFileSystem fs;
   late Directory home;
+  late Directory dataDirectory;
+  late Directory configDirectory;
   late Analytics analytics;
 
   const homeDirName = 'home';
@@ -31,6 +34,7 @@ void main() {
         io.Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
     fs = MemoryFileSystem.test(style: fsStyle);
     home = fs.directory(homeDirName);
+    (dataDirectory, configDirectory) = getToolDirectories(fs)!;
   });
 
   test('Honor legacy dart analytics opt out', () {
@@ -52,6 +56,8 @@ void main() {
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -83,6 +89,8 @@ void main() {
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -113,6 +121,8 @@ void main() {
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -143,6 +153,8 @@ void main() {
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -177,6 +189,8 @@ void main() {
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -211,6 +225,8 @@ void main() {
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -243,6 +259,8 @@ NOT VALID JSON
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -279,6 +297,8 @@ NOT VALID JSON
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -311,6 +331,8 @@ NOT VALID JSON
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,

--- a/pkgs/unified_analytics/test/log_handler_test.dart
+++ b/pkgs/unified_analytics/test/log_handler_test.dart
@@ -18,6 +18,8 @@ import 'package:unified_analytics/unified_analytics.dart';
 void main() {
   late FakeAnalytics analytics;
   late Directory homeDirectory;
+  late Directory dataDirectory;
+  late Directory configDirectory;
   late MemoryFileSystem fs;
   late File logFile;
 
@@ -26,14 +28,15 @@ void main() {
   setUp(() {
     fs = MemoryFileSystem.test(style: FileSystemStyle.posix);
     homeDirectory = fs.directory('home');
-    logFile = homeDirectory
-        .childDirectory(kDartToolDirectoryName)
-        .childFile(kLogFileName);
+    (dataDirectory, configDirectory) = getToolDirectories(fs)!;
+    logFile = dataDirectory.childFile(kLogFileName);
 
     // Create the initialization analytics instance to onboard the tool
     final initializationAnalytics = Analytics.fake(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       dartVersion: 'dartVersion',
       fs: fs,
       platform: DevicePlatform.macos,
@@ -45,6 +48,8 @@ void main() {
     analytics = Analytics.fake(
       tool: DashTool.flutterTool,
       homeDirectory: homeDirectory,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       dartVersion: 'dartVersion',
       fs: fs,
       platform: DevicePlatform.macos,

--- a/pkgs/unified_analytics/test/suppression_test.dart
+++ b/pkgs/unified_analytics/test/suppression_test.dart
@@ -8,11 +8,14 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:test/test.dart';
 import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 void main() {
   late MemoryFileSystem fs;
   late Directory home;
+  late Directory dataDirectory;
+  late Directory configDirectory;
   late Analytics initializationAnalytics;
   late Analytics analytics;
 
@@ -33,12 +36,15 @@ void main() {
         io.Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
     fs = MemoryFileSystem.test(style: fsStyle);
     home = fs.directory(homeDirName);
+    (dataDirectory, configDirectory) = getToolDirectories(fs)!;
 
     // This is the first analytics instance that will be used to demonstrate
     // that events will not be sent with the first run of analytics
     initializationAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -57,6 +63,8 @@ void main() {
     analytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -91,6 +99,8 @@ void main() {
     final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,

--- a/pkgs/unified_analytics/test/survey_handler_test.dart
+++ b/pkgs/unified_analytics/test/survey_handler_test.dart
@@ -262,6 +262,8 @@ void main() {
   group('Testing with FakeSurveyHandler', () {
     late Analytics analytics;
     late Directory homeDirectory;
+    late Directory dataDirectory;
+    late Directory configDirectory;
     late MemoryFileSystem fs;
     late File clientIdFile;
     late File dismissedSurveyFile;
@@ -269,20 +271,17 @@ void main() {
     setUp(() {
       fs = MemoryFileSystem.test(style: FileSystemStyle.posix);
       homeDirectory = fs.directory('home');
+      (dataDirectory, configDirectory) = getToolDirectories(fs)!;
 
       // Write the client ID file out so that we don't get
       // a randomly assigned id for this test generated within
       // the analytics constructor
-      clientIdFile = homeDirectory
-          .childDirectory(kDartToolDirectoryName)
-          .childFile(kClientIdFileName);
+      clientIdFile = dataDirectory.childFile(kClientIdFileName);
       clientIdFile.createSync(recursive: true);
       clientIdFile.writeAsStringSync('string1');
 
       // Assign the json file that will hold the persisted surveys
-      dismissedSurveyFile = homeDirectory
-          .childDirectory(kDartToolDirectoryName)
-          .childFile(kDismissedSurveyFileName);
+      dismissedSurveyFile = dataDirectory.childFile(kDismissedSurveyFileName);
 
       // Setup two tools to be onboarded with this package so
       // that we can simulate two different tools interacting with
@@ -293,6 +292,8 @@ void main() {
       final initialAnalyticsFlutter = Analytics.fake(
         tool: DashTool.flutterTool,
         homeDirectory: homeDirectory,
+        dataDirectory: dataDirectory,
+        configDirectory: configDirectory,
         dartVersion: 'dartVersion',
         fs: fs,
         platform: DevicePlatform.macos,
@@ -300,6 +301,8 @@ void main() {
       final initialAnalyticsDart = Analytics.fake(
         tool: DashTool.dartTool,
         homeDirectory: homeDirectory,
+        dataDirectory: dataDirectory,
+        configDirectory: configDirectory,
         dartVersion: 'dartVersion',
         fs: fs,
         platform: DevicePlatform.macos,
@@ -313,6 +316,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -364,6 +369,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -404,6 +411,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -447,6 +456,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -547,6 +558,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -609,6 +622,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -690,6 +705,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -764,6 +781,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -807,6 +826,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -852,6 +873,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -879,6 +902,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -898,6 +923,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -942,6 +969,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -968,6 +997,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1014,6 +1045,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1044,6 +1077,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1090,6 +1125,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1117,6 +1154,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1139,6 +1178,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,
@@ -1184,6 +1225,8 @@ void main() {
         analytics = Analytics.fake(
           tool: DashTool.flutterTool,
           homeDirectory: homeDirectory,
+          dataDirectory: dataDirectory,
+          configDirectory: configDirectory,
           dartVersion: 'dartVersion',
           fs: fs,
           platform: DevicePlatform.macos,

--- a/pkgs/unified_analytics/test/workflow_test.dart
+++ b/pkgs/unified_analytics/test/workflow_test.dart
@@ -15,7 +15,8 @@ import 'package:unified_analytics/unified_analytics.dart';
 void main() {
   late MemoryFileSystem fs;
   late Directory home;
-  late Directory dartToolDirectory;
+  late Directory dataDirectory;
+  late Directory configDirectory;
   late File clientIdFile;
   late File sessionFile;
   late File configFile;
@@ -40,27 +41,22 @@ void main() {
         io.Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
     fs = MemoryFileSystem.test(style: fsStyle);
     home = fs.directory(homeDirName);
-    dartToolDirectory = home.childDirectory(kDartToolDirectoryName);
+    (dataDirectory, configDirectory) = getToolDirectories(fs)!;
 
-    // The 3 files that should have been generated
-    clientIdFile = home
-        .childDirectory(kDartToolDirectoryName)
-        .childFile(kClientIdFileName);
-    sessionFile =
-        home.childDirectory(kDartToolDirectoryName).childFile(kSessionFileName);
-    configFile =
-        home.childDirectory(kDartToolDirectoryName).childFile(kConfigFileName);
-    logFile =
-        home.childDirectory(kDartToolDirectoryName).childFile(kLogFileName);
-    dismissedSurveyFile = home
-        .childDirectory(kDartToolDirectoryName)
-        .childFile(kDismissedSurveyFileName);
+    // The 5 files that should have been generated
+    clientIdFile = dataDirectory.childFile(kClientIdFileName);
+    sessionFile = dataDirectory.childFile(kSessionFileName);
+    configFile = configDirectory.childFile(kConfigFileName);
+    logFile = dataDirectory.childFile(kLogFileName);
+    dismissedSurveyFile = dataDirectory.childFile(kDismissedSurveyFileName);
   });
 
   test('Confirm workflow for first run', () {
     final firstAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -96,6 +92,8 @@ void main() {
     final firstAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -111,6 +109,8 @@ void main() {
     final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
@@ -128,6 +128,8 @@ void main() {
     final thirdAnalytics = Analytics.fake(
       tool: secondTool, // Different tool
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
@@ -146,6 +148,8 @@ void main() {
     final firstAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -157,7 +161,9 @@ void main() {
 
     // Host of assertions to ensure all required artifacts
     // are created
-    expect(dartToolDirectory.existsSync(), true,
+    expect(dataDirectory.existsSync(), true,
+        reason: 'The directory should have been created');
+    expect(configDirectory.existsSync(), true,
         reason: 'The directory should have been created');
     expect(clientIdFile.existsSync(), true,
         reason: 'The $kClientIdFileName file was not found');
@@ -170,10 +176,14 @@ void main() {
     expect(dismissedSurveyFile.existsSync(), true,
         reason: 'The $dismissedSurveyFile file was not found');
     expect(
-      dartToolDirectory.listSync().length,
-      equals(5),
-      reason: 'There should only be 5 files in the $kDartToolDirectoryName '
-          'directory',
+      dataDirectory.listSync().length,
+      equals(4),
+      reason: 'There should only be 4 files in the data directory',
+    );
+    expect(
+      configDirectory.listSync().length,
+      equals(1),
+      reason: 'There should only be 1 file in the config directory',
     );
     expect(configFile.readAsStringSync(), kConfigString);
 
@@ -201,6 +211,8 @@ void main() {
     final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -232,6 +244,8 @@ void main() {
     final thirdAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
@@ -261,6 +275,8 @@ void main() {
     final fourthAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion + 1, // Incrementing version
       toolsMessage: toolsMessage,
@@ -285,6 +301,8 @@ void main() {
     final firstAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -299,6 +317,8 @@ void main() {
     final secondAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -315,6 +335,8 @@ void main() {
     final thirdAnalytics = Analytics.fake(
       tool: initialTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
@@ -332,6 +354,8 @@ void main() {
     final secondAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: firstVersion,
       toolsMessage: toolsMessage,
@@ -354,6 +378,8 @@ void main() {
     final thirdAnalytics = Analytics.fake(
       tool: secondTool,
       homeDirectory: home,
+      dataDirectory: dataDirectory,
+      configDirectory: configDirectory,
       flutterChannel: flutterChannel,
       toolsMessageVersion: secondVersion,
       toolsMessage: toolsMessage,


### PR DESCRIPTION
This removes the need for the `~/.dart_tool` directory in user's HOME. It moves the config file to `$XDG_CONFIG_HOME/dart_tool`, and all other data to `$XDG_DATA_HOME/dart_tool`. If the old directory exists but the new one doesn't, the old location is used as a fallback. Otherwise, the new directories are created.

See https://github.com/dart-lang/sdk/issues/41560 (this doesn't fully solve the issue, but it does get rid of one of the offending directories)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
