### PR TITLE
Remove any `data` entries with a null value in the `Event.exception` constructor.

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.5
+- Remove any `data` entries with a null value in the `Event.exception` constructor.
+
 ## 6.1.4
 
 - Fix formatting and remove dependency on `package:intl`.

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '6.1.4';
+const String kPackageVersion = '6.1.5';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -496,7 +496,7 @@ final class Event {
   })  : eventName = DashEvent.exception,
         eventData = {
           'exception': exception,
-          ...data,
+          ...data..removeWhere((key, value) => value == null),
         };
 
   /// Event that is emitted from the flutter tool when a build invocation

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 6.1.4
+version: 6.1.5
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -430,7 +430,7 @@ void main() {
   test('Event.exception constructed', () {
     Event generateEvent() => Event.exception(
           exception: 'exception',
-          data: {'foo': 'bar', 'baz': 1},
+          data: {'foo': 'bar', 'baz': 1, 'shouldBeRemoved': null},
         );
 
     final constructedEvent = generateEvent();


### PR DESCRIPTION
This was preventing data from getting sent properly to analytics.