### PR TITLE
Add dart mcp server events

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.0.2
+- Added `Event.dartMCPEvent` for events from the `dart mcp-server` command.
+
 ## 8.0.1
 - Added `Event.flutterInjectDarwinPlugins` event for plugins injected into an iOS/macOS project.
 

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '8.0.1';
+const String kPackageVersion = '8.0.2';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -55,9 +55,9 @@ enum DashEvent {
     description: 'Pub package resolution details',
     toolOwner: DashTool.dartTool,
   ),
-  dartMcpToolEvent(
-    label: 'dart_mcp_tool',
-    description: 'Information for a Dart MCP tool invocation',
+  dartMCPEvent(
+    label: 'dart_mcp_server',
+    description: 'Information for a Dart MCP server event',
     toolOwner: DashTool.dartTool,
   ),
 

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -55,6 +55,11 @@ enum DashEvent {
     description: 'Pub package resolution details',
     toolOwner: DashTool.dartTool,
   ),
+  dartMcpToolEvent(
+    label: 'dart_mcp_tool',
+    description: 'Information for a Dart MCP tool invocation',
+    toolOwner: DashTool.dartTool,
+  ),
 
   // Events for Flutter devtools
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -905,6 +905,31 @@ final class Event {
           },
         );
 
+  /// Event that is sent from the Dart MCP server when a tool is invoked.
+  ///
+  /// The [tool] is the name of the tool that was invoked.
+  ///
+  /// If [success] is `true`, it indicates the tool was successfully invoked,
+  /// specifically this corresponds to the `isError` field on the tool result.
+  ///
+  /// The [elapsedMilliseconds] is the total time from when the tool call was
+  /// received by the server, to when the response was initiated by the server.
+  /// This does not measure the total round trip time, just the time spent in
+  /// the servers own handling of requests. It includes time spent handling
+  /// any other asynchronous tasks as well.
+  Event.dartMcpTool({
+    required String tool,
+    required bool success,
+    required int elapsedMilliseconds,
+  }) : this._(
+          eventName: DashEvent.dartMcpToolEvent,
+          eventData: {
+            'tool': tool,
+            'success': success,
+            'elapsedMilliseconds': elapsedMilliseconds,
+          },
+        );
+
   @override
   int get hashCode => Object.hash(eventName, jsonEncode(eventData));
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -921,7 +921,7 @@ final class Event {
     required String type,
     required Map<String, Object?> eventData,
   }) : this._(
-          eventName: DashEvent.dartMcpToolEvent,
+          eventName: DashEvent.dartMCPEvent,
           eventData: {
             'client': client,
             'clientVersion': clientVersion,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -919,7 +919,7 @@ final class Event {
     required String clientVersion,
     required String serverVersion,
     required String type,
-    required Map<String, Object?> eventData,
+    CustomMetrics? additionalData,
   }) : this._(
           eventName: DashEvent.dartMCPEvent,
           eventData: {
@@ -927,7 +927,7 @@ final class Event {
             'clientVersion': clientVersion,
             'serverVersion': serverVersion,
             'type': type,
-            'eventData': eventData,
+            ...?additionalData?.toMap(),
           },
         );
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -909,6 +909,9 @@ final class Event {
   ///
   /// The [tool] is the name of the tool that was invoked.
   ///
+  /// The [client] is the name of the client, as given when it connected to the
+  /// MCP server, and [clientVersion] is the version of the client.
+  ///
   /// If [success] is `true`, it indicates the tool was successfully invoked,
   /// specifically this corresponds to the `isError` field on the tool result.
   ///
@@ -919,12 +922,16 @@ final class Event {
   /// any other asynchronous tasks as well.
   Event.dartMcpTool({
     required String tool,
+    required String client,
+    required String clientVersion,
     required bool success,
     required int elapsedMilliseconds,
   }) : this._(
           eventName: DashEvent.dartMcpToolEvent,
           eventData: {
             'tool': tool,
+            'client': client,
+            'clientVersion': clientVersion,
             'success': success,
             'elapsedMilliseconds': elapsedMilliseconds,
           },

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -907,33 +907,27 @@ final class Event {
 
   /// Event that is sent from the Dart MCP server when a tool is invoked.
   ///
-  /// The [tool] is the name of the tool that was invoked.
-  ///
   /// The [client] is the name of the client, as given when it connected to the
   /// MCP server, and [clientVersion] is the version of the client.
   ///
-  /// If [success] is `true`, it indicates the tool was successfully invoked,
-  /// specifically this corresponds to the `isError` field on the tool result.
+  /// The [serverVersion] is the version of the Dart MCP server.
   ///
-  /// The [elapsedMilliseconds] is the total time from when the tool call was
-  /// received by the server, to when the response was initiated by the server.
-  /// This does not measure the total round trip time, just the time spent in
-  /// the servers own handling of requests. It includes time spent handling
-  /// any other asynchronous tasks as well.
-  Event.dartMcpTool({
-    required String tool,
+  /// The [type] identifies the kind of event this is, and [eventData] is the
+  /// actual data for that event.
+  Event.dartMCPEvent({
     required String client,
     required String clientVersion,
-    required bool success,
-    required int elapsedMilliseconds,
+    required String serverVersion,
+    required String type,
+    required Map<String, Object?> eventData,
   }) : this._(
           eventName: DashEvent.dartMcpToolEvent,
           eventData: {
-            'tool': tool,
             'client': client,
             'clientVersion': clientVersion,
-            'success': success,
-            'elapsedMilliseconds': elapsedMilliseconds,
+            'serverVersion': serverVersion,
+            'type': type,
+            'eventData': eventData,
           },
         );
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -905,15 +905,15 @@ final class Event {
           },
         );
 
-  /// Event that is sent from the Dart MCP server when a tool is invoked.
+  /// An event that is sent from the Dart MCP server.
   ///
   /// The [client] is the name of the client, as given when it connected to the
   /// MCP server, and [clientVersion] is the version of the client.
   ///
   /// The [serverVersion] is the version of the Dart MCP server.
   ///
-  /// The [type] identifies the kind of event this is, and [eventData] is the
-  /// actual data for that event.
+  /// The [type] identifies the kind of event this is, and [additionalData] is
+  /// the actual data for the event.
   Event.dartMCPEvent({
     required String client,
     required String clientVersion,

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 8.0.1
+version: 8.0.2
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aunified_analytics

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -655,6 +655,27 @@ void main() {
     expect(constructedEvent.eventData.length, 20);
   });
 
+  test('Event.dartMCPEvent constructed', () {
+    final event = Event.dartMCPEvent(
+        client: 'test client',
+        clientVersion: '1.0.0',
+        serverVersion: '1.1.0',
+        type: 'some_event',
+        additionalData:
+            _TestMetrics(boolField: true, stringField: 'hello', intField: 1));
+    expect(
+        event.eventData,
+        equals({
+          'client': 'test client',
+          'clientVersion': '1.0.0',
+          'serverVersion': '1.1.0',
+          'type': 'some_event',
+          'boolField': true,
+          'stringField': 'hello',
+          'intField': 1,
+        }));
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (final declaration in reflectClass(Event).declarations.keys) {
@@ -667,7 +688,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 28;
+    final eventsAccountedForInTests = 29;
     expect(eventsAccountedForInTests, constructorCount,
         reason: 'If you added or removed an event constructor, '
             'ensure you have updated '


### PR DESCRIPTION
This is more a proposal for potential new analytics events than a PR intended to be merged right now.

Specifically, we should consider whether we want a more general purpose event type, or specific events for different MCP server interactions.

For example we do expose runtime errors as both a tool and a resource currently, depending on the client support. Do we want a separate event to capture access to resources, or should we try and make this more general so we can add that kind of event later on without changes to this package?