### PR TITLE
In the `Event.exception` constructor, modify a clone of the `args` argument instead of `args` itself

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.0.1
+- Fixed `UnsupportedError` thrown when Event.exception is called without providing a value for `args`.
+
 ## 7.0.0
 - Added a required parameter `screen` to the `Event.devtoolsEvent` constructor.
 - Added an optional parameter `additionalMetrics` to the `Event.devtoolsEvent` constructor.

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -26,7 +26,7 @@ const String kConfigString = '''
 # All other lines are configuration lines. They have
 # the form "name=value". If multiple lines contain
 # the same configuration name with different values,
-# the parser will default to a conservative value. 
+# the parser will default to a conservative value.
 
 # DISABLING TELEMETRY REPORTING
 #
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '7.0.0';
+const String kPackageVersion = '7.0.1';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -455,7 +455,7 @@ final class Event {
   })  : eventName = DashEvent.exception,
         eventData = {
           'exception': exception,
-          ...data..removeWhere((key, value) => value == null),
+          ...Map.from(data)..removeWhere((key, value) => value == null),
         };
 
   /// Event that is emitted from the flutter tool when a build invocation

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 7.0.0
+version: 7.0.1
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aunified_analytics

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -444,6 +444,14 @@ void main() {
     expect(constructedEvent.eventData.length, 3);
   });
 
+  test('Event.exception constructor works when no data is provided', () {
+    Event generateEvent() => Event.exception(
+          exception: 'exception',
+        );
+
+    expect(generateEvent, returnsNormally);
+  });
+
   test('Event.timing constructed', () {
     Event generateEvent() => Event.timing(
           workflow: 'workflow',


### PR DESCRIPTION
Fixes https://github.com/dart-lang/tools/issues/1195

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
