### PR TITLE
[MIME] Expand default extension map

### DIFF
--- a/pkgs/mime/lib/mime.dart
+++ b/pkgs/mime/lib/mime.dart
@@ -10,7 +10,7 @@
 library;
 
 export 'src/extension.dart';
-export 'src/default_extension.dart';
+export 'src/default_extension_map.dart';
 export 'src/mime_multipart_transformer.dart';
 export 'src/mime_shared.dart';
 export 'src/mime_type.dart';

--- a/pkgs/mime/lib/mime.dart
+++ b/pkgs/mime/lib/mime.dart
@@ -10,6 +10,7 @@
 library;
 
 export 'src/extension.dart';
+export 'src/default_extension.dart';
 export 'src/mime_multipart_transformer.dart';
 export 'src/mime_shared.dart';
 export 'src/mime_type.dart';

--- a/pkgs/mime/lib/src/default_extension_map.dart
+++ b/pkgs/mime/lib/src/default_extension_map.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-const Map<String, String> defaultExtensionMap = <String, String>{
+final Map<String, String> defaultExtensionMap = <String, String>{
   '123': 'application/vnd.lotus-1-2-3',
   '3dml': 'text/vnd.in3d.3dml',
   '3ds': 'image/x-3ds',


### PR DESCRIPTION
I am using packages, that depends on mime (for example, DropTarget). I need to add my file extension to default map, but it is Const

I propose change to Final, now my code is:

```
import 'package:mime/mime.dart' as mime;
mime.defaultExtensionMap['wxo'] = 'application/wxo';

```

This will give the opportunity to add own extension types in standard resolver