### PR TITLE
[pub_semver] Remove dependency on `package:meta`

### DIFF
--- a/pkgs/pub_semver/CHANGELOG.md
+++ b/pkgs/pub_semver/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0-wip
+
+- Remove dependency on `package:meta`.
+- Mark `Version` class as `final` instead of with `@sealed`.
+
 ## 2.1.5
 
 - Require Dart `3.4.0`.

--- a/pkgs/pub_semver/lib/src/version.dart
+++ b/pkgs/pub_semver/lib/src/version.dart
@@ -5,7 +5,6 @@
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
-import 'package:meta/meta.dart' show sealed;
 
 import 'patterns.dart';
 import 'version_constraint.dart';
@@ -15,8 +14,7 @@ import 'version_range.dart';
 const _equality = IterableEquality<Object>();
 
 /// A parsed semantic version number.
-@sealed
-class Version implements VersionConstraint, VersionRange {
+final class Version implements VersionConstraint, VersionRange {
   /// No released version: i.e. "0.0.0".
   static Version get none => Version(0, 0, 0);
 

--- a/pkgs/pub_semver/pubspec.yaml
+++ b/pkgs/pub_semver/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pub_semver
-version: 2.1.5
+version: 2.2.0-wip
 description: >-
   Versions and version constraints implementing pub's versioning policy. This
   is very similar to vanilla semver, with a few corner cases.
@@ -15,7 +15,6 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  meta: ^1.3.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0


### PR DESCRIPTION
Use the `final` class modifier on `Version` instead of `@sealed`. This could technically break anyone who overrides the class while ignoring the resulting diagnostic from `@sealed`.