### PR TITLE
fix: keep micros in monthsAgo, monthsFromNow and yearsAgo

### DIFF
--- a/pkgs/clock/CHANGELOG.md
+++ b/pkgs/clock/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3-wip
+
+* Keep microseconds when using `monthsAgo`, `monthsFromNow` and `yearsAgo`
+
 ## 1.1.2
 
 * Require Dart 3.4

--- a/pkgs/clock/lib/src/clock.dart
+++ b/pkgs/clock/lib/src/clock.dart
@@ -139,7 +139,7 @@ class Clock {
     var year = time.year - (months + 12 - time.month) ~/ 12;
     var day = clampDayOfMonth(year: year, month: month, day: time.day);
     return DateTime(year, month, day, time.hour, time.minute, time.second,
-        time.millisecond);
+        time.millisecond, time.microsecond);
   }
 
   /// Return the point in time [months] from now on the same date.
@@ -152,7 +152,7 @@ class Clock {
     var year = time.year + (months + time.month - 1) ~/ 12;
     var day = clampDayOfMonth(year: year, month: month, day: time.day);
     return DateTime(year, month, day, time.hour, time.minute, time.second,
-        time.millisecond);
+        time.millisecond, time.microsecond);
   }
 
   /// Return the point in time [years] ago on the same date.
@@ -164,7 +164,7 @@ class Clock {
     var year = time.year - years;
     var day = clampDayOfMonth(year: year, month: time.month, day: time.day);
     return DateTime(year, time.month, day, time.hour, time.minute, time.second,
-        time.millisecond);
+        time.millisecond, time.microsecond);
   }
 
   /// Return the point in time [years] from now on the same date.

--- a/pkgs/clock/pubspec.yaml
+++ b/pkgs/clock/pubspec.yaml
@@ -1,5 +1,5 @@
 name: clock
-version: 1.1.2
+version: 1.1.3-wip
 description: A fakeable wrapper for dart:core clock APIs.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/clock
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aclock

--- a/pkgs/clock/test/clock_test.dart
+++ b/pkgs/clock/test/clock_test.dart
@@ -207,4 +207,22 @@ void main() {
     expect(clock.yearsFromNow(30), date(2043, 1, 1));
     expect(clock.yearsFromNow(1000), date(3013, 1, 1));
   });
+
+  group('micros', () {
+    test('should keep micros for monthsAgo', () {
+      expect(Clock.fixed(DateTime(2024, 2, 1, 0, 0, 0, 0, 123)).monthsAgo(1),
+          Clock.fixed(DateTime(2024, 1, 1, 0, 0, 0, 0, 123)).now());
+    });
+
+    test('should keep micros for monthsFromNow', () {
+      expect(
+          Clock.fixed(DateTime(2024, 2, 1, 0, 0, 0, 0, 123)).monthsFromNow(1),
+          Clock.fixed(DateTime(2024, 3, 1, 0, 0, 0, 0, 123)).now());
+    });
+
+    test('should keep micros for yearsAgo', () {
+      expect(Clock.fixed(DateTime(2024, 2, 1, 0, 0, 0, 0, 123)).yearsAgo(1),
+          Clock.fixed(DateTime(2023, 2, 1, 0, 0, 0, 0, 123)).now());
+    });
+  });
 }


### PR DESCRIPTION
- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

I ran into the issue that after calling `Clock.monthsAgo(...)` the `microSecond` field of my initial timestamp got lost (now was 0).
The field was simply not set in the code. I also found that `monthsFromNow` and `yearsAgo` had the same issue.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
