### PR TITLE
Added `workspace:` and `resolution: fields`

### DIFF
--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0
+
+- Add `Pubspec.workspace` and `Pubspec.resolution` fields.
+
 ## 1.4.0
 
 - Require Dart 3.2
@@ -31,7 +35,7 @@
 - Added support for `screenshots` field.
 - Update `HostedDetails` to reflect how `hosted` dependencies are parsed in
   Dart 2.15:
-   - Add `HostedDetails.declaredName` as the (optional) `name` property in a 
+   - Add `HostedDetails.declaredName` as the (optional) `name` property in a
      `hosted` block.
    - `HostedDetails.name` now falls back to the name of the dependency if no
       name is declared in the block.

--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.5.0
+## 1.5.0-wip
 
 - Add `Pubspec.workspace` and `Pubspec.resolution` fields.
 

--- a/pkgs/pubspec_parse/lib/src/pubspec.dart
+++ b/pkgs/pubspec_parse/lib/src/pubspec.dart
@@ -93,6 +93,12 @@ class Pubspec {
   /// and other settings.
   final Map<String, dynamic>? flutter;
 
+  /// If this package is a Pub Workspace, this field lists the sub-packages.
+  final List<String>? workspace;
+
+  /// Specifies how to resolve dependencies with the surrounding Pub Workspace.
+  final String? resolution;
+
   /// If [author] and [authors] are both provided, their values are combined
   /// with duplicates eliminated.
   Pubspec(
@@ -117,6 +123,8 @@ class Pubspec {
     this.screenshots,
     this.documentation,
     this.description,
+    this.workspace,
+    this.resolution,
     Map<String, Dependency>? dependencies,
     Map<String, Dependency>? devDependencies,
     Map<String, Dependency>? dependencyOverrides,

--- a/pkgs/pubspec_parse/lib/src/pubspec.g.dart
+++ b/pkgs/pubspec_parse/lib/src/pubspec.g.dart
@@ -40,6 +40,9 @@ Pubspec _$PubspecFromJson(Map json) => $checkedCreate(
               'screenshots', (v) => parseScreenshots(v as List?)),
           documentation: $checkedConvert('documentation', (v) => v as String?),
           description: $checkedConvert('description', (v) => v as String?),
+          workspace: $checkedConvert('workspace',
+              (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
+          resolution: $checkedConvert('resolution', (v) => v as String?),
           dependencies:
               $checkedConvert('dependencies', (v) => parseDeps(v as Map?)),
           devDependencies:

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.4.0
+version: 1.5.0
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.
@@ -9,7 +9,7 @@ topics:
 - dart-pub
 
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.2.0
 
 dependencies:
   checked_yaml: ^2.0.1

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
 - dart-pub
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.6.0
 
 dependencies:
   checked_yaml: ^2.0.1

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.5.0
+version: 1.5.0-wip
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -63,7 +63,7 @@ void main() {
         'pkg2',
       ],
       'resolution': 'workspace',
-    });
+    }, skipTryPub: true);
     expect(value.name, 'sample');
     expect(value.version, version);
     expect(value.publishTo, 'none');

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -39,31 +39,34 @@ void main() {
   test('all fields set', () async {
     final version = Version.parse('1.2.3');
     final sdkConstraint = VersionConstraint.parse('>=3.6.0 <4.0.0');
-    final value = await parse({
-      'name': 'sample',
-      'version': version.toString(),
-      'publish_to': 'none',
-      'author': 'name@example.com',
-      'environment': {'sdk': sdkConstraint.toString()},
-      'description': 'description',
-      'homepage': 'homepage',
-      'documentation': 'documentation',
-      'repository': 'https://github.com/example/repo',
-      'issue_tracker': 'https://github.com/example/repo/issues',
-      'funding': [
-        'https://patreon.com/example',
-      ],
-      'topics': ['widget', 'button'],
-      'ignored_advisories': ['111', '222'],
-      'screenshots': [
-        {'description': 'my screenshot', 'path': 'path/to/screenshot'},
-      ],
-      'workspace': [
-        'pkg1',
-        'pkg2',
-      ],
-      'resolution': 'workspace',
-    }, skipTryPub: true);
+    final value = await parse(
+      {
+        'name': 'sample',
+        'version': version.toString(),
+        'publish_to': 'none',
+        'author': 'name@example.com',
+        'environment': {'sdk': sdkConstraint.toString()},
+        'description': 'description',
+        'homepage': 'homepage',
+        'documentation': 'documentation',
+        'repository': 'https://github.com/example/repo',
+        'issue_tracker': 'https://github.com/example/repo/issues',
+        'funding': [
+          'https://patreon.com/example',
+        ],
+        'topics': ['widget', 'button'],
+        'ignored_advisories': ['111', '222'],
+        'screenshots': [
+          {'description': 'my screenshot', 'path': 'path/to/screenshot'},
+        ],
+        'workspace': [
+          'pkg1',
+          'pkg2',
+        ],
+        'resolution': 'workspace',
+      },
+      skipTryPub: true,
+    );
     expect(value.name, 'sample');
     expect(value.version, version);
     expect(value.publishTo, 'none');

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -32,11 +32,13 @@ void main() {
     expect(value.repository, isNull);
     expect(value.issueTracker, isNull);
     expect(value.screenshots, isEmpty);
+    expect(value.workspace, isNull);
+    expect(value.resolution, isNull);
   });
 
   test('all fields set', () async {
     final version = Version.parse('1.2.3');
-    final sdkConstraint = VersionConstraint.parse('>=2.12.0 <3.0.0');
+    final sdkConstraint = VersionConstraint.parse('>=3.6.0 <4.0.0');
     final value = await parse({
       'name': 'sample',
       'version': version.toString(),
@@ -56,6 +58,11 @@ void main() {
       'screenshots': [
         {'description': 'my screenshot', 'path': 'path/to/screenshot'},
       ],
+      'workspace': [
+        'pkg1',
+        'pkg2',
+      ],
+      'resolution': 'workspace',
     });
     expect(value.name, 'sample');
     expect(value.version, version);
@@ -86,6 +93,10 @@ void main() {
     expect(value.screenshots, hasLength(1));
     expect(value.screenshots!.first.description, 'my screenshot');
     expect(value.screenshots!.first.path, 'path/to/screenshot');
+    expect(value.workspace, hasLength(2));
+    expect(value.workspace!.first, 'pkg1');
+    expect(value.workspace!.last, 'pkg2');
+    expect(value.resolution, 'workspace');
   });
 
   test('environment values can be null', () async {
@@ -709,6 +720,42 @@ line 1, column 1: Not a map
           lenient: true,
         ),
         throwsException,
+      );
+    });
+  });
+
+  group('workspaces', () {
+    test('workspace key must be a list', () {
+      expectParseThrowsContaining(
+        {
+          ...defaultPubspec,
+          'workspace': 42,
+        },
+        'Unsupported value for "workspace". type \'int\' is not a subtype of type \'List<dynamic>?\' in type cast',
+        skipTryPub: true,
+      );
+    });
+
+    test('workspace key must be a list of strings', () {
+      expectParseThrowsContaining(
+        {
+          ...defaultPubspec,
+          'workspace': [42],
+        },
+        'Unsupported value for "workspace". type \'int\' is not a subtype of type \'String\' in type cast',
+        skipTryPub: true,
+      );
+    });
+
+    test('resolution key must be a string', () {
+      expectParseThrowsContaining(
+        {
+          'name': 'sample',
+          'environment': {'sdk': '^3.6.0'},
+          'resolution': 42,
+        },
+        'Unsupported value for "resolution". type \'int\' is not a subtype of type \'String?\' in type cast',
+        skipTryPub: true,
       );
     });
   });


### PR DESCRIPTION
Fixes #1814 by adding `Pubspec.workspace` (`List<String>?`) and `Pubspec.resolution` (`String?`). Didn't bump the changelog or version yet because I didn't want to conflict with #1946 (@kevmoo?), but I can do that once it's merged (or rebase this onto that branch). 

Does not check that `dart: ^3.6.0`, leaving that up to [these lines in Pub](https://github.com/dart-lang/pub/blob/58de642dc1d07601f6eb2b4ecd94555c0210106b/lib/src/pubspec.dart#L110-L122). 

An omitted `resolution:` or `workspace` field is treated as null. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
