### PR TITLE
Don't emit two WatchEvents when creating a file in a non-existent directory on Windows

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.2-wip
+## 1.1.2
 
 - Fix a bug on Windows where a file creation event could be reported twice when creating
   a file recursively in a non-existent directory.

--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2-wip
+
+- Fix a bug on Windows where a file creation event could be reported twice when creating
+  a file recursively in a non-existent directory.
+
 ## 1.1.1
 
 - Ensure `PollingFileWatcher.ready` completes for files that do not exist.

--- a/pkgs/watcher/lib/src/directory_watcher/windows.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/windows.dart
@@ -184,7 +184,7 @@ class _WindowsDirectoryWatcher
           var stream = Directory(path).list(recursive: true);
           var subscription = stream.listen((entity) {
             if (entity is Directory) return;
-            if (_files.contains(path)) return;
+            if (_files.contains(entity.path)) return;
 
             _emitEvent(ChangeType.ADD, entity.path);
             _files.add(entity.path);

--- a/pkgs/watcher/pubspec.yaml
+++ b/pkgs/watcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 1.1.2-wip
+version: 1.1.2
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.

--- a/pkgs/watcher/pubspec.yaml
+++ b/pkgs/watcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 1.1.1
+version: 1.1.2-wip
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.

--- a/pkgs/watcher/test/directory_watcher/windows_test.dart
+++ b/pkgs/watcher/test/directory_watcher/windows_test.dart
@@ -5,6 +5,10 @@
 @TestOn('windows')
 library;
 
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/windows.dart';
 import 'package:watcher/watcher.dart';
@@ -19,5 +23,42 @@ void main() {
 
   test('DirectoryWatcher creates a WindowsDirectoryWatcher on Windows', () {
     expect(DirectoryWatcher('.'), const TypeMatcher<WindowsDirectoryWatcher>());
+  });
+
+  test('Regression test for https://github.com/dart-lang/tools/issues/2110',
+      () async {
+    late StreamSubscription<WatchEvent> sub;
+    try {
+      final temp = Directory.systemTemp.createTempSync();
+      final watcher = DirectoryWatcher(temp.path);
+      final events = <WatchEvent>[];
+      sub = watcher.events.listen(events.add);
+      await watcher.ready;
+
+      // Create a file in a directory that doesn't exist. This forces the
+      // directory to be created first before the child file.
+      //
+      // When directory creation is detected by the watcher, it calls
+      // `Directory.list` on the directory to determine if there's files that
+      // have been created or modified. It's possible that the watcher will have
+      // already detected the file creation event before `Directory.list`
+      // returns. Before https://github.com/dart-lang/tools/issues/2110 was
+      // resolved, the check to ensure an event hadn't already been emitted for
+      // the file creation was incorrect, leading to the event being emitted
+      // again in some circumstances.
+      final file = File(p.join(temp.path, 'foo', 'file.txt'))
+        ..createSync(recursive: true);
+
+      // Introduce a short delay to allow for the directory watcher to detect
+      // the creation of foo/ and foo/file.txt.
+      await Future<void>.delayed(const Duration(seconds: 1));
+
+      // There should only be a single file added event.
+      expect(events, hasLength(1));
+      expect(events.first.toString(),
+          WatchEvent(ChangeType.ADD, file.path).toString());
+    } finally {
+      await sub.cancel();
+    }
   });
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/tools/issues/2110