### PR TITLE
Widen protobuf dependency to allow 4.0.0

### DIFF
--- a/pkgs/bazel_worker/CHANGELOG.md
+++ b/pkgs/bazel_worker/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.1.3-wip
+## 1.1.3
 
 * Require Dart SDK `^3.4.0`.
+* Widen `package:protobuf` constraint to allow 4.0.0.
 
 ## 1.1.2
 

--- a/pkgs/bazel_worker/pubspec.yaml
+++ b/pkgs/bazel_worker/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 1.1.3-wip
+version: 1.1.3
 description: >-
   Protocol and utilities to implement or invoke persistent bazel workers.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/bazel_worker
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.5.0
-  protobuf: ^3.0.0
+  protobuf: ">=3.0.0 <5.0.0"
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0


### PR DESCRIPTION
* Widen protobuf dependency to allow 4.0.0

* Prepare to publish 1.1.3

`package:protobuf` 4.0.0 was released - generated code is backwards compatible but newer generated code (generated using `package:protoc_plugin >=22.0.0`) requires `package:protobuf >= 4.0.0`. 

Widening protobuf dependency allows packages which depend on newer `package:protobuf` to pull it in otherwise it conflicts with the constraint here. (most common complict path is via `package:build_web_compilers`).
