### PR TITLE
[unified_analytics]Add library cycle info to analysis server data

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 8.0.2
 - Added `Event.dartMCPEvent` for events from the `dart mcp-server` command.
+- Changed `Event.contextStructure` to make optional data that's no longer being
+  collected and to add data about the size of library cycles.
 
 ## 8.0.1
 - Added `Event.flutterInjectDarwinPlugins` event for plugins injected into an iOS/macOS project.

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -309,18 +309,6 @@ final class Event {
   /// Event that is emitted on shutdown to report the structure of the analysis
   /// contexts created immediately after startup.
   ///
-  /// [contextsFromBothFiles] - the number of contexts that were created because
-  ///     of both a package config and an analysis options file.
-  ///
-  /// [contextsFromOptionsFiles] - the number of contexts that were created
-  ///     because of an analysis options file.
-  ///
-  /// [contextsFromPackagesFiles] - the number of contexts that were created
-  ///     because of a package config file.
-  ///
-  /// [contextsWithoutFiles] - the number of contexts that were created because
-  ///     of the lack of either a package config or an analysis options file.
-  ///
   /// [immediateFileCount] - the number of files in one of the analysis
   ///     contexts.
   ///
@@ -341,11 +329,25 @@ final class Event {
   ///
   /// [transitiveFileUniqueLineCount] - the number of lines in the unique
   ///     transitive files.
+  ///
+  /// [libraryCycleLibraryCounts] - json encoded percentile values indicating
+  ///     the number of libraries in a single library cycle.
+  ///
+  /// [libraryCycleLineCounts] - json encoded percentile values indicating the
+  ///     number of lines of code in all of the files in a single library cycle.
+  ///
+  /// [contextsFromBothFiles] - the number of contexts that were created because
+  ///     of both a package config and an analysis options file.
+  ///
+  /// [contextsFromOptionsFiles] - the number of contexts that were created
+  ///     because of an analysis options file.
+  ///
+  /// [contextsFromPackagesFiles] - the number of contexts that were created
+  ///     because of a package config file.
+  ///
+  /// [contextsWithoutFiles] - the number of contexts that were created because
+  ///     of the lack of either a package config or an analysis options file.
   Event.contextStructure({
-    required int contextsFromBothFiles,
-    required int contextsFromOptionsFiles,
-    required int contextsFromPackagesFiles,
-    required int contextsWithoutFiles,
     required int immediateFileCount,
     required int immediateFileLineCount,
     required int numberOfContexts,
@@ -353,13 +355,15 @@ final class Event {
     required int transitiveFileLineCount,
     required int transitiveFileUniqueCount,
     required int transitiveFileUniqueLineCount,
+    String libraryCycleLibraryCounts = '',
+    String libraryCycleLineCounts = '',
+    int contextsFromBothFiles = 0,
+    int contextsFromOptionsFiles = 0,
+    int contextsFromPackagesFiles = 0,
+    int contextsWithoutFiles = 0,
   }) : this._(
           eventName: DashEvent.contextStructure,
           eventData: {
-            'contextsFromBothFiles': contextsFromBothFiles,
-            'contextsFromOptionsFiles': contextsFromOptionsFiles,
-            'contextsFromPackagesFiles': contextsFromPackagesFiles,
-            'contextsWithoutFiles': contextsWithoutFiles,
             'immediateFileCount': immediateFileCount,
             'immediateFileLineCount': immediateFileLineCount,
             'numberOfContexts': numberOfContexts,
@@ -367,6 +371,12 @@ final class Event {
             'transitiveFileLineCount': transitiveFileLineCount,
             'transitiveFileUniqueCount': transitiveFileUniqueCount,
             'transitiveFileUniqueLineCount': transitiveFileUniqueLineCount,
+            'libraryCycleLibraryCounts': libraryCycleLibraryCounts,
+            'libraryCycleLineCounts': libraryCycleLineCounts,
+            'contextsFromBothFiles': contextsFromBothFiles,
+            'contextsFromOptionsFiles': contextsFromOptionsFiles,
+            'contextsFromPackagesFiles': contextsFromPackagesFiles,
+            'contextsWithoutFiles': contextsWithoutFiles,
           },
         );
 

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -85,35 +85,35 @@ void main() {
 
   test('Event.contextStructure constructed', () {
     Event generateEvent() => Event.contextStructure(
-          contextsFromBothFiles: 1,
-          contextsFromOptionsFiles: 2,
-          contextsFromPackagesFiles: 3,
-          contextsWithoutFiles: 4,
-          immediateFileCount: 5,
-          immediateFileLineCount: 6,
-          numberOfContexts: 7,
-          transitiveFileCount: 8,
-          transitiveFileLineCount: 9,
-          transitiveFileUniqueCount: 10,
-          transitiveFileUniqueLineCount: 11,
+          immediateFileCount: 1,
+          immediateFileLineCount: 2,
+          numberOfContexts: 3,
+          transitiveFileCount: 4,
+          transitiveFileLineCount: 5,
+          transitiveFileUniqueCount: 6,
+          transitiveFileUniqueLineCount: 7,
+          libraryCycleLibraryCounts: 'a',
+          libraryCycleLineCounts: 'b',
         );
 
     final constructedEvent = generateEvent();
 
     expect(generateEvent, returnsNormally);
     expect(constructedEvent.eventName, DashEvent.contextStructure);
-    expect(constructedEvent.eventData['contextsFromBothFiles'], 1);
-    expect(constructedEvent.eventData['contextsFromOptionsFiles'], 2);
-    expect(constructedEvent.eventData['contextsFromPackagesFiles'], 3);
-    expect(constructedEvent.eventData['contextsWithoutFiles'], 4);
-    expect(constructedEvent.eventData['immediateFileCount'], 5);
-    expect(constructedEvent.eventData['immediateFileLineCount'], 6);
-    expect(constructedEvent.eventData['numberOfContexts'], 7);
-    expect(constructedEvent.eventData['transitiveFileCount'], 8);
-    expect(constructedEvent.eventData['transitiveFileLineCount'], 9);
-    expect(constructedEvent.eventData['transitiveFileUniqueCount'], 10);
-    expect(constructedEvent.eventData['transitiveFileUniqueLineCount'], 11);
-    expect(constructedEvent.eventData.length, 11);
+    expect(constructedEvent.eventData['immediateFileCount'], 1);
+    expect(constructedEvent.eventData['immediateFileLineCount'], 2);
+    expect(constructedEvent.eventData['numberOfContexts'], 3);
+    expect(constructedEvent.eventData['transitiveFileCount'], 4);
+    expect(constructedEvent.eventData['transitiveFileLineCount'], 5);
+    expect(constructedEvent.eventData['transitiveFileUniqueCount'], 6);
+    expect(constructedEvent.eventData['transitiveFileUniqueLineCount'], 7);
+    expect(constructedEvent.eventData['libraryCycleLibraryCounts'], 'a');
+    expect(constructedEvent.eventData['libraryCycleLineCounts'], 'b');
+    expect(constructedEvent.eventData['contextsFromBothFiles'], 0);
+    expect(constructedEvent.eventData['contextsFromOptionsFiles'], 0);
+    expect(constructedEvent.eventData['contextsFromPackagesFiles'], 0);
+    expect(constructedEvent.eventData['contextsWithoutFiles'], 0);
+    expect(constructedEvent.eventData.length, 13);
   });
 
   test('Event.dartCliCommandExecuted constructed', () {


### PR DESCRIPTION
Add fields to capture analysis information on library cycles to the `Event.contextStructure`.  Also make optional data that is stale and no longer useful for us. These will be removed in a future PR.



