### PR TITLE
Expose ZoneSpecification parameters for package `stack_trace`

### DIFF
--- a/pkgs/stack_trace/lib/src/stack_zone_specification.dart
+++ b/pkgs/stack_trace/lib/src/stack_zone_specification.dart
@@ -61,16 +61,59 @@ class StackZoneSpecification {
   /// Whether this is an error zone.
   final bool _errorZone;
 
-  StackZoneSpecification(this._onError, {bool errorZone = true})
-      : _errorZone = errorZone;
+  /// A custom [Zone.run] implementation for a new zone.
+  final RunHandler? run;
+
+  /// A custom [Zone.runUnary] implementation for a new zone.
+  final RunUnaryHandler? runUnary;
+
+  /// A custom [Zone.runBinary] implementation for a new zone.
+  final RunBinaryHandler? runBinary;
+
+  /// A custom [Zone.scheduleMicrotask] implementation for a new zone.
+  final ScheduleMicrotaskHandler? scheduleMicrotask;
+
+  /// A custom [Zone.createTimer] implementation for a new zone.
+  final CreateTimerHandler? createTimer;
+
+  /// A custom [Zone.createPeriodicTimer] implementation for a new zone.
+  final CreatePeriodicTimerHandler? createPeriodicTimer;
+
+  /// A custom [Zone.print] implementation for a new zone.
+  final PrintHandler? print;
+
+  /// A custom [Zone.handleUncaughtError] implementation for a new zone.
+  final ForkHandler? fork;
+
+  StackZoneSpecification(
+    this._onError, {
+    bool errorZone = true,
+    this.run,
+    this.runUnary,
+    this.runBinary,
+    this.scheduleMicrotask,
+    this.createTimer,
+    this.createPeriodicTimer,
+    this.print,
+    this.fork,
+  }) : _errorZone = errorZone;
 
   /// Converts this specification to a real [ZoneSpecification].
   ZoneSpecification toSpec() => ZoneSpecification(
-      handleUncaughtError: _errorZone ? _handleUncaughtError : null,
-      registerCallback: _registerCallback,
-      registerUnaryCallback: _registerUnaryCallback,
-      registerBinaryCallback: _registerBinaryCallback,
-      errorCallback: _errorCallback);
+        handleUncaughtError: _errorZone ? _handleUncaughtError : null,
+        registerCallback: _registerCallback,
+        registerUnaryCallback: _registerUnaryCallback,
+        registerBinaryCallback: _registerBinaryCallback,
+        errorCallback: _errorCallback,
+        run: run,
+        runBinary: runBinary,
+        runUnary: runUnary,
+        scheduleMicrotask: scheduleMicrotask,
+        createTimer: createTimer,
+        createPeriodicTimer: createPeriodicTimer,
+        print: print,
+        fork: fork,
+      );
 
   /// Returns the current stack chain.
   ///


### PR DESCRIPTION
Reopening after https://github.com/dart-lang/stack_trace/pull/167 was closed because of the repo's migration.

Closes https://github.com/dart-lang/tools/issues/1864 exposing several parameters from the ZoneSpecification for the package `stack_trace`.

This change will allow apps to have more control over the `ZoneSpecification` they need, when using the `stack_trace` package. For example, for security reasons many apps will override the `PrintHandler`, so no prints are exposed in production, but currently it's impossible to do it when using this package.

This is actually the main reason why I submitted this PR, but since I was at it, I thought it would be better to expose all other missing parameters, in case others need them.