### PR TITLE
[html] Allow ampersands in attribute values.

### DIFF
--- a/pkgs/html/CHANGELOG.md
+++ b/pkgs/html/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.6
+## 0.15.5+1
 
 - Support "ambiguous ampersand" in attribute values.
 

--- a/pkgs/html/CHANGELOG.md
+++ b/pkgs/html/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.6
+
+- Support "ambiguous ampersand" in attribute values.
+
 ## 0.15.5
 
 - Require Dart `3.2`.

--- a/pkgs/html/lib/dom.dart
+++ b/pkgs/html/lib/dom.dart
@@ -283,8 +283,15 @@ abstract class Node {
     final tokenizer = HtmlTokenizer(sourceSpan!.text,
         generateSpans: true, attributeSpans: true);
 
-    tokenizer.moveNext();
-    final token = tokenizer.current as StartTagToken;
+    // Find the start token in the tokenized source. This is needed because
+    // the tokenizer may introduce non-fatal (but unexpected here)
+    // `ParseErrorToken`s.
+    Token token;
+    do {
+      tokenizer.moveNext();
+      token = tokenizer.current;
+    } while (token.kind != TokenKind.startTag);
+    token as StartTagToken;
 
     if (token.attributeSpans == null) return; // no attributes
 

--- a/pkgs/html/lib/dom.dart
+++ b/pkgs/html/lib/dom.dart
@@ -283,15 +283,8 @@ abstract class Node {
     final tokenizer = HtmlTokenizer(sourceSpan!.text,
         generateSpans: true, attributeSpans: true);
 
-    // Find the start token in the tokenized source. This is needed because
-    // the tokenizer may introduce non-fatal (but unexpected here)
-    // `ParseErrorToken`s.
-    Token token;
-    do {
-      tokenizer.moveNext();
-      token = tokenizer.current;
-    } while (token.kind != TokenKind.startTag);
-    token as StartTagToken;
+    tokenizer.moveNext();
+    final token = tokenizer.current as StartTagToken;
 
     if (token.attributeSpans == null) return; // no attributes
 

--- a/pkgs/html/lib/src/tokenizer.dart
+++ b/pkgs/html/lib/src/tokenizer.dart
@@ -313,7 +313,6 @@ class HtmlTokenizer implements Iterator<Token> {
 
       // Try to find the longest entity the string will match to take care
       // of &noti for instance.
-
       int entityLen;
       for (entityLen = charStack.length - 1; entityLen > 1; entityLen--) {
         final possibleEntityName = charStack.sublist(0, entityLen).join();
@@ -340,7 +339,11 @@ class HtmlTokenizer implements Iterator<Token> {
           output = '$output${slice(charStack, entityLen).join()}';
         }
       } else {
-        _addToken(ParseErrorToken('expected-named-entity'));
+        if (!fromAttribute) {
+          // Only emit this error token when we're consuming this NOT as part of an attribute.
+          // See: https://html.spec.whatwg.org/multipage/parsing.html#ambiguous-ampersand-state
+          _addToken(ParseErrorToken('expected-named-entity'));
+        }
         stream.unget(charStack.removeLast());
         output = '&${charStack.join()}';
       }

--- a/pkgs/html/pubspec.yaml
+++ b/pkgs/html/pubspec.yaml
@@ -1,5 +1,5 @@
 name: html
-version: 0.15.5
+version: 0.15.6
 description: APIs for parsing and manipulating HTML content outside the browser.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/html
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ahtml

--- a/pkgs/html/pubspec.yaml
+++ b/pkgs/html/pubspec.yaml
@@ -1,5 +1,5 @@
 name: html
-version: 0.15.6
+version: 0.15.5+1
 description: APIs for parsing and manipulating HTML content outside the browser.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/html
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ahtml

--- a/pkgs/html/test/data/tokenizer/test4.test
+++ b/pkgs/html/test/data/tokenizer/test4.test
@@ -28,6 +28,10 @@
 "input":"<z ====>",
 "output":["ParseError", "ParseError", "ParseError", ["StartTag", "z", {"=": "=="}]]},
 
+{"description":"Ambiguous ampersand in attribute value",
+"input":"<tag attr=\"foo?a=b&c=d\">",
+"output":[["StartTag", "tag", {"attr": "foo?a=b&c=d"}]]},
+
 {"description":"Allowed \" after ampersand in attribute value",
 "input":"<z z=\"&\">",
 "output":[["StartTag", "z", {"z": "&"}]]},

--- a/pkgs/html/test/parser_feature_test.dart
+++ b/pkgs/html/test/parser_feature_test.dart
@@ -148,7 +148,7 @@ On line 4, column 3 of ParseError: Unexpected DOCTYPE. Ignored.
     expect(elem.attributeSpans!['extends'], null);
   });
 
-  test('attribute spans if value contains & (non-fatal ParseErrorTokens)', () {
+  test('attribute spans if value contains & (ambiguous ampersand)', () {
     final expectedUrl = 'foo?key=value&key2=value2';
     final text = '<script src="$expectedUrl"></script>';
 

--- a/pkgs/html/test/parser_feature_test.dart
+++ b/pkgs/html/test/parser_feature_test.dart
@@ -148,6 +148,18 @@ On line 4, column 3 of ParseError: Unexpected DOCTYPE. Ignored.
     expect(elem.attributeSpans!['extends'], null);
   });
 
+  test('attribute spans if value contains & (non-fatal ParseErrorTokens)', () {
+    final expectedUrl = 'foo?key=value&key2=value2';
+    final text = '<script src="$expectedUrl"></script>';
+
+    final doc = parse(text, generateSpans: true);
+    final elem = doc.querySelector('script')!;
+    final span = elem.attributeValueSpans!['src']!;
+
+    expect(span.start.offset, text.indexOf('foo'));
+    expect(span.text, expectedUrl);
+  });
+
   test('void element innerHTML', () {
     var doc = parse('<div></div>');
     expect(doc.body!.innerHtml, '<div></div>');


### PR DESCRIPTION
Skips unexpected tokens when attempting to find a `StartTagToken` in `dom.dart`, so attribute values can contain the `&` sign without it being part of an actual HTML Entity.

* Issue: https://github.com/dart-lang/tools/issues/2035

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
