### PR TITLE
Add --fail-under flag for minimum coverage threshold

### DIFF
--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.13.0
+## 1.13.0-wip
 
 - Introduced support for minimum coverage thresholds using --fail-under flag in
   format_coverage..

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.13.0-wip
 
 - Introduced support for minimum coverage thresholds using --fail-under flag in
-  format_coverage..
+  format_coverage.
   
 ## 1.12.0
 

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.13.0
+
+- Introduced support for minimum coverage thresholds using --fail-under flag in
+  format_coverage..
+  
 ## 1.12.0
 
 - Introduced support for specifying coverage flags through a YAML file.

--- a/pkgs/coverage/bin/format_coverage.dart
+++ b/pkgs/coverage/bin/format_coverage.dart
@@ -134,9 +134,10 @@ Future<void> main(List<String> arguments) async {
   }
   await outputSink.close();
 
-  // Check coverage against the fail-under threshold if specified
-  if (env.failUnder != null) {
-    // Calculate the overall coverage percentage using the utility function
+  // Check coverage against the fail-under threshold if specified.
+  final failUnder = env.failUnder;
+  if (failUnder != null) {
+    // Calculate the overall coverage percentage using the utility function.
     final result = calculateCoveragePercentage(
       hitmap,
     );
@@ -148,11 +149,11 @@ Future<void> main(List<String> arguments) async {
 
     if (result.percentage < env.failUnder!) {
       print('Error: Coverage ${result.percentage.toStringAsFixed(2)}% '
-          'is less than required ${env.failUnder!.toStringAsFixed(2)}%');
+          'is less than required ${failUnder.toStringAsFixed(2)}%');
       exit(1);
     } else if (env.verbose) {
-      print('Coverage ${result.percentage.toStringAsFixed(2)}% '
-          'meets or exceeds the required ${env.failUnder!.toStringAsFixed(2)}%');
+      print('Coverage ${result.percentage.toStringAsFixed(2)}% meets or exceeds'
+          'the required ${failUnder.toStringAsFixed(2)}%');
     }
   }
 }

--- a/pkgs/coverage/bin/format_coverage.dart
+++ b/pkgs/coverage/bin/format_coverage.dart
@@ -148,11 +148,11 @@ Future<void> main(List<String> arguments) async {
 
     if (result.percentage < env.failUnder!) {
       print('Error: Coverage ${result.percentage.toStringAsFixed(2)}% '
-          'is less than required ${env.failUnder}%');
+          'is less than required ${env.failUnder!.toStringAsFixed(2)}%');
       exit(1);
     } else if (env.verbose) {
       print('Coverage ${result.percentage.toStringAsFixed(2)}% '
-          'meets or exceeds the required ${env.failUnder}%');
+          'meets or exceeds the required ${env.failUnder!.toStringAsFixed(2)}%');
     }
   }
 }

--- a/pkgs/coverage/bin/format_coverage.dart
+++ b/pkgs/coverage/bin/format_coverage.dart
@@ -147,7 +147,7 @@ Future<void> main(List<String> arguments) async {
           '(${result.coveredLines} of ${result.totalLines} lines)');
     }
 
-    if (result.percentage < env.failUnder!) {
+    if (result.percentage < failUnder) {
       print('Error: Coverage ${result.percentage.toStringAsFixed(2)}% '
           'is less than required ${failUnder.toStringAsFixed(2)}%');
       exit(1);

--- a/pkgs/coverage/bin/format_coverage.dart
+++ b/pkgs/coverage/bin/format_coverage.dart
@@ -32,7 +32,6 @@ class Environment {
     required this.verbose,
     required this.workers,
     required this.failUnder,
-    required this.precision,
   });
 
   String? baseDirectory;
@@ -53,7 +52,6 @@ class Environment {
   bool verbose;
   int workers;
   double? failUnder;
-  int precision;
 }
 
 Future<void> main(List<String> arguments) async {
@@ -141,20 +139,19 @@ Future<void> main(List<String> arguments) async {
     // Calculate the overall coverage percentage using the utility function
     final result = calculateCoveragePercentage(
       hitmap,
-      precision: env.precision,
     );
 
     if (env.verbose) {
-      print('Coverage: ${result.percentage}% '
+      print('Coverage: ${result.percentage.toStringAsFixed(2)}% '
           '(${result.coveredLines} of ${result.totalLines} lines)');
     }
 
     if (result.percentage < env.failUnder!) {
-      print('Error: Coverage ${result.percentage}% '
+      print('Error: Coverage ${result.percentage.toStringAsFixed(2)}% '
           'is less than required ${env.failUnder}%');
       exit(1);
     } else if (env.verbose) {
-      print('Coverage ${result.percentage}% '
+      print('Coverage ${result.percentage.toStringAsFixed(2)}% '
           'meets or exceeds the required ${env.failUnder}%');
     }
   }
@@ -174,12 +171,6 @@ Environment parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
     ..addOption(
       'fail-under',
       help: 'Fail if coverage is less than the given percentage (0-100)',
-    )
-    ..addOption(
-      'precision',
-      help:
-          'Number of decimal places to use when reporting coverage percentage',
-      defaultsTo: '0',
     )
     ..addOption(
       'packages',
@@ -360,36 +351,26 @@ Environment parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
     }
   }
 
-  int precision;
-  try {
-    precision = int.parse(args['precision'] as String);
-    if (precision < 0) {
-      fail('--precision must be a non-negative integer');
-    }
-  } catch (e) {
-    fail('Invalid --precision value: $e');
-  }
-
   return Environment(
-      baseDirectory: baseDirectory,
-      bazel: bazel,
-      bazelWorkspace: bazelWorkspace,
-      checkIgnore: checkIgnore,
-      input: input,
-      lcov: lcov,
-      output: output,
-      packagesPath: packagesPath,
-      packagePath: packagePath,
-      prettyPrint: prettyPrint,
-      prettyPrintFunc: prettyPrintFunc,
-      prettyPrintBranch: prettyPrintBranch,
-      reportOn: reportOn,
-      ignoreFiles: ignoredGlobs,
-      sdkRoot: sdkRoot,
-      verbose: verbose,
-      workers: workers,
-      failUnder: failUnder,
-      precision: precision);
+    baseDirectory: baseDirectory,
+    bazel: bazel,
+    bazelWorkspace: bazelWorkspace,
+    checkIgnore: checkIgnore,
+    input: input,
+    lcov: lcov,
+    output: output,
+    packagesPath: packagesPath,
+    packagePath: packagePath,
+    prettyPrint: prettyPrint,
+    prettyPrintFunc: prettyPrintFunc,
+    prettyPrintBranch: prettyPrintBranch,
+    reportOn: reportOn,
+    ignoreFiles: ignoredGlobs,
+    sdkRoot: sdkRoot,
+    verbose: verbose,
+    workers: workers,
+    failUnder: failUnder,
+  );
 }
 
 /// Given an absolute path absPath, this function returns a [List] of files

--- a/pkgs/coverage/bin/test_with_coverage.dart
+++ b/pkgs/coverage/bin/test_with_coverage.dart
@@ -89,11 +89,6 @@ ArgParser _createArgParser(CoverageOptions defaultOptions) => ArgParser()
     'fail-under',
     help: 'Fail if coverage is less than the given percentage (0-100)',
   )
-  ..addOption(
-    'precision',
-    help: 'Number of decimal places to use when reporting coverage percentage',
-    defaultsTo: '0',
-  )
   ..addMultiOption('scope-output',
       defaultsTo: defaultOptions.scopeOutput,
       help: 'restrict coverage results so that only scripts that start with '
@@ -111,8 +106,7 @@ class Flags {
     this.functionCoverage,
     this.branchCoverage,
     this.scopeOutput,
-    this.failUnder,
-    this.precision, {
+    this.failUnder, {
     required this.rest,
   });
 
@@ -124,8 +118,7 @@ class Flags {
   final bool functionCoverage;
   final bool branchCoverage;
   final List<String> scopeOutput;
-  final double? failUnder;
-  final int precision;
+  final String? failUnder;
   final List<String> rest;
 }
 
@@ -173,29 +166,6 @@ ${parser.usage}
     );
   }
 
-  double? failUnder;
-  final failUnderStr = args['fail-under'] as String?;
-  if (failUnderStr != null) {
-    try {
-      failUnder = double.parse(failUnderStr);
-      if (failUnder < 0 || failUnder > 100) {
-        fail('--fail-under must be a percentage between 0 and 100');
-      }
-    } catch (e) {
-      fail('Invalid --fail-under value: $e');
-    }
-  }
-
-  int precision;
-  try {
-    precision = int.parse(args['precision'] as String);
-    if (precision < 0) {
-      fail('--precision must be a non-negative integer');
-    }
-  } catch (e) {
-    fail('Invalid --precision value: $e');
-  }
-
   return Flags(
     packageDir,
     packageName,
@@ -205,8 +175,7 @@ ${parser.usage}
     args['function-coverage'] as bool,
     args['branch-coverage'] as bool,
     args['scope-output'] as List<String>,
-    failUnder,
-    precision,
+    args['fail-under'] as String?,
     rest: args.rest,
   );
 }
@@ -272,7 +241,6 @@ Future<void> main(List<String> arguments) async {
     '-o',
     outLcov,
     if (flags.failUnder != null) '--fail-under=${flags.failUnder}',
-    '--precision=${flags.precision}',
   ]);
   exit(0);
 }

--- a/pkgs/coverage/lib/src/coverage_percentage.dart
+++ b/pkgs/coverage/lib/src/coverage_percentage.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:math';
+
+import 'hitmap.dart';
+
+/// Calculates the coverage percentage from a hitmap.
+///
+/// [hitmap] is the map of file paths to hit maps.
+/// [precision] is the number of decimal places to round to (default: 0).
+///
+/// Returns a [CoverageResult] containing the coverage percentage and line
+/// counts.
+CoverageResult calculateCoveragePercentage(
+  Map<String, HitMap> hitmap, {
+  int precision = 0,
+}) {
+  var totalLines = 0;
+  var coveredLines = 0;
+
+  for (final entry in hitmap.entries) {
+    final lineHits = entry.value.lineHits;
+    totalLines += lineHits.length;
+    coveredLines += lineHits.values.where((v) => v > 0).length;
+  }
+  final coveragePercentage = totalLines > 0
+      ? _roundToDecimalPlaces(coveredLines * 100 / totalLines, precision)
+      : 0.0;
+
+  return CoverageResult(
+    percentage: coveragePercentage,
+    coveredLines: coveredLines,
+    totalLines: totalLines,
+  );
+}
+
+/// Rounds a number to the specified number of decimal places.
+double _roundToDecimalPlaces(double value, int decimalPlaces) {
+  final mod = pow(10, decimalPlaces);
+  return (value * mod).round() / mod;
+}
+
+/// The result of a coverage calculation.
+class CoverageResult {
+  /// Creates a new [CoverageResult].
+  const CoverageResult({
+    required this.percentage,
+    required this.coveredLines,
+    required this.totalLines,
+  });
+
+  /// The coverage percentage.
+  final double percentage;
+
+  /// The number of covered lines.
+  final int coveredLines;
+
+  /// The total number of lines.
+  final int totalLines;
+}

--- a/pkgs/coverage/lib/src/coverage_percentage.dart
+++ b/pkgs/coverage/lib/src/coverage_percentage.dart
@@ -14,16 +14,14 @@ CoverageResult calculateCoveragePercentage(Map<String, HitMap> hitmap) {
   var totalLines = 0;
   var coveredLines = 0;
   for (final entry in hitmap.entries) {
-    var coveredBranches = 0;
     final lineHits = entry.value.lineHits;
     final branchHits = entry.value.branchHits;
     totalLines += lineHits.length;
     if (branchHits != null) {
-      coveredBranches += branchHits.values.where((v) => v > 0).length;
       totalLines += branchHits.length;
+      coveredLines += branchHits.values.where((v) => v > 0).length;
     }
-    coveredLines +=
-        lineHits.values.where((v) => v > 0).length + coveredBranches;
+    coveredLines += lineHits.values.where((v) => v > 0).length;
   }
   final coveragePercentage =
       totalLines > 0 ? coveredLines * 100 / totalLines : 0.0;

--- a/pkgs/coverage/lib/src/coverage_percentage.dart
+++ b/pkgs/coverage/lib/src/coverage_percentage.dart
@@ -2,44 +2,37 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:math';
-
 import 'hitmap.dart';
 
 /// Calculates the coverage percentage from a hitmap.
 ///
 /// [hitmap] is the map of file paths to hit maps.
-/// [precision] is the number of decimal places to round to (default: 0).
 ///
 /// Returns a [CoverageResult] containing the coverage percentage and line
 /// counts.
-CoverageResult calculateCoveragePercentage(
-  Map<String, HitMap> hitmap, {
-  int precision = 0,
-}) {
+CoverageResult calculateCoveragePercentage(Map<String, HitMap> hitmap) {
   var totalLines = 0;
   var coveredLines = 0;
-
   for (final entry in hitmap.entries) {
+    var coveredBranches = 0;
     final lineHits = entry.value.lineHits;
+    final branchHits = entry.value.branchHits;
     totalLines += lineHits.length;
-    coveredLines += lineHits.values.where((v) => v > 0).length;
+    if (branchHits != null) {
+      coveredBranches += branchHits.values.where((v) => v > 0).length;
+      totalLines += branchHits.length;
+    }
+    coveredLines +=
+        lineHits.values.where((v) => v > 0).length + coveredBranches;
   }
-  final coveragePercentage = totalLines > 0
-      ? _roundToDecimalPlaces(coveredLines * 100 / totalLines, precision)
-      : 0.0;
+  final coveragePercentage =
+      totalLines > 0 ? coveredLines * 100 / totalLines : 0.0;
 
   return CoverageResult(
     percentage: coveragePercentage,
     coveredLines: coveredLines,
     totalLines: totalLines,
   );
-}
-
-/// Rounds a number to the specified number of decimal places.
-double _roundToDecimalPlaces(double value, int decimalPlaces) {
-  final mod = pow(10, decimalPlaces);
-  return (value * mod).round() / mod;
 }
 
 /// The result of a coverage calculation.

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.12.0
+version: 1.13.0-wip
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage

--- a/pkgs/coverage/test/coverage_percentage_test.dart
+++ b/pkgs/coverage/test/coverage_percentage_test.dart
@@ -71,5 +71,21 @@ void main() {
       expect(result.coveredLines, equals(3));
       expect(result.totalLines, equals(3));
     });
+    test('includes branch hits in coverage percentage', () {
+      // 2 lines (1 covered) + 3 branches (2 covered) = 5 total, 3 covered
+      final hitmap = {
+        'file.dart': HitMap(
+          {1: 1, 2: 0}, // lineHits
+          null,
+          null,
+          {10: 1, 11: 0, 12: 2}, // branchHits
+        ),
+      };
+      final result = calculateCoveragePercentage(hitmap);
+
+      expect(result.totalLines, equals(5));
+      expect(result.coveredLines, equals(3));
+      expect(result.percentage.toStringAsFixed(2), equals('60.00'));
+    });
   });
 }

--- a/pkgs/coverage/test/coverage_percentage_test.dart
+++ b/pkgs/coverage/test/coverage_percentage_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('calculateCoveragePercentage', () {
-    test('calculates correct percentage with default precision', () {
+    test('calculates correct percentage', () {
       final hitmap = {
         'file1.dart': HitMap({
           1: 1, // covered
@@ -26,36 +26,10 @@ void main() {
       final result = calculateCoveragePercentage(hitmap);
 
       // 4 covered lines out of 7 total lines = 57.14%
-      // With default precision (0), this rounds to 57%
-      expect(result.percentage, equals(57));
+      expect(result.percentage.toStringAsFixed(2), equals('57.14'));
       expect(result.coveredLines, equals(4));
       expect(result.totalLines, equals(7));
     });
-
-    test('calculates correct percentage with custom precision', () {
-      final hitmap = {
-        'file1.dart': HitMap({
-          1: 1, // covered
-          2: 1, // covered
-          3: 0, // not covered
-          4: 1, // covered
-        }),
-        'file2.dart': HitMap({
-          1: 1, // covered
-          2: 0, // not covered
-          3: 0, // not covered
-        }),
-      };
-
-      final result = calculateCoveragePercentage(hitmap, precision: 2);
-
-      // 4 covered lines out of 7 total lines = 57.14%
-      // With precision 2, this rounds to 57.14%
-      expect(result.percentage, equals(57.14));
-      expect(result.coveredLines, equals(4));
-      expect(result.totalLines, equals(7));
-    });
-
     test('handles empty hitmap', () {
       final hitmap = <String, HitMap>{};
 

--- a/pkgs/coverage/test/coverage_percentage_test.dart
+++ b/pkgs/coverage/test/coverage_percentage_test.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:coverage/src/coverage_percentage.dart';
+import 'package:coverage/src/hitmap.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('calculateCoveragePercentage', () {
+    test('calculates correct percentage with default precision', () {
+      final hitmap = {
+        'file1.dart': HitMap({
+          1: 1, // covered
+          2: 1, // covered
+          3: 0, // not covered
+          4: 1, // covered
+        }),
+        'file2.dart': HitMap({
+          1: 1, // covered
+          2: 0, // not covered
+          3: 0, // not covered
+        }),
+      };
+
+      final result = calculateCoveragePercentage(hitmap);
+
+      // 4 covered lines out of 7 total lines = 57.14%
+      // With default precision (0), this rounds to 57%
+      expect(result.percentage, equals(57));
+      expect(result.coveredLines, equals(4));
+      expect(result.totalLines, equals(7));
+    });
+
+    test('calculates correct percentage with custom precision', () {
+      final hitmap = {
+        'file1.dart': HitMap({
+          1: 1, // covered
+          2: 1, // covered
+          3: 0, // not covered
+          4: 1, // covered
+        }),
+        'file2.dart': HitMap({
+          1: 1, // covered
+          2: 0, // not covered
+          3: 0, // not covered
+        }),
+      };
+
+      final result = calculateCoveragePercentage(hitmap, precision: 2);
+
+      // 4 covered lines out of 7 total lines = 57.14%
+      // With precision 2, this rounds to 57.14%
+      expect(result.percentage, equals(57.14));
+      expect(result.coveredLines, equals(4));
+      expect(result.totalLines, equals(7));
+    });
+
+    test('handles empty hitmap', () {
+      final hitmap = <String, HitMap>{};
+
+      final result = calculateCoveragePercentage(hitmap);
+
+      expect(result.percentage, equals(0));
+      expect(result.coveredLines, equals(0));
+      expect(result.totalLines, equals(0));
+    });
+
+    test('handles hitmap with no covered lines', () {
+      final hitmap = {
+        'file1.dart': HitMap({
+          1: 0, // not covered
+          2: 0, // not covered
+          3: 0, // not covered
+        }),
+      };
+
+      final result = calculateCoveragePercentage(hitmap);
+
+      expect(result.percentage, equals(0));
+      expect(result.coveredLines, equals(0));
+      expect(result.totalLines, equals(3));
+    });
+
+    test('handles hitmap with all lines covered', () {
+      final hitmap = {
+        'file1.dart': HitMap({
+          1: 1, // covered
+          2: 1, // covered
+          3: 1, // covered
+        }),
+      };
+
+      final result = calculateCoveragePercentage(hitmap);
+
+      expect(result.percentage, equals(100));
+      expect(result.coveredLines, equals(3));
+      expect(result.totalLines, equals(3));
+    });
+  });
+}

--- a/pkgs/coverage/test/test_with_coverage_package/lib/validate_lib.dart
+++ b/pkgs/coverage/test/test_with_coverage_package/lib/validate_lib.dart
@@ -17,3 +17,17 @@ int product(Iterable<int> values) {
   }
   return val;
 }
+
+String evaluateScore(int score) {
+  if (score < 0) {
+    return 'Invalid';
+  } else if (score < 50) {
+    return 'Fail';
+  } else if (score < 70) {
+    return 'Pass';
+  } else if (score <= 100) {
+    return 'Excellent';
+  } else {
+    return 'Overflow';
+  }
+}

--- a/pkgs/coverage/test/test_with_coverage_package/test/evaluate_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_package/test/evaluate_test.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../lib/validate_lib.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('evaluateScore', () {
+    test('returns Invalid for negative score', () {
+      expect(evaluateScore(-10), equals('Invalid'));
+    });
+
+    test('returns Fail for score < 50', () {
+      expect(evaluateScore(30), equals('Fail'));
+    });
+
+    test('returns Excellent for score 85', () {
+      expect(evaluateScore(85), equals('Excellent'));
+    });
+  });
+}

--- a/pkgs/coverage/test/test_with_coverage_package/test/evaluate_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_package/test/evaluate_test.dart
@@ -2,8 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../lib/validate_lib.dart';
 import 'package:test/test.dart';
+
+// ignore: avoid_relative_lib_imports
+import '../lib/validate_lib.dart';
 
 void main() {
   group('evaluateScore', () {

--- a/pkgs/coverage/test/test_with_coverage_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_test.dart
@@ -86,6 +86,7 @@ dependency_overrides:
       {
         'product': 1,
         'sum': 1,
+        'evaluateScore': 1,
       },
     );
   });
@@ -104,6 +105,7 @@ dependency_overrides:
       {
         'product': 0,
         'sum': 1,
+        'evaluateScore': 0,
       },
       reason: 'only `sum` tests should be run',
     );
@@ -129,26 +131,50 @@ dependency_overrides:
     final process = await _run([
       'run',
       _testWithCoveragePath,
-      '-f',
-      '--fail-under=50', // This should pass as coverage=100% when all tests run
+      '--fail-under=100', // This should pass as coverage=100% when all tests run
       '--port',
       '${_port++}',
     ]);
     await process.shouldExit(0);
   });
-
   test(
       'dart run bin/test_with_coverage.dart --fail-under fails when coverage is below threshold',
       () async {
     final process = await _run([
       'run',
       _testWithCoveragePath,
-      '--fail-under=90', // This should throw an exit(1) as coverage =50% when
-      '--port', // only the `sum` test is run
-      '${_port++}',
+      '--fail-under=90', // This should throw an exit(1) as coverage =27.27% when
+      '--port', // only the `sum` test is run i.e. out of 11 lines only 3 lines
+      '${_port++}', //i.e. [5,7,8]will have hits>0
       '--',
       '-N',
       'sum',
+    ]);
+    await process.shouldExit(1);
+  });
+  test(
+      'dart run bin/test_with_coverage.dart -b --fail-under succeeds when coverage meets threshold',
+      () async {
+    final process = await _run([
+      'run',
+      _testWithCoveragePath,
+      '-b',
+      '--fail-under=95', // This should pass as total lines+branches covered=20
+      '--port', // and total lines (11)+branches covered(10)=21 => percentage_covered=95.23
+      '${_port++}',
+    ]);
+    await process.shouldExit(0);
+  });
+  test(
+      'dart run bin/test_with_coverage.dart -b --fail-under fails when coverage is below threshold',
+      () async {
+    final process = await _run([
+      'run',
+      _testWithCoveragePath,
+      '-b',
+      '--fail-under=96', // This should throw an exit(1) as percentage_covered=95.24 approx
+      '--port',
+      '${_port++}',
     ]);
     await process.shouldExit(1);
   });

--- a/pkgs/coverage/test/test_with_coverage_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_test.dart
@@ -144,7 +144,9 @@ dependency_overrides:
       'run',
       _testWithCoveragePath,
       '--fail-under=90', // This should throw an exit(1) as coverage =50% when
-      '--', // only the `sum` test is run
+      '--port', // only the `sum` test is run
+      '${_port++}',
+      '--',
       '-N',
       'sum',
     ]);

--- a/pkgs/coverage/test/test_with_coverage_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_test.dart
@@ -122,6 +122,34 @@ dependency_overrides:
       ['pub', 'global', 'run', 'coverage:test_with_coverage'],
     );
   });
+
+  test(
+      'dart run bin/test_with_coverage.dart --fail-under succeeds when coverage meets threshold',
+      () async {
+    final process = await _run([
+      'run',
+      _testWithCoveragePath,
+      '-f',
+      '--fail-under=50', // This should pass as coverage=100% when all tests run
+      '--port',
+      '${_port++}',
+    ]);
+    await process.shouldExit(0);
+  });
+
+  test(
+      'dart run bin/test_with_coverage.dart --fail-under fails when coverage is below threshold',
+      () async {
+    final process = await _run([
+      'run',
+      _testWithCoveragePath,
+      '--fail-under=90', // This should throw an exit(1) as coverage =50% when
+      '--', // only the `sum` test is run
+      '-N',
+      'sum',
+    ]);
+    await process.shouldExit(1);
+  });
 }
 
 Future<TestProcess> _run(List<String> args) => TestProcess.start(

--- a/pkgs/coverage/test/test_with_coverage_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_test.dart
@@ -128,10 +128,11 @@ dependency_overrides:
   test(
       'dart run bin/test_with_coverage.dart --fail-under succeeds when coverage meets threshold',
       () async {
+    // This should pass as coverage=100% when all tests run
     final process = await _run([
       'run',
       _testWithCoveragePath,
-      '--fail-under=100', // This should pass as coverage=100% when all tests run
+      '--fail-under=100',
       '--port',
       '${_port++}',
     ]);
@@ -140,12 +141,15 @@ dependency_overrides:
   test(
       'dart run bin/test_with_coverage.dart --fail-under fails when coverage is below threshold',
       () async {
+    /* This should throw an exit(1) as coverage =27.27% when
+     only the `sum` test is run i.e. out of 11 lines only 3 lines
+    i.e. [5,7,8]will have hits>0 */
     final process = await _run([
       'run',
       _testWithCoveragePath,
-      '--fail-under=90', // This should throw an exit(1) as coverage =27.27% when
-      '--port', // only the `sum` test is run i.e. out of 11 lines only 3 lines
-      '${_port++}', //i.e. [5,7,8]will have hits>0
+      '--fail-under=90',
+      '--port',
+      '${_port++}',
       '--',
       '-N',
       'sum',
@@ -155,12 +159,14 @@ dependency_overrides:
   test(
       'dart run bin/test_with_coverage.dart -b --fail-under succeeds when coverage meets threshold',
       () async {
+    /* This should pass as total lines+branches covered=20
+     and total lines (11)+branches covered(10)=21 => percentage_covered=95.23 */
     final process = await _run([
       'run',
       _testWithCoveragePath,
       '-b',
-      '--fail-under=95', // This should pass as total lines+branches covered=20
-      '--port', // and total lines (11)+branches covered(10)=21 => percentage_covered=95.23
+      '--fail-under=90',
+      '--port',
       '${_port++}',
     ]);
     await process.shouldExit(0);
@@ -168,11 +174,12 @@ dependency_overrides:
   test(
       'dart run bin/test_with_coverage.dart -b --fail-under fails when coverage is below threshold',
       () async {
+    // This should throw an exit(1) as percentage_covered=95.23
     final process = await _run([
       'run',
       _testWithCoveragePath,
       '-b',
-      '--fail-under=96', // This should throw an exit(1) as percentage_covered=95.24 approx
+      '--fail-under=99',
       '--port',
       '${_port++}',
     ]);

--- a/pkgs/coverage/test/test_with_coverage_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_test.dart
@@ -126,9 +126,9 @@ dependency_overrides:
   });
 
   test(
-      'dart run bin/test_with_coverage.dart --fail-under succeeds when coverage meets threshold',
-      () async {
-    // This should pass as coverage=100% when all tests run
+      'dart run bin/test_with_coverage.dart --fail-under succeeds'
+      'when coverage meets threshold', () async {
+    // This should pass as coverage=100% when all tests run.
     final process = await _run([
       'run',
       _testWithCoveragePath,
@@ -139,11 +139,10 @@ dependency_overrides:
     await process.shouldExit(0);
   });
   test(
-      'dart run bin/test_with_coverage.dart --fail-under fails when coverage is below threshold',
-      () async {
-    /* This should throw an exit(1) as coverage =27.27% when
-     only the `sum` test is run i.e. out of 11 lines only 3 lines
-    i.e. [5,7,8]will have hits>0 */
+      'dart run bin/test_with_coverage.dart --fail-under fails'
+      'when coverage is below threshold', () async {
+    // This should throw an exit(1) as coverage =27.27% when only the `sum` test
+    // is run i.e. out of 11 lines only 3 lines i.e. [5,7,8]will have hits>0.
     final process = await _run([
       'run',
       _testWithCoveragePath,
@@ -157,10 +156,10 @@ dependency_overrides:
     await process.shouldExit(1);
   });
   test(
-      'dart run bin/test_with_coverage.dart -b --fail-under succeeds when coverage meets threshold',
-      () async {
-    /* This should pass as total lines+branches covered=20
-     and total lines (11)+branches covered(10)=21 => percentage_covered=95.23 */
+      'dart run bin/test_with_coverage.dart -b --fail-under succeeds'
+      'when coverage meets threshold', () async {
+    // This should pass as total lines+branches covered=20 and total lines(11)+
+    // branches covered(10)=21 => percentage_covered=95.23.
     final process = await _run([
       'run',
       _testWithCoveragePath,
@@ -172,9 +171,9 @@ dependency_overrides:
     await process.shouldExit(0);
   });
   test(
-      'dart run bin/test_with_coverage.dart -b --fail-under fails when coverage is below threshold',
-      () async {
-    // This should throw an exit(1) as percentage_covered=95.23
+      'dart run bin/test_with_coverage.dart -b --fail-under fails'
+      'when coverage is below threshold', () async {
+    // This should throw an exit(1) as percentage_covered=95.23 .
     final process = await _run([
       'run',
       _testWithCoveragePath,


### PR DESCRIPTION
## Implement `--fail-under` Flag for Enforcing Minimum Code Coverage Thresholds

This pull request introduces a new command-line flag, `--fail-under`, to the `package:coverage` tool. The feature is modeled after the behavior of the `--fail-under` flag in Python’s [`coverage.py`](https://github.com/nedbat/coveragepy) library.

## Overview of Changes

### New Feature: `--fail-under`

- Accepts a numeric percentage value representing the minimum acceptable code coverage.
- If the actual test coverage falls below this threshold, the tool will return a non-zero exit code (`exit(1)`), signaling failure. 

### Optional Precision Control: `--precision`

- An additional `--precision` flag has been introduced to control the number of decimal places shown in the computed coverage percentage.

### Need Clarity

-Currently i have only added tests for directly testing the coverage percentage calculator,Is it sufficient or should I modify the test_with_coverage_test to test the flag also

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

Fixes #514 
