### PR TITLE
[test_reflective_loader] Pass test locations to `pkg:test` to improve IDE navigation

### DIFF
--- a/.github/workflows/test_reflective_loader.yaml
+++ b/.github/workflows/test_reflective_loader.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [dev, 3.1]
+        sdk: [dev, 3.2]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/test_reflective_loader.yaml
+++ b/.github/workflows/test_reflective_loader.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [dev, 3.2]
+        sdk: [dev, 3.5]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/pkgs/test_reflective_loader/CHANGELOG.md
+++ b/pkgs/test_reflective_loader/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3.0
 
+- Require Dart `^3.2.0`.
 - Update to `package:test` 1.26.1.
 - Pass locations of groups/tests to `package:test` to improve locations reported
   in the JSON reporter that may be used for navigation in IDEs.

--- a/pkgs/test_reflective_loader/CHANGELOG.md
+++ b/pkgs/test_reflective_loader/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0
+
+- Update to `package:test` 1.26.0.
+- Pass locations of groups/tests to `package:test` to improve locations reported
+  in the JSON reporter that may be used for navigation in IDEs.
+
 ## 0.2.3
 
 - Require Dart `^3.1.0`.

--- a/pkgs/test_reflective_loader/CHANGELOG.md
+++ b/pkgs/test_reflective_loader/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.0
 
-- Update to `package:test` 1.26.0.
+- Update to `package:test` 1.26.1.
 - Pass locations of groups/tests to `package:test` to improve locations reported
   in the JSON reporter that may be used for navigation in IDEs.
 

--- a/pkgs/test_reflective_loader/CHANGELOG.md
+++ b/pkgs/test_reflective_loader/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.0
 
-- Require Dart `^3.2.0`.
+- Require Dart `^3.5.0`.
 - Update to `package:test` 1.26.1.
 - Pass locations of groups/tests to `package:test` to improve locations reported
   in the JSON reporter that may be used for navigation in IDEs.

--- a/pkgs/test_reflective_loader/lib/test_reflective_loader.dart
+++ b/pkgs/test_reflective_loader/lib/test_reflective_loader.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:mirrors';
 
-import 'package:test/scaffolding.dart' as test_package show TestLocation;
 import 'package:test/test.dart' as test_package;
 
 /// A marker annotation used to annotate test methods which are expected to fail

--- a/pkgs/test_reflective_loader/lib/test_reflective_loader.dart
+++ b/pkgs/test_reflective_loader/lib/test_reflective_loader.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:mirrors';
 
-import 'package:test/scaffolding.dart';
+import 'package:test/scaffolding.dart' as test_package show TestLocation;
 import 'package:test/test.dart' as test_package;
 
 /// A marker annotation used to annotate test methods which are expected to fail
@@ -308,14 +308,14 @@ class _AssertFailingTest {
 class _Group {
   final bool isSolo;
   final String name;
-  final TestLocation? location;
+  final test_package.TestLocation? location;
   final List<_Test> tests = <_Test>[];
 
   _Group(this.isSolo, this.name, this.location);
 
   bool get hasSoloTest => tests.any((test) => test.isSolo);
 
-  void addSkippedTest(String name, TestLocation? location) {
+  void addSkippedTest(String name, test_package.TestLocation? location) {
     var fullName = _combineNames(this.name, name);
     tests.add(_Test.skipped(isSolo, fullName, location));
   }
@@ -347,7 +347,7 @@ class _Test {
   final String name;
   final _TestFunction function;
   final test_package.Timeout? timeout;
-  final TestLocation? location;
+  final test_package.TestLocation? location;
 
   final bool isSkipped;
 
@@ -361,9 +361,10 @@ class _Test {
 }
 
 extension on DeclarationMirror {
-  TestLocation? get testLocation {
+  test_package.TestLocation? get testLocation {
     if (location case var location?) {
-      return TestLocation(location.sourceUri, location.line, location.column);
+      return test_package.TestLocation(
+          location.sourceUri, location.line, location.column);
     } else {
       return null;
     }

--- a/pkgs/test_reflective_loader/pubspec.yaml
+++ b/pkgs/test_reflective_loader/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.1.0
 
 dependencies:
-  test: ^1.26.0
+  test: ^1.26.1
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0

--- a/pkgs/test_reflective_loader/pubspec.yaml
+++ b/pkgs/test_reflective_loader/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dart-lang/tools/tree/main/pkgs/test_reflective_lo
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Atest_reflective_loader
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.5.0
 
 dependencies:
   test: ^1.26.1

--- a/pkgs/test_reflective_loader/pubspec.yaml
+++ b/pkgs/test_reflective_loader/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dart-lang/tools/tree/main/pkgs/test_reflective_lo
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Atest_reflective_loader
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   test: ^1.26.1

--- a/pkgs/test_reflective_loader/pubspec.yaml
+++ b/pkgs/test_reflective_loader/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_reflective_loader
-version: 0.2.3
+version: 0.3.0
 description: Support for discovering tests and test suites using reflection.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/test_reflective_loader
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Atest_reflective_loader
@@ -8,7 +8,8 @@ environment:
   sdk: ^3.1.0
 
 dependencies:
-  test: ^1.16.0
+  test: ^1.26.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
+  path: ^1.8.0

--- a/pkgs/test_reflective_loader/test/location_test.dart
+++ b/pkgs/test_reflective_loader/test/location_test.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  test("reports correct locations in the JSON output from 'dart test'",
+      () async {
+    var testPackagePath = (await Isolate.resolvePackageUri(
+            Uri.parse('package:test_reflective_loader/')))!
+        .toFilePath();
+    var testFilePath = path.normalize(path.join(
+        testPackagePath, '..', 'test', 'test_reflective_loader_test.dart'));
+    var testFileContent = File(testFilePath).readAsLinesSync();
+    var result = await Process.run(
+        Platform.resolvedExecutable, ['test', '-r', 'json', testFilePath]);
+
+    var error = result.stderr.toString().trim();
+    var output = result.stdout.toString().trim();
+
+    expect(error, isEmpty);
+    expect(output, isNotEmpty);
+
+    for (var event in LineSplitter.split(output).map(jsonDecode)) {
+      if (event case {'type': 'testStart', 'test': Map<String, Object?> test}) {
+        var name = test['name'] as String;
+
+        // Skip the "loading" test, it never has a location.
+        if (name.startsWith('loading')) {
+          continue;
+        }
+
+        // Split just the method name from the combined test so we can search
+        // the source code to ensure the locations match up.
+        name = name.split('|').last.trim();
+
+        // Expect locations for all remaining fields.
+        var url = test['url'] as String;
+        var line = test['line'] as int;
+        var column = test['column'] as int;
+
+        expect(path.equals(Uri.parse(url).toFilePath(), testFilePath), isTrue);
+
+        // Verify the location provided matches where this test appears in the
+        // file.
+        var lineContent = testFileContent[line - 1];
+        // If the line is an annotation, skip to the next line
+        if (lineContent.trim().startsWith('@')) {
+          lineContent = testFileContent[line];
+        }
+        expect(lineContent, contains(name),
+            reason: 'JSON reports test $name on line $line, '
+                'but line content is "$lineContent"');
+
+        // Verify the column too.
+        var columnContent = lineContent.substring(column - 1);
+        expect(columnContent, contains(name),
+            reason: 'JSON reports test $name at column $column, '
+                'but text at column is "$columnContent"');
+      }
+    }
+  });
+}


### PR DESCRIPTION
This updates `pkg:test_reflective_loader` to the latest version of `pkg:test` and passes the locations of tests declarations through to `test()` calls.

These locations are then used by `pkg:test` in the JSON reporter so that IDEs can navigate to the correct locations of these tests (rather than always to the `defineReflectiveTests()` call, because the real test declarations are not in the call stack at the point that `test()` is called).

Fixes https://github.com/dart-lang/tools/issues/2081
Fixes https://github.com/Dart-Code/Dart-Code/issues/5480


https://github.com/user-attachments/assets/beef0977-0338-4b86-9850-bbc895aeb09a

