### PR TITLE
[coverage] Fix another flaky lifecycle management error

### DIFF
--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.13.1
+
+- Fix a bug where the VM service can be shut down while some coverage
+  collections are still happening.
+
 ## 1.13.0
 
 - Introduced support for minimum coverage thresholds using --fail-under flag in

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.13.0
+version: 1.13.1
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage

--- a/pkgs/coverage/test/isolate_paused_listener_test.dart
+++ b/pkgs/coverage/test/isolate_paused_listener_test.dart
@@ -867,7 +867,7 @@ void main() {
       pauseEvent('B', '2');
       pauseEvent('A', '1', 'main');
 
-      while (received.length < 4) {
+      while (received.length < 3) {
         await Future<void>.delayed(Duration.zero);
       }
 
@@ -875,7 +875,6 @@ void main() {
         'Pause B. Collect group 2? Yes',
         'Pause A. Collect group 1? Yes',
         'Pause done A',
-        'Resume A',
       ]);
 
       delayingB.complete();
@@ -884,8 +883,9 @@ void main() {
         'Pause B. Collect group 2? Yes',
         'Pause A. Collect group 1? Yes',
         'Pause done A',
-        'Resume A',
         'Pause done B',
+        // A waits for B's pause callback to complete before resuming.
+        'Resume A',
         // Don't try to resume B, because the VM service is already shut down.
       ]);
     });


### PR DESCRIPTION
Another flaky lifecycle error contributing to b/411490560. If the main isolate is resumed while another isolate group's coverage is being collected, the VM service may shut down during collection, causing a "Service connection disposed" error. So we have to keep track of all pending collection requests and wait for them to finish before resuming the main isolate.