### PR TITLE
[source_span] Add a test covering the highlighting of non-contiguous spans

### DIFF
--- a/pkgs/source_span/test/multiple_highlight_test.dart
+++ b/pkgs/source_span/test/multiple_highlight_test.dart
@@ -44,6 +44,22 @@ gibble bibble bop
   '"""));
   });
 
+  test('highlights non contiguous spans', () {
+    expect(
+        file.span(17, 21).highlightMultiple(
+            'one', {file.span(60, 66): 'two', file.span(4, 7): 'three'}),
+        equals("""
+    ,
+1   | foo bar baz
+    |     === three
+2   | whiz bang boom
+    |      ^^^^ one
+... |
+5   | argle bargle boo
+    |       ====== two
+    '"""));
+  });
+
   test('highlights spans on the same line', () {
     expect(
         file.span(17, 21).highlightMultiple(


### PR DESCRIPTION
I ported this package to PHP as part of the [scssphp project](https://github.com/scssphp/) (as I'm porting dart-sass which uses this package). When collecting code coverage for the testsuite of my PHP port, I noticed that the code dealing with non-contiguous lines was not covered by the tests.
This PR adds a test covering this case.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
