### PR TITLE
add support for `setUpClass` and `tearDownClass`

### DIFF
--- a/pkgs/test_reflective_loader/CHANGELOG.md
+++ b/pkgs/test_reflective_loader/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+- Add support for one-time set up and teardown in test classes via static
+  `setUpClass` and `tearDownClass` methods
+
 ## 0.3.0
 
 - Require Dart `^3.5.0`.

--- a/pkgs/test_reflective_loader/pubspec.yaml
+++ b/pkgs/test_reflective_loader/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_reflective_loader
-version: 0.3.0
+version: 0.4.0
 description: Support for discovering tests and test suites using reflection.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/test_reflective_loader
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Atest_reflective_loader

--- a/pkgs/test_reflective_loader/test/location_test.dart
+++ b/pkgs/test_reflective_loader/test/location_test.dart
@@ -40,6 +40,11 @@ void main() {
         // the source code to ensure the locations match up.
         name = name.split('|').last.trim();
 
+        // Skip "tearDownAll" or "setUpAll", it never has a location.
+        if (name case '(tearDownAll)' || '(setUpAll)') {
+          continue;
+        }
+
         // Expect locations for all remaining fields.
         var url = test['url'] as String;
         var line = test['line'] as int;

--- a/pkgs/test_reflective_loader/test/test_reflective_loader_test.dart
+++ b/pkgs/test_reflective_loader/test/test_reflective_loader_test.dart
@@ -11,14 +11,53 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 void main() {
   defineReflectiveSuite(() {
+    // ensure set-ups and tear-downs are not prematurely called ie before any
+    // tests actually execute
+    setUpAll(() {
+      expect(TestReflectiveLoaderTest.didSetUpClass, false);
+      expect(TestReflectiveLoaderTest.didTearDownClass, false);
+      expect(SecondTest.didSetUpClass, false);
+      expect(SecondTest.didTearDownClass, false);
+    });
     defineReflectiveTests(TestReflectiveLoaderTest);
+    defineReflectiveTests(SecondTest);
+    tearDownAll(() {
+      expect(TestReflectiveLoaderTest.didSetUpClass, true);
+      expect(TestReflectiveLoaderTest.didTearDownClass, true);
+      expect(SecondTest.didSetUpClass, true);
+      expect(SecondTest.didTearDownClass, true);
+    });
   });
 }
 
 @reflectiveTest
 class TestReflectiveLoaderTest {
-  void test_passes() {
-    expect(true, true);
+  static bool didSetUpClass = false;
+  static bool didTearDownClass = false;
+
+  // TODO(scheglov): Linter was updated to automatically ignore
+  // this but needs time before it is actually used. Remove this
+  // ignore and others like it in this file once the linter
+  // change is active in this project:
+  // ignore: unreachable_from_main
+  static void setUpClass() {
+    expect(didSetUpClass, false);
+    didSetUpClass = true;
+    expect(didTearDownClass, false);
+  }
+
+  // TODO(scheglov): See comment directly above
+  // "TestReflectiveLoaderTest.setUpClass" for info about this ignore:
+  // ignore: unreachable_from_main
+  static void tearDownClass() {
+    expect(didSetUpClass, true);
+    expect(didTearDownClass, false);
+    didTearDownClass = true;
+  }
+
+  void test_classwide_state() {
+    expect(didSetUpClass, true);
+    expect(didTearDownClass, false);
   }
 
   @failingTest
@@ -26,8 +65,8 @@ class TestReflectiveLoaderTest {
     expect(false, true);
   }
 
-  @failingTest
-  void test_fails_throws_sync() {
+  @skippedTest
+  void test_fails_but_skipped() {
     throw StateError('foo');
   }
 
@@ -36,13 +75,46 @@ class TestReflectiveLoaderTest {
     return Future.error('foo');
   }
 
-  @skippedTest
-  void test_fails_but_skipped() {
+  @failingTest
+  void test_fails_throws_sync() {
     throw StateError('foo');
+  }
+
+  void test_passes() {
+    expect(true, true);
   }
 
   @skippedTest
   void test_times_out_but_skipped() {
     while (true) {}
+  }
+}
+
+@reflectiveTest
+class SecondTest {
+  static bool didSetUpClass = false;
+  static bool didTearDownClass = false;
+
+  // TODO(scheglov): See comment directly above
+  // "TestReflectiveLoaderTest.setUpClass" for info about this ignore:
+  // ignore: unreachable_from_main
+  static void setUpClass() {
+    expect(didSetUpClass, false);
+    didSetUpClass = true;
+    expect(didTearDownClass, false);
+  }
+
+  // TODO(scheglov): See comment directly above
+  // "TestReflectiveLoaderTest.setUpClass" for info about this ignore:
+  // ignore: unreachable_from_main
+  static void tearDownClass() {
+    expect(didSetUpClass, true);
+    expect(didTearDownClass, false);
+    didTearDownClass = true;
+  }
+
+  void test_classwide_state() {
+    expect(didSetUpClass, true);
+    expect(didTearDownClass, false);
   }
 }


### PR DESCRIPTION
if a test class defines `setUpClass` it will be run before any tests are ever run. if it is asynchronous then no test runs until the future is completed

`tearDownClass` is called once after all tests are run

~the same `InstanceMirror` is used for the setup and for the tear-down, following how setup and tear-down is done for each unit test~

tests are updated to support and check for new behavior