### PR TITLE
[code_builder] Set `external` and `static` in correct order

### DIFF
--- a/pkgs/code_builder/CHANGELOG.md
+++ b/pkgs/code_builder/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Upgrade `dart_style` and `source_gen` to remove `package:macros` dependency.
 * Require Dart `^3.6.0` due to the upgrades.
 * Support `Expression.newInstanceNamed` with empty name
+* Fixed bug: Fields declared with `static` and `external` now produce code with correct order
 
 ## 4.10.1
 

--- a/pkgs/code_builder/lib/src/emitter.dart
+++ b/pkgs/code_builder/lib/src/emitter.dart
@@ -437,14 +437,14 @@ class DartEmitter extends Object
     for (var a in spec.annotations) {
       visitAnnotation(a, output);
     }
+    if (spec.external) {
+      output.write('external ');
+    }
     if (spec.static) {
       output.write('static ');
     }
     if (spec.late && _useNullSafetySyntax) {
       output.write('late ');
-    }
-    if (spec.external) {
-      output.write('external ');
     }
     switch (spec.modifier) {
       case FieldModifier.var$:

--- a/pkgs/code_builder/test/specs/field_test.dart
+++ b/pkgs/code_builder/test/specs/field_test.dart
@@ -110,4 +110,34 @@ void main() {
       '''),
     );
   });
+
+  test('should create a late static field', () {
+    expect(
+      Field((b) => b
+        ..name = 'value'
+        ..static = true
+        ..late = true
+        ..type = refer('String')
+        ..annotations.addAll([refer('JS').call([])])),
+      equalsDart(r'''
+        @JS()
+        static late String value;
+      ''', DartEmitter(useNullSafetySyntax: true)),
+    );
+  });
+
+  test('should create an external static field', () {
+    expect(
+      Field((b) => b
+        ..name = 'value'
+        ..external = true
+        ..static = true
+        ..type = refer('double')
+        ..annotations.addAll([refer('JS').call([])])),
+      equalsDart(r'''
+        @JS()
+        external static double value;
+      '''),
+    );
+  });
 }


### PR DESCRIPTION
Closes #2118 

This PR fixes the order of the `external` and `static` keywords in fields to follow correct Dart language structure.
Fields in `code_builder` should now render as `external static` rather than `static external` when both are `true`.

---

<details>
  <summary>Contribution guidelines</summary><br>
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
</details>
