### PR TITLE
[coverage] Fix remaining ~0.1% flakiness

### DIFF
--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.14.1
+
+- Silence a rare error that can occur when trying to resume the main isolate
+  because the VM service has already shut down. This was responsible for a ~0.1%
+  flakiness, and is safe to ignore.
+
 ## 1.14.0
 
 - Require Dart ^3.6.0

--- a/pkgs/coverage/lib/src/isolate_paused_listener.dart
+++ b/pkgs/coverage/lib/src/isolate_paused_listener.dart
@@ -63,7 +63,11 @@ class IsolatePausedListener {
 
     // Resume the main isolate.
     if (_mainIsolate != null) {
-      await _service.resume(_mainIsolate!.id!);
+      try {
+        await _service.resume(_mainIsolate!.id!);
+      } catch (RPCError) {
+        // The VM Service has already shut down, so there's nothing left to do.
+      }
     }
   }
 

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.14.0
+version: 1.14.1
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage


### PR DESCRIPTION
https://github.com/dart-lang/test/pull/2494 has landed and has almost eliminated all the flakiness from coverage collection. But I'm still seeing about ~0.1% flakiness.

This last bit of flakiness is hard to debug. The error is the same as before (trying to resume the main isolate after the VM service has already shut down), but the event sequence that leads to that point looks correct. There's no reason the service should have shut down at that point.

```
onStart: main (this is identified as the main isolate)
onPause: main
onStart: test_suite:file:///build/work/bd7788ee6ad0...
onPause: test_suite:file:///build/work/bd7788ee6ad0...
collectIsolate: test_suite:file:///build/work/bd7788ee6ad0...
    done collecting: test_suite:file:///build/work/bd7788ee6ad0...
Resuming: test_suite:file:///build/work/bd7788ee6ad0...
collectIsolate: main
onExit: test_suite:file:///build/work/bd7788ee6ad0...
    done collecting: main
Resuming main: main
Failed to resume main: resume: (-32000) Service connection disposed

resume: (-32000) Service connection disposed
package:vm_service/src/vm_service.dart 268:34                         new _OutstandingRequest
package:vm_service/src/vm_service.dart 1950:25                        VmService._call.<fn>
package:vm_service/src/vm_service.dart 1962:8                         VmService._call
package:vm_service/src/vm_service.dart 1651:7                         VmService.resume
package:coverage/src/isolate_paused_listener.dart 68:24               IsolatePausedListener.waitUntilAllExited
```

There's always the option of catching the RPC error and ignoring it. I was hesitant to do this earlier because I didn't want to hide legitimate errors that could lead to missing coverage. But the main isolate's coverage is being collected successfully, so I think it's safe enough to ignore the error at this point.