### PR TITLE
add a workflow to deply the markdown playground

### DIFF
--- a/.github/workflows/deploy_pages.yaml
+++ b/.github/workflows/deploy_pages.yaml
@@ -1,18 +1,14 @@
-# Publish the markdown playground to dart-lang.github.io/tools/markdown.
+# Publish the GitHub Pages site for this repo.
 
-name: "package:markdown: playground"
+name: "Deploy Pages"
 
 on:
   # Run on pushes to the default branch.
   push:
     branches: [ main ]
     paths:
-      - '.github/workflows/markdown_playground.yaml'
+      - '.github/workflows/deploy_pages.yaml'
       - 'pkgs/markdown/**'
-
-defaults:
-  run:
-    working-directory: pkgs/markdown/
 
 jobs:
   deploy:
@@ -29,23 +25,29 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
       
-      - name: Install dependencies
+      # Build the markdown playground.
+      - name: "markdown: pub get"
         run: dart pub get
-
-      - name: Build markdown playground
+        working-directory: pkgs/markdown
+      - name: "markdown: build playground"
         run: >
           dart compile js -o example/app.dart.js
           --minify --no-frequency-based-minification --no-source-maps
           example/app.dart
+        working-directory: pkgs/markdown/example
 
+      # Create the _site directory.
+      - run: mkdir _site
+      - run: cp -r pkgs/markdown/example _site/markdown
+      - run: rm _site/markdown/*.dart
+
+      # Deploy to GitHub Pages.
       - name: setup pages
         uses: actions/configure-pages@v5
-
       - name: upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: pkgs/markdown/example
-
+          path: _site
       - name: deploy to github pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -18,11 +18,9 @@ on:
 env:
   PUB_ENVIRONMENT: bot.github
 
-
 defaults:
   run:
     working-directory: pkgs/markdown/
-
 
 jobs:
   # Check code formatting and static analysis on a single OS (linux)

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -46,6 +46,21 @@ jobs:
         run: dart analyze --fatal-infos
         if: always() && steps.install.outcome == 'success'
 
+  # Ensure the markdown playground builds.
+  build-playground:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [stable]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
+        with:
+          sdk: ${{ matrix.sdk }}
+      - run: dart pub get
+      - run: dart compile js -o example/app.dart.js example/app.dart
+
   # Run tests on a matrix consisting of two dimensions:
   # 1. OS: ubuntu-latest, (macos-latest, windows-latest)
   # 2. release channel: dev

--- a/.github/workflows/markdown_crash_test.yaml
+++ b/.github/workflows/markdown_crash_test.yaml
@@ -9,12 +9,10 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/markdown_crash_test.yaml'
-      - 'pkgs/markdown/**'
   pull_request:
     branches: [ main ]
     paths:
       - '.github/workflows/markdown_crash_test.yaml'
-      - 'pkgs/markdown/**'
   schedule:
     # “At 00:00 (UTC) on Sunday.”
     - cron: '0 0 * * 0'

--- a/.github/workflows/markdown_crash_test.yaml
+++ b/.github/workflows/markdown_crash_test.yaml
@@ -1,5 +1,5 @@
-# Run against all markdown files in latest version of packages on pub.dev to
-# see if any can provoke a crash
+# Run against all markdown files in the latest version of packages on pub.dev
+# to see if any can provoke a crash.
 
 name: "package:markdown: crash tests"
 
@@ -9,10 +9,12 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/markdown_crash_test.yaml'
+      - 'pkgs/markdown/**'
   pull_request:
     branches: [ main ]
     paths:
       - '.github/workflows/markdown_crash_test.yaml'
+      - 'pkgs/markdown/**'
   schedule:
     # “At 00:00 (UTC) on Sunday.”
     - cron: '0 0 * * 0'

--- a/.github/workflows/markdown_playground.yaml
+++ b/.github/workflows/markdown_playground.yaml
@@ -3,18 +3,13 @@
 name: "package:markdown: playground"
 
 on:
-  # Run on PRs and pushes to the default branch.
+  # Run on pushes to the default branch.
   push:
     branches: [ main ]
     paths:
       - '.github/workflows/markdown_playground.yaml'
       - 'pkgs/markdown/**'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - '.github/workflows/markdown_playground.yaml'
-      - 'pkgs/markdown/**'
-    
+
 defaults:
   run:
     working-directory: pkgs/markdown/
@@ -26,25 +21,31 @@ jobs:
       pages: write
       id-token: write
     runs-on: ubuntu-latest
-    needs: jekyll-build
     environment:
       name: github-pages
       url: ${{steps.deployment.outputs.page_url}}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      
       - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
       
       - name: Install dependencies
         run: dart pub get
 
       - name: Build markdown playground
-        run: dart compile js -o example/app.dart.js --minify --no-frequency-based-minification --no-source-maps example/app.dart
+        run: >
+          dart compile js -o example/app.dart.js
+          --minify --no-frequency-based-minification --no-source-maps
+          example/app.dart
 
-      - name: Deploy artifact
+      - name: setup pages
+        uses: actions/configure-pages@v5
+
+      - name: upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pkgs/markdown/example
+
+      - name: deploy to github pages
         id: deployment
         uses: actions/deploy-pages@v4
-
-todo: split into 'build' and 'deploy'
-

--- a/.github/workflows/markdown_playground.yaml
+++ b/.github/workflows/markdown_playground.yaml
@@ -1,0 +1,50 @@
+# Publish the markdown playground to dart-lang.github.io/tools/markdown.
+
+name: "package:markdown: playground"
+
+on:
+  # Run on PRs and pushes to the default branch.
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/markdown_playground.yaml'
+      - 'pkgs/markdown/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/markdown_playground.yaml'
+      - 'pkgs/markdown/**'
+    
+defaults:
+  run:
+    working-directory: pkgs/markdown/
+
+jobs:
+  deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: jekyll-build
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      
+      - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
+      
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Build markdown playground
+        run: dart compile js -o example/app.dart.js --minify --no-frequency-based-minification --no-source-maps example/app.dart
+
+      - name: Deploy artifact
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+todo: split into 'build' and 'deploy'
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # https://dart.dev/tools/pub/private-files
 .dart_tool
 pubspec.lock
+_site/

--- a/pkgs/markdown/.gitignore
+++ b/pkgs/markdown/.gitignore
@@ -3,3 +3,7 @@
 .pub
 pubspec.lock
 doc/
+
+example/app.dart.js
+example/app.dart.js.deps
+example/app.dart.js.map

--- a/pkgs/markdown/CHANGELOG.md
+++ b/pkgs/markdown/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.3.1-wip
+
+* Update the README link to the markdown playground
+  (https://dart-lang.github.io/tools).
+
 ## 7.3.0
 
 * Move to `dart-lang/tools` monorepo.

--- a/pkgs/markdown/README.md
+++ b/pkgs/markdown/README.md
@@ -5,8 +5,7 @@
 A portable Markdown library written in Dart. It can parse Markdown into
 HTML on both the client and server.
 
-Play with it at
-[dart-lang.github.io/markdown](https://dart-lang.github.io/markdown).
+Play with it at [dart-lang.github.io/tools](https://dart-lang.github.io/tools).
 
 ### Usage
 

--- a/pkgs/markdown/README.md
+++ b/pkgs/markdown/README.md
@@ -2,10 +2,11 @@
 [![pub package](https://img.shields.io/pub/v/markdown.svg)](https://pub.dev/packages/markdown)
 [![package publisher](https://img.shields.io/pub/publisher/markdown.svg)](https://pub.dev/packages/markdown/publisher)
 
-A portable Markdown library written in Dart. It can parse Markdown into
-HTML on both the client and server.
+A portable Markdown library written in Dart. It can parse Markdown into HTML on
+both the client and server.
 
-Play with it at [dart-lang.github.io/tools](https://dart-lang.github.io/tools).
+Play with it at
+[dart-lang.github.io/tools/markdown](https://dart-lang.github.io/tools/markdown).
 
 ### Usage
 

--- a/pkgs/markdown/lib/src/version.dart
+++ b/pkgs/markdown/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '7.3.0';
+const packageVersion = '7.3.1-wip';

--- a/pkgs/markdown/pubspec.yaml
+++ b/pkgs/markdown/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 7.3.0
+version: 7.3.1-wip
 description: >-
   A portable Markdown library written in Dart that can parse Markdown into HTML.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/markdown


### PR DESCRIPTION
- add a workflow to deply the markdown playground
- close https://github.com/dart-lang/tools/issues/1960

This deploys the markdown playground to https://dart-lang.github.io/tools on pushes to `main`, and tests that the app builds on every PR.

I may follow this up with a change that instead deploys to `https://dart-lang.github.io/tools/markdown` / `https://dart-lang.github.io/tools/markdown_playground` (or, happy to do that as part of this PR).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
