### PR TITLE
Fixed no blank lines between extension members (#1143)

### DIFF
--- a/pkgs/code_builder/CHANGELOG.md
+++ b/pkgs/code_builder/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 4.10.2-wip
 
+* Support `Expression.newInstanceNamed` with empty name
+* Consistently add blank lines between `=>` in class-like definitions.
+* Fixed bug: Fields declared with `static` and `external` now produce code with
+  correct order
 * Upgrade `dart_style` and `source_gen` to remove `package:macros` dependency.
 * Require Dart `^3.6.0` due to the upgrades.
-* Support `Expression.newInstanceNamed` with empty name
-* Fixed bug: Fields declared with `static` and `external` now produce code with correct order
 
 ## 4.10.1
 

--- a/pkgs/code_builder/lib/src/emitter.dart
+++ b/pkgs/code_builder/lib/src/emitter.dart
@@ -204,7 +204,7 @@ class DartEmitter extends Object
     for (var m in spec.methods) {
       visitMethod(m, out);
       if (_isLambdaMethod(m)) {
-        out.write(';');
+        out.writeln(';');
       }
       out.writeln();
     }
@@ -910,7 +910,7 @@ class DartEmitter extends Object
     for (var m in spec.methods) {
       visitMethod(m, out);
       if (_isLambdaMethod(m)) {
-        out.write(';');
+        out.writeln(';');
       }
       out.writeln();
     }

--- a/pkgs/code_builder/lib/src/emitter.dart
+++ b/pkgs/code_builder/lib/src/emitter.dart
@@ -329,7 +329,7 @@ class DartEmitter extends Object
     for (var m in spec.methods) {
       visitMethod(m, out);
       if (_isLambdaMethod(m)) {
-        out.write(';');
+        out.writeln(';');
       }
       out.writeln();
     }


### PR DESCRIPTION
Just change method from write to writeln so that extension class members have black lines between them mentioned in #1143 
---

- [ X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
