### PR TITLE
Add tests for file watcher behavior with links.

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.4-wip
+
+- Bug fix: with `FileWatcher` on MacOS, an incorrect modify event was sometimes
+  reported if the file was created immediately before the watcher was created.
+  Now, file creation is never reported as a modification. This makes the behavior on
+  MacOS consistent with other platforms and with the polling watcher.
+
 ## 1.1.3
 
 - Improve handling of

--- a/pkgs/watcher/lib/src/file_watcher/native.dart
+++ b/pkgs/watcher/lib/src/file_watcher/native.dart
@@ -69,7 +69,7 @@ class _NativeFileWatcher implements FileWatcher, ManuallyClosedWatcher {
     // event to be received. Even if the file already existed. Ignore it.
     if (Platform.isMacOS) {
       _existsResult ??= await _exists!;
-      if (!_existsResult! &&
+      if (_existsResult! &&
           batch.every((event) => event.type == FileSystemEvent.create)) {
         return;
       }

--- a/pkgs/watcher/lib/src/file_watcher/native.dart
+++ b/pkgs/watcher/lib/src/file_watcher/native.dart
@@ -58,6 +58,14 @@ class _NativeFileWatcher implements FileWatcher, ManuallyClosedWatcher {
       return;
     }
 
+    // There should not be any `create` events: the watch is on a file that
+    // already exists. On MacOS `File.watch` docs say "changes that occur
+    // shortly _before_ the `watch` method is called may ... appear", and this
+    // can cause a `create` event to be received. Ignore it.
+    if (batch.every((event) => event.type == FileSystemEvent.create)) {
+      return;
+    }
+
     _eventsController.add(WatchEvent(ChangeType.MODIFY, path));
   }
 

--- a/pkgs/watcher/pubspec.yaml
+++ b/pkgs/watcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 1.1.3
+version: 1.1.4-wip
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.

--- a/pkgs/watcher/test/file_watcher/file_tests.dart
+++ b/pkgs/watcher/test/file_watcher/file_tests.dart
@@ -80,12 +80,20 @@ void fileTests({required bool isNative}) {
 
     if (isNative && Platform.isLinux) {
       expect(expectNoEvents, throwsA(isA<PathNotFoundException>()));
-    } else {
-      // TODO(davidmorgan): polling watcher and MacOS watcher should throw on
-      // missing file like the native Linux watcher.
-      expect(await expectNoEvents(), null);
+    } else if (isNative && Platform.isMacOS) {
+      // TODO(davidmorgan): MacOS watcher does not throw on watch of missing
+      // file, does not report creation, reports modification as modification.
+      await expectNoEvents();
       writeFile('other_file.txt');
-      expect(await expectNoEvents(), null);
+      await expectNoEvents();
+      writeFile('other_file.txt');
+      await expectModifyEvent('other_file.txt');
+    } else {
+      // TODO(davidmorgan): Polling watcher does not throw on watch of missing
+      // file, and reports creation and modification as modification.
+      await expectNoEvents();
+      writeFile('other_file.txt');
+      await expectModifyEvent('other_file.txt');
       writeFile('other_file.txt');
       await expectModifyEvent('other_file.txt');
     }

--- a/pkgs/watcher/test/file_watcher/file_tests.dart
+++ b/pkgs/watcher/test/file_watcher/file_tests.dart
@@ -78,19 +78,10 @@ void fileTests({required bool isNative}) {
   test('throws if file does not exist', () async {
     await startWatcher(path: 'other_file.txt');
 
+    // TODO(davidmorgan): reconcile differences.
     if (isNative && Platform.isLinux) {
       expect(expectNoEvents, throwsA(isA<PathNotFoundException>()));
-    } else if (isNative && Platform.isMacOS) {
-      // TODO(davidmorgan): MacOS watcher does not throw on watch of missing
-      // file, does not report creation, reports modification as modification.
-      await expectNoEvents();
-      writeFile('other_file.txt');
-      await expectNoEvents();
-      writeFile('other_file.txt');
-      await expectModifyEvent('other_file.txt');
     } else {
-      // TODO(davidmorgan): Polling watcher does not throw on watch of missing
-      // file, and reports creation and modification as modification.
       await expectNoEvents();
       writeFile('other_file.txt');
       await expectModifyEvent('other_file.txt');

--- a/pkgs/watcher/test/file_watcher/file_tests.dart
+++ b/pkgs/watcher/test/file_watcher/file_tests.dart
@@ -84,6 +84,9 @@ void fileTests({required bool isNative}) {
       // TODO(davidmorgan): polling watcher should throw on missing file like
       // the native watcher.
       expect(await expectNoEvents(), null);
+
+      writeFile('other_file.txt');
+      expect(await expectNoEvents(), null);
     }
   });
 }

--- a/pkgs/watcher/test/file_watcher/file_tests.dart
+++ b/pkgs/watcher/test/file_watcher/file_tests.dart
@@ -78,15 +78,16 @@ void fileTests({required bool isNative}) {
   test('throws if file does not exist', () async {
     await startWatcher(path: 'other_file.txt');
 
-    if (isNative) {
+    if (isNative && Platform.isLinux) {
       expect(expectNoEvents, throwsA(isA<PathNotFoundException>()));
     } else {
-      // TODO(davidmorgan): polling watcher should throw on missing file like
-      // the native watcher.
+      // TODO(davidmorgan): polling watcher and MacOS watcher should throw on
+      // missing file like the native Linux watcher.
       expect(await expectNoEvents(), null);
-
       writeFile('other_file.txt');
       expect(await expectNoEvents(), null);
+      writeFile('other_file.txt');
+      await expectModifyEvent('other_file.txt');
     }
   });
 }

--- a/pkgs/watcher/test/file_watcher/file_tests.dart
+++ b/pkgs/watcher/test/file_watcher/file_tests.dart
@@ -2,16 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import '../utils.dart';
 
-void sharedTests() {
+void fileTests({required bool isNative}) {
+  setUp(() async {
+    writeFile('file.txt');
+  });
+
   test("doesn't notify if the file isn't modified", () async {
     await startWatcher(path: 'file.txt');
-    await pumpEventQueue();
-    deleteFile('file.txt');
-    await expectRemoveEvent('file.txt');
+    await expectNoEvents();
   });
 
   test('notifies when a file is modified', () async {
@@ -69,5 +73,17 @@ void sharedTests() {
   test('ready completes even if file does not exist', () async {
     // startWatcher awaits 'ready'
     await startWatcher(path: 'foo/bar/baz');
+  });
+
+  test('throws if file does not exist', () async {
+    await startWatcher(path: 'other_file.txt');
+
+    if (isNative) {
+      expect(expectNoEvents, throwsA(isA<PathNotFoundException>()));
+    } else {
+      // TODO(davidmorgan): polling watcher should throw on missing file like
+      // the native watcher.
+      expect(await expectNoEvents(), null);
+    }
   });
 }

--- a/pkgs/watcher/test/file_watcher/link_tests.dart
+++ b/pkgs/watcher/test/file_watcher/link_tests.dart
@@ -1,0 +1,168 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void linkTests({required bool isNative}) {
+  setUp(() async {
+    writeFile('target.txt');
+    writeLink(link: 'link.txt', target: 'target.txt');
+  });
+
+  test("doesn't notify if nothing is modified", () async {
+    await startWatcher(path: 'link.txt');
+    await expectNoEvents();
+  });
+
+  test('notifies when a link is overwritten with an identical file', () async {
+    await startWatcher(path: 'link.txt');
+    writeFile('link.txt');
+    await expectModifyEvent('link.txt');
+  });
+
+  test('notifies when a link is overwritten with a different file', () async {
+    await startWatcher(path: 'link.txt');
+    writeFile('link.txt', contents: 'modified');
+    await expectModifyEvent('link.txt');
+  });
+
+  test(
+    'notifies when a link target is overwritten with an identical file',
+    () async {
+      await startWatcher(path: 'link.txt');
+      writeFile('target.txt');
+
+      // TODO(davidmorgan): reconcile differences.
+      if (isNative) {
+        await expectModifyEvent('link.txt');
+      } else {
+        await expectNoEvents();
+      }
+    },
+  );
+
+  test('notifies when a link target is modified', () async {
+    await startWatcher(path: 'link.txt');
+    writeFile('target.txt', contents: 'modified');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectModifyEvent('link.txt');
+    } else {
+      await expectNoEvents();
+    }
+  });
+
+  test('notifies when a link is removed', () async {
+    await startWatcher(path: 'link.txt');
+    deleteFile('link.txt');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectNoEvents();
+    } else {
+      await expectRemoveEvent('link.txt');
+    }
+  });
+
+  test('notifies when a link target is removed', () async {
+    await startWatcher(path: 'link.txt');
+    deleteFile('target.txt');
+    await expectRemoveEvent('link.txt');
+  });
+
+  test('notifies when a link target is modified multiple times', () async {
+    await startWatcher(path: 'link.txt');
+
+    writeFile('target.txt', contents: 'modified');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectModifyEvent('link.txt');
+    } else {
+      await expectNoEvents();
+    }
+
+    writeFile('target.txt', contents: 'modified again');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectModifyEvent('link.txt');
+    } else {
+      await expectNoEvents();
+    }
+  });
+
+  test('notifies when a link is moved away', () async {
+    await startWatcher(path: 'link.txt');
+    renameFile('link.txt', 'new.txt');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectNoEvents();
+    } else {
+      await expectRemoveEvent('link.txt');
+    }
+  });
+
+  test('notifies when a link target is moved away', () async {
+    await startWatcher(path: 'link.txt');
+    renameFile('target.txt', 'new.txt');
+    await expectRemoveEvent('link.txt');
+  });
+
+  test('notifies when an identical file is moved over the link', () async {
+    await startWatcher(path: 'link.txt');
+    writeFile('old.txt');
+    renameFile('old.txt', 'link.txt');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectNoEvents();
+    } else {
+      await expectModifyEvent('link.txt');
+    }
+  });
+
+  test('notifies when an different file is moved over the link', () async {
+    await startWatcher(path: 'link.txt');
+    writeFile('old.txt', contents: 'modified');
+    renameFile('old.txt', 'link.txt');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectNoEvents();
+    } else {
+      await expectModifyEvent('link.txt');
+    }
+  });
+
+  test('notifies when an identical file is moved over the target', () async {
+    await startWatcher(path: 'link.txt');
+    writeFile('old.txt');
+    renameFile('old.txt', 'target.txt');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectModifyEvent('link.txt');
+    } else {
+      await expectNoEvents();
+    }
+  });
+
+  test('notifies when a different file is moved over the target', () async {
+    await startWatcher(path: 'link.txt');
+    writeFile('old.txt', contents: 'modified');
+    renameFile('old.txt', 'target.txt');
+
+    // TODO(davidmorgan): reconcile differences.
+    if (isNative) {
+      await expectModifyEvent('link.txt');
+    } else {
+      await expectNoEvents();
+    }
+  });
+}

--- a/pkgs/watcher/test/file_watcher/native_test.dart
+++ b/pkgs/watcher/test/file_watcher/native_test.dart
@@ -9,14 +9,14 @@ import 'package:test/test.dart';
 import 'package:watcher/src/file_watcher/native.dart';
 
 import '../utils.dart';
-import 'shared.dart';
+import 'file_tests.dart';
+import 'link_tests.dart';
+import 'startup_race_tests.dart';
 
 void main() {
   watcherFactory = NativeFileWatcher.new;
 
-  setUp(() {
-    writeFile('file.txt');
-  });
-
-  sharedTests();
+  fileTests(isNative: true);
+  linkTests(isNative: true);
+  startupRaceTests();
 }

--- a/pkgs/watcher/test/file_watcher/polling_test.dart
+++ b/pkgs/watcher/test/file_watcher/polling_test.dart
@@ -2,19 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
 import '../utils.dart';
-import 'shared.dart';
+import 'file_tests.dart';
+import 'link_tests.dart';
+import 'startup_race_tests.dart';
 
 void main() {
-  watcherFactory = (file) =>
-      PollingFileWatcher(file, pollingDelay: const Duration(milliseconds: 100));
+  watcherFactory = (file) => PollingFileWatcher(
+        file,
+        pollingDelay: const Duration(milliseconds: 100),
+      );
 
-  setUp(() {
-    writeFile('file.txt');
-  });
-
-  sharedTests();
+  fileTests(isNative: false);
+  linkTests(isNative: false);
+  startupRaceTests();
 }

--- a/pkgs/watcher/test/file_watcher/startup_race_tests.dart
+++ b/pkgs/watcher/test/file_watcher/startup_race_tests.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+/// Tests for a startup race that affects MacOS.
+///
+/// As documented in `File.watch`, changes from shortly _before_ the `watch`
+/// method is called might be reported on MacOS. They should be ignored.
+/// Runs on other platforms too, where no special handling should be needed.
+void startupRaceTests() {
+  test('writing then immediately watching catches most events', () async {
+    // Write then immediately watch 100 times and count the events received.
+    var events = 0;
+    final futures = <Future<void>>[];
+    for (var i = 0; i != 100; ++i) {
+      writeFile('file$i.txt');
+      await startWatcher(path: 'file$i.txt');
+      futures.add(
+        waitForEvent().then((event) {
+          if (event != null) ++events;
+        }),
+      );
+    }
+    await Future.wait(futures);
+    expect(events, 0);
+  });
+}


### PR DESCRIPTION
For #2170.

File watchers are simpler that directory watchers, so start adding test coverage around symlinks there.