### PR TITLE
[UA] Add a Flutter event for plugins injected into an iOS/macOS project.

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.0.1
+- Added `Event.flutterInjectDarwinPlugins` event for plugins injected into an iOS/macOS project.
+
 ## 8.0.0
 - Send `enabled_features` as an event parameter in all events rather than as a user property.
 

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '8.0.0';
+const String kPackageVersion = '8.0.1';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -74,7 +74,7 @@ enum DashEvent {
   ),
   codeSizeAnalysis(
     label: 'code_size_analysis',
-    description: 'Indicates when the "--analyize-size" command is run',
+    description: 'Indicates when the "--analyze-size" command is run',
     toolOwner: DashTool.flutterTool,
   ),
   commandUsageValues(
@@ -96,6 +96,11 @@ enum DashEvent {
   flutterCommandResult(
     label: 'flutter_command_result',
     description: 'Provides information about flutter commands that ran',
+    toolOwner: DashTool.flutterTool,
+  ),
+  flutterInjectDarwinPlugins(
+    label: 'flutter_inject_darwin_plugins',
+    description: 'Information on plugins injected into an iOS/macOS project',
     toolOwner: DashTool.flutterTool,
   ),
   hotReloadTime(

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -566,8 +566,8 @@ final class Event {
   ///
   /// [isModule] - whether the project is an add-to-app Flutter module.
   ///
-  /// [swiftPackageManagerUsed] - if Swift Package Manager can be used for the
-  /// project's plugins.
+  /// [swiftPackageManagerUsable] - if `true`, Swift Package Manager can be used
+  /// for the project's plugins if any are Swift Package Manager compatible.
   ///
   /// [swiftPackageManagerFeatureEnabled] - if the Swift Package Manager feature
   /// flag is on. If false, Swift Package Manager is off for all projects on
@@ -578,7 +578,7 @@ final class Event {
   /// Manager for a single project.
   ///
   /// [projectHasSwiftPackageManagerIntegration] - if the Xcode project has
-  /// Swift Package Manager integration. If false, the project needs to be
+  /// Swift Package Manager integration. If `false`, the project needs to be
   /// migrated.
   ///
   /// [pluginCount] - the total number of plugins for this project. A plugin
@@ -597,7 +597,7 @@ final class Event {
   Event.flutterInjectDarwinPlugins({
     required String platform,
     required bool isModule,
-    required bool swiftPackageManagerUsed,
+    required bool swiftPackageManagerUsable,
     required bool swiftPackageManagerFeatureEnabled,
     required bool projectDisabledSwiftPackageManager,
     required bool projectHasSwiftPackageManagerIntegration,
@@ -609,7 +609,7 @@ final class Event {
           eventData: {
             'platform': platform,
             'isModule': isModule,
-            'swiftPackageManagerUsed': swiftPackageManagerUsed,
+            'swiftPackageManagerUsable': swiftPackageManagerUsable,
             'swiftPackageManagerFeatureEnabled':
                 swiftPackageManagerFeatureEnabled,
             'projectDisabledSwiftPackageManager':

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -557,6 +557,71 @@ final class Event {
           },
         );
 
+  /// Provides information about the plugins injected into an iOS or macOS
+  /// project.
+  ///
+  /// This event is not sent if a project has no plugins.
+  ///
+  /// [platform] - The project's platform. Either 'ios' or 'macos'.
+  ///
+  /// [isModule] - whether the project is an add-to-app Flutter module.
+  ///
+  /// [swiftPackageManagerUsed] - if Swift Package Manager can be used for the
+  /// project's plugins.
+  ///
+  /// [swiftPackageManagerFeatureEnabled] - if the Swift Package Manager feature
+  /// flag is on. If false, Swift Package Manager is off for all projects on
+  /// the development machine.
+  ///
+  /// [projectDisabledSwiftPackageManager] - if the project's .pubspec has
+  /// `disable-swift-package-manager: true`. This turns off Swift Package
+  /// Manager for a single project.
+  ///
+  /// [projectHasSwiftPackageManagerIntegration] - if the Xcode project has
+  /// Swift Package Manager integration. If false, the project needs to be
+  /// migrated.
+  ///
+  /// [pluginCount] - the total number of plugins for this project. A plugin
+  /// can be compatible with both Swift Package Manager and CocoaPods. Plugins
+  /// compatible with both will be counted in both [swiftPackageCount] and
+  /// [podCount]. Swift Package Manager was used to inject all plugins if
+  /// [pluginCount] is equal to [swiftPackageCount].
+  ///
+  /// [swiftPackageCount] - the number of plugins compatible with Swift Package
+  /// Manager. This is less than or equal to [pluginCount]. If
+  /// [swiftPackageCount] is less than [pluginCount], the project uses CocoaPods
+  /// to inject plugins.
+  ///
+  /// [podCount] - the number of plugins compatible with CocoaPods. This is less
+  /// than or equal to [podCount].
+  Event.flutterInjectDarwinPlugins({
+    required String platform,
+    required bool isModule,
+    required bool swiftPackageManagerUsed,
+    required bool swiftPackageManagerFeatureEnabled,
+    required bool projectDisabledSwiftPackageManager,
+    required bool projectHasSwiftPackageManagerIntegration,
+    required int pluginCount,
+    required int swiftPackageCount,
+    required int podCount,
+  }) : this._(
+          eventName: DashEvent.flutterInjectDarwinPlugins,
+          eventData: {
+            'platform': platform,
+            'isModule': isModule,
+            'swiftPackageManagerUsed': swiftPackageManagerUsed,
+            'swiftPackageManagerFeatureEnabled':
+                swiftPackageManagerFeatureEnabled,
+            'projectDisabledSwiftPackageManager':
+                projectDisabledSwiftPackageManager,
+            'projectHasSwiftPackageManagerIntegration':
+                projectHasSwiftPackageManagerIntegration,
+            'pluginCount': pluginCount,
+            'swiftPackageCount': swiftPackageCount,
+            'podCount': podCount,
+          },
+        );
+
   // TODO: eliasyishak, remove this or replace once we have a generic
   //  timing event that can be used by potentially more than one DashTool
   Event.hotReloadTime({required int timeMs})

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 8.0.0
+version: 8.0.1
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aunified_analytics

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -404,7 +404,7 @@ void main() {
     Event generateEvent() => Event.flutterInjectDarwinPlugins(
           platform: 'ios',
           isModule: true,
-          swiftPackageManagerUsed: true,
+          swiftPackageManagerUsable: true,
           swiftPackageManagerFeatureEnabled: true,
           projectDisabledSwiftPackageManager: false,
           projectHasSwiftPackageManagerIntegration: true,
@@ -419,7 +419,7 @@ void main() {
     expect(constructedEvent.eventName, DashEvent.flutterInjectDarwinPlugins);
     expect(constructedEvent.eventData['platform'], 'ios');
     expect(constructedEvent.eventData['isModule'], isTrue);
-    expect(constructedEvent.eventData['swiftPackageManagerUsed'], isTrue);
+    expect(constructedEvent.eventData['swiftPackageManagerUsable'], isTrue);
     expect(constructedEvent.eventData['swiftPackageManagerFeatureEnabled'],
         isTrue);
     expect(constructedEvent.eventData['projectDisabledSwiftPackageManager'],

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -400,6 +400,35 @@ void main() {
     expect(constructedEvent.eventData.length, 4);
   });
 
+  test('Event.flutterInjectDarwinPlugins constructed', () {
+    Event generateEvent() => Event.flutterInjectDarwinPlugins(
+          platform: 'ios',
+          isModule: true,
+          swiftPackageManagerUsed: true,
+          swiftPackageManagerFeatureEnabled: true,
+          projectDisabledSwiftPackageManager: false,
+          projectHasSwiftPackageManagerIntegration: true,
+          pluginCount: 123,
+          swiftPackageCount: 456,
+          podCount: 678,
+        );
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.flutterInjectDarwinPlugins);
+    expect(constructedEvent.eventData['platform'], 'ios');
+    expect(constructedEvent.eventData['isModule'], isTrue);
+    expect(constructedEvent.eventData['swiftPackageManagerUsed'], isTrue);
+    expect(constructedEvent.eventData['swiftPackageManagerFeatureEnabled'], isTrue);
+    expect(constructedEvent.eventData['projectDisabledSwiftPackageManager'], isFalse);
+    expect(constructedEvent.eventData['projectHasSwiftPackageManagerIntegration'], isTrue);
+    expect(constructedEvent.eventData['pluginCount'], 123);
+    expect(constructedEvent.eventData['swiftPackageCount'], 456);
+    expect(constructedEvent.eventData['podCount'], 678);
+    expect(constructedEvent.eventData.length, 9);
+  });
+
   test('Event.codeSizeAnalysis constructed', () {
     Event generateEvent() => Event.codeSizeAnalysis(platform: 'platform');
 
@@ -634,7 +663,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 27;
+    final eventsAccountedForInTests = 28;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -420,9 +420,13 @@ void main() {
     expect(constructedEvent.eventData['platform'], 'ios');
     expect(constructedEvent.eventData['isModule'], isTrue);
     expect(constructedEvent.eventData['swiftPackageManagerUsed'], isTrue);
-    expect(constructedEvent.eventData['swiftPackageManagerFeatureEnabled'], isTrue);
-    expect(constructedEvent.eventData['projectDisabledSwiftPackageManager'], isFalse);
-    expect(constructedEvent.eventData['projectHasSwiftPackageManagerIntegration'], isTrue);
+    expect(constructedEvent.eventData['swiftPackageManagerFeatureEnabled'],
+        isTrue);
+    expect(constructedEvent.eventData['projectDisabledSwiftPackageManager'],
+        isFalse);
+    expect(
+        constructedEvent.eventData['projectHasSwiftPackageManagerIntegration'],
+        isTrue);
     expect(constructedEvent.eventData['pluginCount'], 123);
     expect(constructedEvent.eventData['swiftPackageCount'], 456);
     expect(constructedEvent.eventData['podCount'], 678);


### PR DESCRIPTION
Flutter is migrating from CocoaPods to Swift Package Manager to manage native dependencies on iOS and macOS. We'd like to answer the following questions:

1. Does the Swift Package Manager feature increase error rates?
2. Can we remove CocoaPods support from Flutter's tooling?
3. Can we tell plugin authors that they can remove CocoaPods integration from their plugins? 

This adds a telemetry event that Flutter will send when it injects plugins into an iOS or macOS project. This will happen whenever a user does commands like `flutter build ios`, `flutter build macos`, and more.

Part of https://github.com/flutter/flutter/issues/147602

Flutter PR: https://github.com/flutter/flutter/pull/166773

cc @vashworth

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
