### PR TITLE
[coverage] Partial workspace support

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -89,7 +89,7 @@ jobs:
         name: Install dependencies
         run: dart pub get
       - name: Collect and report coverage
-        run: dart run bin/test_with_coverage.dart --port=9292
+        run: dart run bin/test_with_coverage.dart
       - name: Upload coverage
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -56,12 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.4, dev]
-        exclude:
-          # VM service times out on windows before Dart 3.5
-          # https://github.com/dart-lang/coverage/issues/490
-          - os: windows-latest
-            sdk: 3.4
+        sdk: [3.6, dev]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.14.0-wip
 
-- Require Dart ^3.6
+- Require Dart ^3.6.0
 - Partial support for workspace packages in `test_wth_coverage`.
 - Deprecate `test_wth_coverage`'s `--package-name` flag, because it doesn't make
   sense for workspaces.

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.14.0
+
+- Partial support for workspace packages in `test_wth_coverage`.
+- Deprecate `test_wth_coverage`'s `--package-name` flag, because it doesn't make
+  sense for workspaces.
+- Change the default `--port` to 0, allowing the VM to choose a free port.
+
 ## 1.13.1
 
 - Fix a bug where the VM service can be shut down while some coverage

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.14.0
+## 1.14.0-wip
 
 - Require Dart ^3.6
 - Partial support for workspace packages in `test_wth_coverage`.

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.14.0-wip
+## 1.14.0
 
 - Require Dart ^3.6.0
 - Partial support for workspace packages in `test_wth_coverage`.

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.14.0
 
+- Require Dart ^3.6
 - Partial support for workspace packages in `test_wth_coverage`.
 - Deprecate `test_wth_coverage`'s `--package-name` flag, because it doesn't make
   sense for workspaces.

--- a/pkgs/coverage/README.md
+++ b/pkgs/coverage/README.md
@@ -47,7 +47,7 @@ see the sections below.
 
 package:coverage has partial support for
 [workspaces](https://dart.dev/tools/pub/workspaces). You can run
-`test_wth_coverage` from the root of the workspace to collect coverage for all
+`test_with_coverage` from the root of the workspace to collect coverage for all
 the tests in all the subpackages, but you must specify the test directories to
 run.
 

--- a/pkgs/coverage/README.md
+++ b/pkgs/coverage/README.md
@@ -43,6 +43,26 @@ dart pub global run coverage:format_coverage --packages=.dart_tool/package_confi
 For more complicated use cases, where you want to control each of these stages,
 see the sections below.
 
+#### Workspaces
+
+package:coverage has partial support for
+[workspaces](https://dart.dev/tools/pub/workspaces). You can run
+`test_wth_coverage` from the root of the workspace to collect coverage for all
+the tests in all the subpackages, but you must specify the test directories to
+run.
+
+For example, in a workspace with subpackages `pkgs/foo` and `pkgs/bar`, you
+could run the following command from the root directory of the workspace:
+
+```
+dart run coverage:test_with_coverage -- pkgs/foo/test pkgs/bar/test
+```
+
+This would output coverage to ./coverage/ as normal.
+[Full support](https://github.com/dart-lang/tools/issues/2083) for workspaces
+will likely be added in a future version. This will mean you won't need to
+explicitly specify the test directories: `dart run coverage:test_with_coverage`
+
 #### Collecting coverage from the VM
 
 ```

--- a/pkgs/coverage/README.md
+++ b/pkgs/coverage/README.md
@@ -58,7 +58,11 @@ could run the following command from the root directory of the workspace:
 dart run coverage:test_with_coverage -- pkgs/foo/test pkgs/bar/test
 ```
 
-This would output coverage to ./coverage/ as normal.
+This would output coverage to ./coverage/ as normal. An important caveat is that
+the working directory of the tests will be the workspace's root directory. So
+this approach won't work if your tests assume that they are being run from the
+subpackage directory.
+
 [Full support](https://github.com/dart-lang/tools/issues/2083) for workspaces
 will likely be added in a future version. This will mean you won't need to
 explicitly specify the test directories: `dart run coverage:test_with_coverage`

--- a/pkgs/coverage/bin/test_with_coverage.dart
+++ b/pkgs/coverage/bin/test_with_coverage.dart
@@ -211,7 +211,9 @@ Future<void> main(List<String> arguments) async {
     },
     onStderr: (line) {
       if (!serviceUriCompleter.isCompleted) {
-        _killSubprocessesAndExit(ProcessSignal.sigkill);
+        if (line.contains('Could not start the VM service')) {
+          _killSubprocessesAndExit(ProcessSignal.sigkill);
+        }
       }
     },
   );

--- a/pkgs/coverage/bin/test_with_coverage.dart
+++ b/pkgs/coverage/bin/test_with_coverage.dart
@@ -159,13 +159,13 @@ ${parser.usage}
 
   return Flags(
     packageDir,
-    (args['out'] as String?) ?? path.join(packageDir, 'coverage'),
-    args['port'] as String? ?? '0',
-    args['test'] as String,
-    args['function-coverage'] as bool,
-    args['branch-coverage'] as bool,
-    args['scope-output'] as List<String>,
-    args['fail-under'] as String?,
+    args.option('out') ?? path.join(packageDir, 'coverage'),
+    args.option('port') ?? '0',
+    args.option('test')!,
+    args.flag('function-coverage'),
+    args.flag('branch-coverage'),
+    args.multiOption('scope-output'),
+    args.option('fail-under'),
     rest: args.rest,
   );
 }

--- a/pkgs/coverage/dart_test.yaml
+++ b/pkgs/coverage/dart_test.yaml
@@ -1,0 +1,5 @@
+tags:
+  # Tests that start subprocesses, so are slower and can be a bit flaky.
+  integration:
+    timeout: 2x
+    retry: 3

--- a/pkgs/coverage/lib/src/collect.dart
+++ b/pkgs/coverage/lib/src/collect.dart
@@ -264,17 +264,10 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
     return scripts[scriptRef];
   }
 
-  HitMap getHitMap(Uri scriptUri) => hitMaps.putIfAbsent(scriptUri, () {
-        final hits = HitMap();
-        if (functionCoverage) {
-          hits.funcNames = <int, String>{};
-          hits.funcHits = <int, int>{};
-        }
-        if (branchCoverage) {
-          hits.branchHits = <int, int>{};
-        }
-        return hits;
-      });
+  HitMap getHitMap(Uri scriptUri) => hitMaps.putIfAbsent(
+      scriptUri,
+      () => HitMap.empty(
+          functionCoverage: functionCoverage, branchCoverage: branchCoverage));
 
   Future<void> processFunction(FuncRef funcRef) async {
     final func = await service.getObject(isolateRef.id!, funcRef.id!) as Func;

--- a/pkgs/coverage/lib/src/collect.dart
+++ b/pkgs/coverage/lib/src/collect.dart
@@ -265,16 +265,16 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
   }
 
   HitMap getHitMap(Uri scriptUri) => hitMaps.putIfAbsent(scriptUri, () {
-    final hits = HitMap();
-    if (functionCoverage) {
-      hits.funcNames = <int, String>{};
-      hits.funcHits = <int, int>{};
-    }
-    if (branchCoverage) {
-      hits.branchHits = <int, int>{};
-    }
-    return hits;
-  });
+        final hits = HitMap();
+        if (functionCoverage) {
+          hits.funcNames = <int, String>{};
+          hits.funcHits = <int, int>{};
+        }
+        if (branchCoverage) {
+          hits.branchHits = <int, int>{};
+        }
+        return hits;
+      });
 
   Future<void> processFunction(FuncRef funcRef) async {
     final func = await service.getObject(isolateRef.id!, funcRef.id!) as Func;

--- a/pkgs/coverage/lib/src/collect.dart
+++ b/pkgs/coverage/lib/src/collect.dart
@@ -170,6 +170,7 @@ Future<Map<String, dynamic>> _getAllCoverage(
         isolateReport,
         includeDart,
         functionCoverage,
+        branchCoverage,
         coverableLineCache,
         scopedOutput);
     allCoverage.addAll(coverage);
@@ -244,6 +245,7 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
     SourceReport report,
     bool includeDart,
     bool functionCoverage,
+    bool branchCoverage,
     Map<String, Set<int>>? coverableLineCache,
     Set<String> scopedOutput) async {
   final hitMaps = <Uri, HitMap>{};
@@ -262,7 +264,17 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
     return scripts[scriptRef];
   }
 
-  HitMap getHitMap(Uri scriptUri) => hitMaps.putIfAbsent(scriptUri, HitMap.new);
+  HitMap getHitMap(Uri scriptUri) => hitMaps.putIfAbsent(scriptUri, () {
+    final hits = HitMap();
+    if (functionCoverage) {
+      hits.funcNames = <int, String>{};
+      hits.funcHits = <int, int>{};
+    }
+    if (branchCoverage) {
+      hits.branchHits = <int, int>{};
+    }
+    return hits;
+  });
 
   Future<void> processFunction(FuncRef funcRef) async {
     final func = await service.getObject(isolateRef.id!, funcRef.id!) as Func;
@@ -290,8 +302,7 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
       return;
     }
     final hits = getHitMap(Uri.parse(script.uri!));
-    hits.funcHits ??= <int, int>{};
-    (hits.funcNames ??= <int, String>{})[line] = funcName;
+    hits.funcNames![line] = funcName;
   }
 
   for (var range in report.ranges!) {
@@ -385,13 +396,12 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
       hits.funcHits?.putIfAbsent(line, () => 0);
     });
 
-    final branchCoverage = range.branchCoverage;
-    if (branchCoverage != null) {
-      hits.branchHits ??= <int, int>{};
-      forEachLine(branchCoverage.hits, (line) {
+    final branches = range.branchCoverage;
+    if (branchCoverage && branches != null) {
+      forEachLine(branches.hits, (line) {
         hits.branchHits!.increment(line);
       });
-      forEachLine(branchCoverage.misses, (line) {
+      forEachLine(branches.misses, (line) {
         hits.branchHits!.putIfAbsent(line, () => 0);
       });
     }

--- a/pkgs/coverage/lib/src/coverage_options.dart
+++ b/pkgs/coverage/lib/src/coverage_options.dart
@@ -9,7 +9,6 @@ class CoverageOptions {
     required this.functionCoverage,
     required this.branchCoverage,
     required this.packageDirectory,
-    this.packageName,
     required this.testScript,
   });
 
@@ -40,8 +39,6 @@ class CoverageOptions {
       branchCoverage: options.optionalBool('branch_coverage') ??
           defaultOptions.branchCoverage,
       packageDirectory: packageDirectory,
-      packageName:
-          options.optionalString('package_name') ?? defaultOptions.packageName,
       testScript:
           options.optionalString('test_script') ?? defaultOptions.testScript,
     );
@@ -52,7 +49,6 @@ class CoverageOptions {
   final bool functionCoverage;
   final bool branchCoverage;
   final String packageDirectory;
-  final String? packageName;
   final String testScript;
 }
 
@@ -119,7 +115,6 @@ class CoverageOptionsProvider {
     functionCoverage: false,
     branchCoverage: false,
     packageDirectory: '.',
-    packageName: null,
     testScript: 'test',
   );
 }

--- a/pkgs/coverage/lib/src/formatter.dart
+++ b/pkgs/coverage/lib/src/formatter.dart
@@ -151,6 +151,20 @@ extension FileHitMapsFormatter on Map<String, HitMap> {
     );
     final buf = StringBuffer();
     for (final entry in entries) {
+      final source = resolver.resolve(entry.key);
+      if (source == null) {
+        continue;
+      }
+
+      if (!pathFilter(source)) {
+        continue;
+      }
+
+      final lines = await loader.load(source);
+      if (lines == null) {
+        continue;
+      }
+
       final v = entry.value;
       if (reportFuncs && v.funcHits == null) {
         throw StateError(
@@ -165,24 +179,12 @@ extension FileHitMapsFormatter on Map<String, HitMap> {
             'missing branch coverage information. Did you run '
             'collect_coverage with the --branch-coverage flag?');
       }
+
       final hits = reportFuncs
           ? v.funcHits!
           : reportBranches
               ? v.branchHits!
               : v.lineHits;
-      final source = resolver.resolve(entry.key);
-      if (source == null) {
-        continue;
-      }
-
-      if (!pathFilter(source)) {
-        continue;
-      }
-
-      final lines = await loader.load(source);
-      if (lines == null) {
-        continue;
-      }
       buf.writeln(source);
       for (var line = 1; line <= lines.length; line++) {
         var prefix = _prefix;

--- a/pkgs/coverage/lib/src/hitmap.dart
+++ b/pkgs/coverage/lib/src/hitmap.dart
@@ -20,12 +20,12 @@ class HitMap {
 
   /// Constructs an empty hitmap, optionally with function and branch coverage
   /// tables.
-  HitMap.empty({bool functionCoverage = false, bool branchCoverage = false}) :
-      this(
-          null,
-          functionCoverage ? <int, int>{} : null,
-          functionCoverage ? <int, String>{} : null,
-          branchCoverage ? <int, int>{} : null);
+  HitMap.empty({bool functionCoverage = false, bool branchCoverage = false})
+      : this(
+            null,
+            functionCoverage ? <int, int>{} : null,
+            functionCoverage ? <int, String>{} : null,
+            branchCoverage ? <int, int>{} : null);
 
   /// Map from line to hit count for that line.
   final Map<int, int> lineHits;

--- a/pkgs/coverage/lib/src/hitmap.dart
+++ b/pkgs/coverage/lib/src/hitmap.dart
@@ -18,6 +18,15 @@ class HitMap {
     this.branchHits,
   ]) : lineHits = lineHits ?? {};
 
+  /// Constructs an empty hitmap, optionally with function and branch coverage
+  /// tables.
+  HitMap.empty({bool functionCoverage = false, bool branchCoverage = false}) :
+      this(
+          null,
+          functionCoverage ? <int, int>{} : null,
+          functionCoverage ? <int, String>{} : null,
+          branchCoverage ? <int, int>{} : null);
+
   /// Map from line to hit count for that line.
   final Map<int, int> lineHits;
 

--- a/pkgs/coverage/lib/src/util.dart
+++ b/pkgs/coverage/lib/src/util.dart
@@ -59,25 +59,6 @@ Uri? extractVMServiceUri(String str) {
   return null;
 }
 
-/// Returns an open port by creating a temporary Socket
-Future<int> getOpenPort() async {
-  ServerSocket socket;
-
-  try {
-    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-  } catch (_) {
-    // try again v/ V6 only. Slight possibility that V4 is disabled
-    socket =
-        await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
-  }
-
-  try {
-    return socket.port;
-  } finally {
-    await socket.close();
-  }
-}
-
 final muliLineIgnoreStart = RegExp(r'//\s*coverage:ignore-start[\w\d\s]*$');
 final muliLineIgnoreEnd = RegExp(r'//\s*coverage:ignore-end[\w\d\s]*$');
 final singleLineIgnore = RegExp(r'//\s*coverage:ignore-line[\w\d\s]*$');

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.14.0-wip
+version: 1.14.0
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.13.1
+version: 1.14.0
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage
@@ -15,6 +15,7 @@ dependencies:
   meta: ^1.0.2
   package_config: ^2.0.0
   path: ^1.8.0
+  pubspec_parse: ^1.5.0
   source_maps: ^0.10.10
   stack_trace: ^1.10.0
   vm_service: '>=12.0.0 <16.0.0'

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.14.0
+version: 1.14.0-wip
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage

--- a/pkgs/coverage/test/collect_coverage_api_test.dart
+++ b/pkgs/coverage/test/collect_coverage_api_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Tags(['slow'])
+@Tags(['integration'])
 library;
 
 import 'dart:async';
@@ -143,10 +143,8 @@ Future<Map<String, dynamic>> _collectCoverage(
     bool functionCoverage = false,
     bool branchCoverage = false,
     Map<String, Set<int>>? coverableLineCache}) async {
-  final openPort = await getOpenPort();
-
   // run the sample app, with the right flags
-  final sampleProcess = await runTestApp(openPort);
+  final sampleProcess = await runTestApp();
 
   final serviceUri = await serviceUriFromProcess(sampleProcess.stdoutStream());
   final isolateIdSet = isolateIds ? <String>{} : null;

--- a/pkgs/coverage/test/collect_coverage_api_test.dart
+++ b/pkgs/coverage/test/collect_coverage_api_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['slow'])
+library;
+
 import 'dart:async';
 
 import 'package:coverage/coverage.dart';

--- a/pkgs/coverage/test/collect_coverage_config_test.dart
+++ b/pkgs/coverage/test/collect_coverage_config_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:coverage/src/coverage_options.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -35,7 +39,6 @@ void main() {
 
       expect(path.canonicalize(testCoverage.packageDir),
           path.canonicalize(defaults.packageDirectory));
-      expect(testCoverage.packageName, 'coverage');
       expect(path.canonicalize(testCoverage.outDir),
           path.canonicalize('coverage'));
       expect(testCoverage.testScript, defaults.testScript);
@@ -73,7 +76,6 @@ void main() {
     // Verify test with coverage yaml values
     expect(path.canonicalize(testCoverage.packageDir),
         path.canonicalize('test/test_files'));
-    expect(testCoverage.packageName, 'My Dart Package');
     expect(path.canonicalize(testCoverage.outDir),
         path.canonicalize('var/coverage_data'));
     expect(testCoverage.testScript, 'test1');
@@ -102,7 +104,6 @@ void main() {
       expect(collectedCoverage.functionCoverage, isFalse);
       expect(path.canonicalize(formattedCoverage.output!),
           path.canonicalize('var/coverage_data/custom_coverage/lcov.info'));
-      expect(testCoverage.packageName, 'Custom Dart Package');
       expect(testCoverage.scopeOutput, ['lib', 'test']);
     });
 
@@ -133,7 +134,6 @@ void main() {
           path.canonicalize('test/test_coverage_options'));
 
       // Verify test with coverage yaml values
-      expect(testCoverage.packageName, 'coverage');
       expect(path.canonicalize(testCoverage.outDir),
           path.canonicalize('var/coverage_data/custom_lcov'));
       expect(testCoverage.testScript, 'custom_test');
@@ -178,7 +178,6 @@ void main() {
       expect(formattedCoverage.packagePath, '../code_builder');
 
       // Verify test with coverage command line args
-      expect(testCoverage.packageName, 'test');
       expect(testCoverage.outDir, 'test_coverage.json');
       expect(testCoverage.testScript, 'test_test.dart');
       expect(testCoverage.functionCoverage, isTrue);
@@ -218,7 +217,6 @@ void main() {
       expect(formattedCoverage.packagePath, '../cli_config');
 
       // Verify test with coverage command line args
-      expect(testCoverage.packageName, 'cli_config');
       expect(testCoverage.outDir, 'cli_config_coverage.json');
       expect(testCoverage.testScript, 'cli_config_test.dart');
       expect(testCoverage.functionCoverage, isTrue);

--- a/pkgs/coverage/test/collect_coverage_test.dart
+++ b/pkgs/coverage/test/collect_coverage_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Retry(3)
+@Tags(['slow'])
 library;
 
 import 'dart:async';

--- a/pkgs/coverage/test/collect_coverage_test.dart
+++ b/pkgs/coverage/test/collect_coverage_test.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Retry(3)
-@Tags(['slow'])
+@Tags(['integration'])
 library;
 
 import 'dart:async';
@@ -295,10 +294,8 @@ Future<String> _collectCoverage(
     bool functionCoverage, bool branchCoverage) async {
   expect(FileSystemEntity.isFileSync(testAppPath), isTrue);
 
-  final openPort = await getOpenPort();
-
   // Run the sample app with the right flags.
-  final sampleProcess = await runTestApp(openPort);
+  final sampleProcess = await runTestApp();
 
   // Capture the VM service URI.
   final serviceUri = await serviceUriFromProcess(sampleProcess.stdoutStream());

--- a/pkgs/coverage/test/config_file_locator_test.dart
+++ b/pkgs/coverage/test/config_file_locator_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'package:coverage/src/coverage_options.dart';
 import 'package:path/path.dart' as path;

--- a/pkgs/coverage/test/function_coverage_test.dart
+++ b/pkgs/coverage/test/function_coverage_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Tags(['slow'])
+@Tags(['integration'])
 library;
 
 import 'dart:async';
@@ -77,11 +77,9 @@ void main() {
 Future<String> _collectCoverage() async {
   expect(FileSystemEntity.isFileSync(_funcCovApp), isTrue);
 
-  final openPort = await getOpenPort();
-
   // Run the sample app with the right flags.
   final sampleProcess = await TestProcess.start(Platform.resolvedExecutable, [
-    '--enable-vm-service=$openPort',
+    '--enable-vm-service=0',
     '--pause_isolates_on_exit',
     _funcCovApp
   ]);

--- a/pkgs/coverage/test/function_coverage_test.dart
+++ b/pkgs/coverage/test/function_coverage_test.dart
@@ -78,11 +78,8 @@ Future<String> _collectCoverage() async {
   expect(FileSystemEntity.isFileSync(_funcCovApp), isTrue);
 
   // Run the sample app with the right flags.
-  final sampleProcess = await TestProcess.start(Platform.resolvedExecutable, [
-    '--enable-vm-service=0',
-    '--pause_isolates_on_exit',
-    _funcCovApp
-  ]);
+  final sampleProcess = await TestProcess.start(Platform.resolvedExecutable,
+      ['--enable-vm-service=0', '--pause_isolates_on_exit', _funcCovApp]);
 
   final serviceUri = await serviceUriFromProcess(sampleProcess.stdoutStream());
 

--- a/pkgs/coverage/test/function_coverage_test.dart
+++ b/pkgs/coverage/test/function_coverage_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['slow'])
+library;
+
 import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:io';

--- a/pkgs/coverage/test/lcov_test.dart
+++ b/pkgs/coverage/test/lcov_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['slow'])
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/pkgs/coverage/test/lcov_test.dart
+++ b/pkgs/coverage/test/lcov_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Tags(['slow'])
+@Tags(['integration'])
 library;
 
 import 'dart:async';
@@ -340,13 +340,10 @@ void main() {
 Future<Map<String, HitMap>> _getHitMap() async {
   expect(FileSystemEntity.isFileSync(_sampleAppPath), isTrue);
 
-  // select service port.
-  final port = await getOpenPort();
-
   // start sample app.
   final sampleAppArgs = [
     '--pause-isolates-on-exit',
-    '--enable-vm-service=$port',
+    '--enable-vm-service=0',
     '--branch-coverage',
     _sampleAppPath
   ];

--- a/pkgs/coverage/test/run_and_collect_test.dart
+++ b/pkgs/coverage/test/run_and_collect_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Tags(['slow'])
+@Tags(['integration'])
 library;
 
 import 'package:coverage/coverage.dart';

--- a/pkgs/coverage/test/run_and_collect_test.dart
+++ b/pkgs/coverage/test/run_and_collect_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['slow'])
+library;
+
 import 'package:coverage/coverage.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';

--- a/pkgs/coverage/test/test_coverage_options/pubspec.yaml
+++ b/pkgs/coverage/test/test_coverage_options/pubspec.yaml
@@ -1,0 +1,1 @@
+name: test_coverage_options

--- a/pkgs/coverage/test/test_files/pubspec.yaml
+++ b/pkgs/coverage/test/test_files/pubspec.yaml
@@ -1,0 +1,5 @@
+name: coverage_test_files
+
+dev_dependencies:
+  coverage:
+    path: ../../

--- a/pkgs/coverage/test/test_util.dart
+++ b/pkgs/coverage/test/test_util.dart
@@ -11,7 +11,7 @@ import 'package:test_process/test_process.dart';
 
 final String testAppPath = p.join('test', 'test_files', 'test_app.dart');
 
-const Duration timeout = Duration(seconds: 20);
+const Duration timeout = Duration(seconds: 30);
 
 Future<TestProcess> runTestApp() => TestProcess.start(
       Platform.resolvedExecutable,

--- a/pkgs/coverage/test/test_util.dart
+++ b/pkgs/coverage/test/test_util.dart
@@ -13,10 +13,10 @@ final String testAppPath = p.join('test', 'test_files', 'test_app.dart');
 
 const Duration timeout = Duration(seconds: 20);
 
-Future<TestProcess> runTestApp(int openPort) => TestProcess.start(
+Future<TestProcess> runTestApp() => TestProcess.start(
       Platform.resolvedExecutable,
       [
-        '--enable-vm-service=$openPort',
+        '--enable-vm-service=0',
         '--pause_isolates_on_exit',
         '--branch-coverage',
         testAppPath

--- a/pkgs/coverage/test/test_with_coverage_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(seconds: 60))
+@Tags(['slow'])
 library;
 
 import 'dart:convert';

--- a/pkgs/coverage/test/test_with_coverage_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_test.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(Duration(seconds: 60))
-@Tags(['slow'])
+@Tags(['integration'])
 library;
 
 import 'dart:convert';

--- a/pkgs/coverage/test/util_test.dart
+++ b/pkgs/coverage/test/util_test.dart
@@ -355,4 +355,22 @@ void main() {
       ]);
     });
   });
+
+  test('getAllWorkspaceNames', () {
+    // Uses the workspace_names directory:
+    // workspace_names
+    // └── pkgs
+    //     ├── foo
+    //     │   └── foo_example  // Not part of foo's workspace.
+    //     └── bar
+    //         └── bar_example  // Part of bar's workspace.
+    expect(
+        getAllWorkspaceNames('test/workspace_names'),
+        unorderedEquals([
+          'workspace_names',
+          'foo',
+          'bar',
+          'bar_example',
+        ]));
+  });
 }

--- a/pkgs/coverage/test/workspace_names/pkgs/bar/bar_example/pubspec.yaml
+++ b/pkgs/coverage/test/workspace_names/pkgs/bar/bar_example/pubspec.yaml
@@ -1,0 +1,2 @@
+name: bar_example
+resolution: workspace

--- a/pkgs/coverage/test/workspace_names/pkgs/bar/pubspec.yaml
+++ b/pkgs/coverage/test/workspace_names/pkgs/bar/pubspec.yaml
@@ -1,0 +1,4 @@
+name: bar
+resolution: workspace
+workspace:
+- bar_example

--- a/pkgs/coverage/test/workspace_names/pkgs/foo/foo_example/pubspec.yaml
+++ b/pkgs/coverage/test/workspace_names/pkgs/foo/foo_example/pubspec.yaml
@@ -1,0 +1,1 @@
+name: foo_example

--- a/pkgs/coverage/test/workspace_names/pkgs/foo/pubspec.yaml
+++ b/pkgs/coverage/test/workspace_names/pkgs/foo/pubspec.yaml
@@ -1,0 +1,2 @@
+name: foo
+resolution: workspace

--- a/pkgs/coverage/test/workspace_names/pubspec.yaml
+++ b/pkgs/coverage/test/workspace_names/pubspec.yaml
@@ -1,0 +1,4 @@
+name: workspace_names
+workspace:
+- pkgs/bar
+- pkgs/foo


### PR DESCRIPTION
The eventual goal is that the user should be able to run `dart run coverage:test_with_coverage` from the workspace root, and it runs all the tests in the workspace and produces a single coverage report. There are 2 problems that need to be solved for this to happen:

1) Find and run all the tests (with the correct working directory)
2) Update the scoping logic to not exclude the subpackages from the report

I'm only tackling the scoping changes for now (see [this comment](https://github.com/dart-lang/tools/issues/2083#issuecomment-2892543659)). So this means that users can run `test_with_coverage` from the workspace root, but they have to manually specify the tests they want to run: `dart run coverage:test_with_coverage -- pkgs/foo/test pkgs/bar/test`.

The packages included in the final report are controlled by the `--scope-output` option. The problem is with the default behavior, where it defaults to the current package. This excludes all the subpackages. The fix is just to parse the pubspec.yaml file, and include all the subpackages in the default scopes. Workspaces can be nested, so we have to do this recursively.

#2083

### Other changes

- Deprecated the `--package-name` option. It's only used to set the `--scope-output` option, so it's a bit redundant. And it doesn't make sense in the context of workspaces anyway.
- Changed the default `--port` option to 0. There's special logic in the Dart VM that will choose an arbitrary free port if you set `--enable-vm-service=0`.
- Tag all the integration tests so that I can do `dart test -x integration` to run all the fast tests during development. Also, pull out the common bits of integration test config to dart_test.yaml.
- Bump min SDK version so that we have access to workspaces
- Unrelated changes to `lib/src/collect.dart` and `lib/src/formatter.dart` to fix some failing tests
- Fail gracefully if the VM service fails to start. Fixes #2096