### PR TITLE
[coverage] Expose `filterIgnored` function

### DIFF
--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.15.0
+
+- Expose `filterIgnored` function, which filters the coverage data according to
+  `// coverage:ignore-...` comments. Previously this filtering functionality
+  was only available when loading coverage data from json using `parseJson` etc.
+
 ## 1.14.1
 
 - Remove dependency on `package:pubspec_parse`.

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.14.1
+version: 1.15.0
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage

--- a/pkgs/coverage/test/filter_ignored_test.dart
+++ b/pkgs/coverage/test/filter_ignored_test.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:coverage/coverage.dart' show Resolver;
+import 'package:coverage/src/hitmap.dart';
+import 'package:test/test.dart';
+
+String fileUri(String relativePath) =>
+    Uri.file(File(relativePath).absolute.path).toString();
+
+void main() {
+  test('filter ignored', () async {
+    // The ignored lines come from the comments in the test dart files. But the
+    // hitmaps are fake, and don't have to correspond to real coverage data.
+    final hitmaps = {
+      fileUri('nonexistent_file.dart'): HitMap(
+        {1: 1, 2: 2, 3: 3},
+        {1: 1, 2: 2, 3: 3},
+        {1: "abc", 2: "def"},
+        {1: 1, 2: 2, 3: 3},
+      ),
+      fileUri('another_nonexistent_file.dart'): HitMap(
+        {1: 1, 2: 2, 3: 3},
+      ),
+      fileUri('test/test_files/test_app.dart'): HitMap(
+        {1: 1, 2: 2, 3: 3},
+        {1: 1, 2: 2, 3: 3},
+        {1: "abc", 2: "def"},
+        {1: 1, 2: 2, 3: 3},
+      ),
+      fileUri('test/test_files/test_app_isolate.dart'): HitMap(
+        { for (var i = 50; i < 100; ++i) i: i },
+        { for (var i = 50; i < 100; ++i) i: i },
+        { for (var i = 50; i < 100; ++i) i: '$i' },
+        { for (var i = 50; i < 100; ++i) i: i },
+      ),
+    };
+
+    // Lines ignored in test/test_files/test_app_isolate.dart.
+    const ignores = [
+      52,
+      54,
+      55,
+      56,
+      57,
+      58,
+      63,
+      64,
+      65,
+      66,
+      67,
+      68,
+      69,
+      70,
+      71,
+      72,
+      73,
+    ];
+
+    final expected = {
+      fileUri('nonexistent_file.dart'): HitMap(
+        {1: 1, 2: 2, 3: 3},
+        {1: 1, 2: 2, 3: 3},
+        {1: "abc", 2: "def"},
+        {1: 1, 2: 2, 3: 3},
+      ),
+      fileUri('another_nonexistent_file.dart'): HitMap(
+        {1: 1, 2: 2, 3: 3},
+      ),
+      fileUri('test/test_files/test_app_isolate.dart'): HitMap(
+        { for (var i = 50; i < 100; ++i) if (!ignores.contains(i)) i: i },
+        { for (var i = 50; i < 100; ++i) if (!ignores.contains(i)) i: i },
+        { for (var i = 50; i < 100; ++i) i: '$i' },
+        { for (var i = 50; i < 100; ++i) if (!ignores.contains(i)) i: i },
+      ),
+    };
+
+    final resolver = await Resolver.create(packagePath: '.');
+
+    final actual = hitmaps.filterIgnored(
+        ignoredLinesInFilesCache: {}, resolver: resolver);
+
+    expect(actual.keys.toList(), expected.keys.toList());
+    for (final source in expected.keys) {
+      expect(actual[source]!.lineHits, expected[source]!.lineHits);
+      expect(actual[source]!.funcHits, expected[source]!.funcHits);
+      expect(actual[source]!.funcNames, expected[source]!.funcNames);
+      expect(actual[source]!.branchHits, expected[source]!.branchHits);
+    }
+  });
+}

--- a/pkgs/coverage/test/util_test.dart
+++ b/pkgs/coverage/test/util_test.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: only_throw_errors
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:coverage/src/util.dart';
 import 'package:test/test.dart';
@@ -237,9 +238,7 @@ void main() {
       for (final content in invalidSources) {
         final lines = content.split('\n');
         lines.add(' // coverage:ignore-file');
-        expect(getIgnoredLines('', lines), [
-          [0, lines.length]
-        ]);
+        expect(getIgnoredLines('', lines), null);
       }
     });
 
@@ -250,9 +249,7 @@ void main() {
       '''
           .split('\n');
 
-      expect(getIgnoredLines('', lines), [
-        [0, lines.length]
-      ]);
+      expect(getIgnoredLines('', lines), null);
     });
 
     test('return the correct range of lines ignored', () {
@@ -372,5 +369,30 @@ void main() {
           'bar',
           'bar_example',
         ]));
+  });
+
+  test('IgnoredLinesContains', () {
+    (List<List<int>>, int) createRandomRanges(int len) {
+      final ranges = <List<int>>[];
+      int line = 0;
+      final rand = Random();
+      while (ranges.length < len) {
+        int start = (line += 1 + rand.nextInt(5));
+        int end = (line += rand.nextInt(5));
+        ranges.add([start, end]);
+      }
+      return (ranges, line);
+    }
+
+    bool naiveIgnoredContains(List<List<int>> ranges, int line) =>
+        ranges.any((range) => range[0] <= line && range[1] >= line);
+
+    for (final len in [0, 1, 2, 3, 10, 100, 1000]) {
+      final (ranges, end) = createRandomRanges(len);
+      for (var line = 0; line < end + 3; ++line) {
+        expect(ranges.ignoredContains(line),
+            naiveIgnoredContains(ranges, line));
+      }
+    }
   });
 }


### PR DESCRIPTION
`package:coverage` ignores lines that have `// coverage:ignore-...` comments, but for historical reasons this filtering is only applied during the formatting phase, when JSON coverage data is converted to LCOV etc. Specifically, there's a flag in the `parseJson` function that applies this filtering.

This PR pulls that functionality out into its own API function, `filterIgnored`. That way, clients can apply this filtering to their coverage data without converting it to JSON and back.

While I was at it, I also rewrote the algorithm that determines if a line is ignored. Previously it was a somewhat brittle stateful algorithm involving advancing a line range iterator while iterating through the hitmap (which also made potentially unsafe assumptions about the iteration order of the map). Now it's a simple binary search.

Part of https://github.com/dart-lang/test/issues/2511