### PR TITLE
[unified analytics] fix `lintUsageCount` docs

### DIFF
--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -622,7 +622,7 @@ final class Event {
   /// Event that is emitted periodically to report the number of times each lint
   /// has been enabled.
   ///
-  /// [count] - the number of contexts in which the lint was enabled.
+  /// [count] - the number of options files in which the lint was enabled.
   ///
   /// [name] - the name of the lint.
   Event.lintUsageCount({


### PR DESCRIPTION
The current docs are inaccurate. In times of yore, it was true that each options file implied a fresh context but not any more so what this count is actually tracking is number of occurences in an options file.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
