### PR TITLE
Support newInstanceNamed with empty name

### DIFF
--- a/pkgs/code_builder/CHANGELOG.md
+++ b/pkgs/code_builder/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Upgrade `dart_style` and `source_gen` to remove `package:macros` dependency.
 * Require Dart `^3.6.0` due to the upgrades.
+* Support `Expression.newInstanceNamed` with empty name
 
 ## 4.10.1
 

--- a/pkgs/code_builder/lib/src/specs/expression.dart
+++ b/pkgs/code_builder/lib/src/specs/expression.dart
@@ -578,7 +578,7 @@ abstract mixin class ExpressionEmitter
     final out = output ??= StringBuffer();
     return _writeConstExpression(out, expression.isConst, () {
       expression.target.accept(this, out);
-      if (expression.name != null) {
+      if (expression.name case final name? when name.isNotEmpty) {
         out
           ..write('.')
           ..write(expression.name);

--- a/pkgs/code_builder/lib/src/specs/expression.dart
+++ b/pkgs/code_builder/lib/src/specs/expression.dart
@@ -581,7 +581,7 @@ abstract mixin class ExpressionEmitter
       if (expression.name case final name? when name.isNotEmpty) {
         out
           ..write('.')
-          ..write(expression.name);
+          ..write(name);
       }
       if (expression.typeArguments.isNotEmpty) {
         out.write('<');

--- a/pkgs/code_builder/test/specs/code/expression_test.dart
+++ b/pkgs/code_builder/test/specs/code/expression_test.dart
@@ -251,6 +251,13 @@ void main() {
     );
   });
 
+  test('should emit invoking unnamed constructor when name is empty', () {
+    expect(
+      refer('Foo').newInstanceNamed('', []),
+      equalsDart('Foo()'),
+    );
+  });
+
   test('should emit invoking const Type()', () {
     expect(
       refer('Object').constInstance([]),


### PR DESCRIPTION
Copied from https://github.com/dart-archive/code_builder/pull/463 through the GitHub UI. I have not run tests locally.

--------------

Opts to rewrite `refer('Foo').newInstanceNamed('', [])` as `Foo` rather than `Foo.`. Two primary reasons

- `Foo.` breaks compilation with bad error messages
- [Analyzer's ConstructorElement#name](https://github.com/dart-lang/sdk/blob/e8939b0ff089a97297cf28626be46c3c75fe72e7/pkg/analyzer/lib/dart/element/element.dart#L466) is a non-nullable String, which pushes the `isEmpty` check to user code

--------------
[x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.