### PR TITLE
[coverage] Fix isolate resumption after service disposal

### DIFF
--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 1.11.0
+
+- Fix a [bug](https://github.com/dart-lang/tools/issues/685) where the tool
+  would occasionally try to resume an isolate after the VM service had been
+  disposed.
+
 ## 1.10.0
 
-- Fix bug where tests involving multiple isolates never finish (#520).
+- Fix a [bug](https://github.com/dart-lang/tools/issues/520) where tests
+  involving multiple isolates never finish.
 
 ## 1.9.2
 

--- a/pkgs/coverage/lib/src/isolate_paused_listener.dart
+++ b/pkgs/coverage/lib/src/isolate_paused_listener.dart
@@ -46,7 +46,8 @@ class IsolatePausedListener {
     try {
       if (_mainIsolate != null) {
         if (await _mainIsolatePaused.future) {
-          await _runCallbackAndResume(_mainIsolate!, true);
+          await _runCallbackAndResume(
+              _mainIsolate!, !_getGroup(_mainIsolate!).collected);
         }
       }
     } finally {
@@ -114,8 +115,13 @@ class IsolatePausedListener {
     }
   }
 
+  bool get _mainRunning =>
+      _mainIsolate != null && !_mainIsolatePaused.isCompleted;
+
   void _checkCompleted() {
-    if (_numNonMainIsolates == 0 && !_allNonMainIsolatesExited.isCompleted) {
+    if (_numNonMainIsolates == 0 &&
+        !_mainRunning &&
+        !_allNonMainIsolatesExited.isCompleted) {
       _allNonMainIsolatesExited.complete();
     }
   }

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.10.0
+version: 1.11.0
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 

--- a/pkgs/coverage/test/isolate_paused_listener_test.dart
+++ b/pkgs/coverage/test/isolate_paused_listener_test.dart
@@ -700,6 +700,68 @@ void main() {
       ]);
     });
 
+    test(
+        'all other isolates exit before main isolate pauses, then main '
+        'starts another isolate, then pauses before they exit', () async {
+      startEvent('A', '1', 'main');
+      startEvent('B', '1');
+      pauseEvent('B', '1');
+      exitEvent('B', '1');
+
+      await Future<void>.delayed(Duration.zero);
+
+      startEvent('C', '1');
+      pauseEvent('C', '1');
+      pauseEvent('A', '1', 'main');
+      exitEvent('C', '1');
+
+      await Future<void>.delayed(Duration.zero);
+
+      exitEvent('A', '1', 'main');
+
+      await endTest();
+
+      expect(received, [
+        'Pause B. Last in group 1? No',
+        'Resume B',
+        'Pause C. Last in group 1? No',
+        'Resume C',
+        'Pause A. Last in group 1? Yes',
+        'Resume A',
+      ]);
+    });
+
+    test(
+        'all other isolates exit before main isolate pauses, then main '
+        'starts another isolate, then pauses before they pause', () async {
+      startEvent('A', '1', 'main');
+      startEvent('B', '1');
+      pauseEvent('B', '1');
+      exitEvent('B', '1');
+
+      await Future<void>.delayed(Duration.zero);
+
+      startEvent('C', '1');
+      pauseEvent('A', '1', 'main');
+      pauseEvent('C', '1');
+      exitEvent('C', '1');
+
+      await Future<void>.delayed(Duration.zero);
+
+      exitEvent('A', '1', 'main');
+
+      await endTest();
+
+      expect(received, [
+        'Pause B. Last in group 1? No',
+        'Resume B',
+        'Pause C. Last in group 1? Yes',
+        'Resume C',
+        'Pause A. Last in group 1? No',
+        'Resume A',
+      ]);
+    });
+
     test('group reopened', () async {
       // If an isolate is reported in a group after the group as believed to be
       // closed, reopen the group. This double counts some coverage, but at


### PR DESCRIPTION
The sequence of events that reproduces the bug is:

1. Main isolate starts
2. Main isolate spawns other isolates
3. Other isolates pause, are collected, and exit
4. `IsolatePausedListener._allNonMainIsolatesExited` is completed, so `IsolatePausedListener.waitUntilAllExited` starts waiting on `IsolatePausedListener._mainIsolatePaused`.
5. Main isolate spawns more isolates
6. Main isolate pauses
7. `IsolatePausedListener._mainIsolatePaused` is completed, so `IsolatePausedListener.waitUntilAllExited` collects and resumes the main isolate
8. The main isolate has exited, so the VM shuts down, and the VM service connection is disposed
10. The remaining isolates pause, so `IsolatePausedListener` tries to collect and resume them, causing the exception seen in the bug.
 
Step 5 is the bit I didn't consider when writing the new flow. The fix is just to make `_allNonMainIsolatesExited` wait for main to pause (logically this future is now `_allNonMainIsolatesExitedAndMainIsolatePaused`, but that's a bit verbose).

Details:

- We're already calling `_checkCompleted()` when main is paused (to fix a different edge case), so we're still going to complete the `_allNonMainIsolatesExited` future even if all the non-main isolates exit before main pauses.
- In some sequences (see test), the other isolates in main's group are collected before main, so main's `_runCallbackAndResume()` call now has to check if main's group has already been collected.

Fixes #685