### PR TITLE
[oauth2] Add isClosed and exception handling for closed state to oaut…

### DIFF
--- a/pkgs/oauth2/lib/src/client.dart
+++ b/pkgs/oauth2/lib/src/client.dart
@@ -66,6 +66,9 @@ class Client extends http.BaseClient {
   Credentials get credentials => _credentials;
   Credentials _credentials;
 
+  /// Indicates whether the client is closed or not.
+  bool get isClosed => _httpClient == null;
+
   /// Callback to be invoked whenever the credentials refreshed.
   final CredentialsRefreshedCallback? _onCredentialsRefreshed;
 
@@ -110,8 +113,13 @@ class Client extends http.BaseClient {
       await refreshCredentials();
     }
 
+    final httpClient = _httpClient;
+    if (httpClient == null) {
+      throw http.ClientException('Client is already closed.');
+    }
+
     request.headers['authorization'] = 'Bearer ${credentials.accessToken}';
-    var response = await _httpClient!.send(request);
+    var response = await httpClient.send(request);
 
     if (response.statusCode != 401) return response;
     if (!response.headers.containsKey('www-authenticate')) return response;

--- a/pkgs/oauth2/test/client_test.dart
+++ b/pkgs/oauth2/test/client_test.dart
@@ -189,6 +189,26 @@ void main() {
 
       expect(client.refreshCredentials(), throwsA(isStateError));
     });
+
+    test("won't send a request with closed client", () {
+      var credentials = oauth2.Credentials('access token');
+
+      var client = oauth2.Client(
+        credentials,
+        identifier: 'identifier',
+        secret: 'secret',
+        httpClient: httpClient,
+      );
+
+      expect(client.isClosed, equals(false));
+      client.close();
+      expect(client.isClosed, equals(true));
+
+      expect(
+        client.read(requestUri),
+        throwsA(const TypeMatcher<http.ClientException>()),
+      );
+    });
   });
 
   group('with invalid credentials', () {


### PR DESCRIPTION
Until now there is no way to detect whether an oauth2.Client is closed or not. This PR changes that.

There is now an isClosed field on the oauth2.Client.

A request on a closed client no longer leads to a 'Null check operator used on a null value' error, but instead an http.ClientException is thrown with a meaningful error message.

---

- [x ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
