### PR TITLE
[Markdown] Fix HTML comment parser.

### DIFF
--- a/pkgs/markdown/CHANGELOG.md
+++ b/pkgs/markdown/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update the README link to the markdown playground
   (https://dart-lang.github.io/tools).
 * Update `package:web` API references in the example.
+* Fix performance and correctness of HTML comment parser.
 * Require Dart `^3.4.0`.
 
 ## 7.3.0

--- a/pkgs/markdown/lib/src/inline_syntaxes/inline_html_syntax.dart
+++ b/pkgs/markdown/lib/src/inline_syntaxes/inline_html_syntax.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// These are RegExps, always use raw strings.
+// ignore_for_file: unnecessary_raw_strings
+
 import '../../markdown.dart';
 import '../charcode.dart';
 import '../patterns.dart';
@@ -22,23 +25,23 @@ class InlineHtmlSyntax extends TextSyntax {
 
       // HTML comment, see
       // https://spec.commonmark.org/0.30/#html-comment.
-      '<!--(?:(?:[^-<>]+-[^-<>]+)+|[^-<>]+)-->'
+      r'<!--(?!-?>)[^\-]*-(?:[^\-]+-)*?->'
       '|'
 
       // Processing-instruction, see
       // https://spec.commonmark.org/0.30/#processing-instruction
-      r'<\?.*?\?>'
+      r'<\?[^]*?\?>'
       '|'
 
       // Declaration, see
       // https://spec.commonmark.org/0.30/#declaration.
-      '(<![a-z]+.*?>)'
+      r'(<![a-zA-Z]+[^]*?>)'
       '|'
 
       // CDATA section, see
       // https://spec.commonmark.org/0.30/#cdata-section.
-      r'(<!\[CDATA\[.*?]]>)';
+      r'(<!\[CDATA\[[^]*?\]\]>)';
 
   InlineHtmlSyntax()
-      : super(_pattern, startCharacter: $lt, caseSensitive: false);
+      : super(_pattern, startCharacter: $lt, caseSensitive: true);
 }

--- a/pkgs/markdown/lib/src/patterns.dart
+++ b/pkgs/markdown/lib/src/patterns.dart
@@ -65,7 +65,7 @@ const namedTagDefinition =
     '<'
 
     // Tag name.
-    '[a-z][a-z0-9-]*'
+    '[a-zA-Z][a-zA-Z0-9-]*'
 
     // Attribute begins, see
     // https://spec.commonmark.org/0.30/#attribute.
@@ -73,7 +73,7 @@ const namedTagDefinition =
 
     // Attribute name, see
     // https://spec.commonmark.org/0.30/#attribute-name.
-    '[a-z_:][a-z0-9._:-]*'
+    '[a-zA-Z_:][a-zA-Z0-9._:-]*'
 
     //
     '(?:'
@@ -96,7 +96,7 @@ const namedTagDefinition =
 
     // Closing tag, see
     // https://spec.commonmark.org/0.30/#closing-tag.
-    r'</[a-z][a-z0-9-]*\s*>';
+    r'</[a-zA-Z][a-zA-Z0-9-]*\s*>';
 
 /// A pattern to match the start of an HTML block.
 ///

--- a/pkgs/markdown/test/regression_test.dart
+++ b/pkgs/markdown/test/regression_test.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:markdown/markdown.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('HTML comment with dashes #2119', () {
+    // See https://dartbug.com/tools/2119.
+    // For this issue, the leading letter was needed,
+    // an HTML comment starting a line is handled by a different path.
+    // The empty line before the `-->` is needed.
+    // The number of lines increase time exponentially.
+    // The length of lines affect the base of the exponentiation.
+    // Locally, three "Lorem-ipsum" lines ran in ~6 seconds, two in < 200 ms.
+    // Adding a fourth line should ensure it cannot possibly finish in ten
+    // seconds if the bug isn't fixed.
+    const input = '''
+a <!-- 
+    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+-->
+''';
+
+    final time = Stopwatch()..start();
+    final html = markdownToHtml(input); // Should not hang.
+    final elapsed = time.elapsedMilliseconds;
+    expect(elapsed, lessThan(10000));
+  });
+
+  test('HTML comment with lt/gt', () {
+    // Incorrect parsing found as part of fixing #2119.
+    // Now matches `<!--$text-->` where text
+    // does not start with `>` or `->`, does not end with `-`,
+    // and does not contain `--`.
+    const input = 'a <!--<->>-<!-->';
+    final html = markdownToHtml(input);
+    expect(html, '<p>$input</p>\n');
+  });
+}

--- a/pkgs/markdown/test/regression_test.dart
+++ b/pkgs/markdown/test/regression_test.dart
@@ -18,15 +18,28 @@ void main() {
     // seconds if the bug isn't fixed.
     const input = '''
 a <!-- 
-    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+      ut aliquip ex ea commodo consequat.
+    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+      ut aliquip ex ea commodo consequat.
+    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+      ut aliquip ex ea commodo consequat.
+    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+      ut aliquip ex ea commodo consequat.
 -->
 ''';
 
     final time = Stopwatch()..start();
     final html = markdownToHtml(input); // Should not hang.
+    expect(html, isNotNull); // To use the output.
     final elapsed = time.elapsedMilliseconds;
     expect(elapsed, lessThan(10000));
   });


### PR DESCRIPTION
See #2119 

 Fix performance and correctness of HTML comment parser.
    
RegExp had catastrophic backtracking. Also didn't match the spec if linked to.
(Which is still CM 30, not 31.2, they differ.)
    
Fixed a few other incorrect parsings.
- The content of `<?...?>`, `<!a...>` and `<![CDATA[...]]>` can
  contain newlines. Changed `.` to `[^]`.
- The `<![CDATA[` tag is case sensitive. Changed RegExp to be
  case sensitive, so added `A-Z` to all the `a-z`s used in that
  regexp.
