### PR TITLE
Add test coverage around startup race and missing file on startup.

### DIFF
--- a/pkgs/watcher/test/file_watcher/native_test.dart
+++ b/pkgs/watcher/test/file_watcher/native_test.dart
@@ -9,14 +9,12 @@ import 'package:test/test.dart';
 import 'package:watcher/src/file_watcher/native.dart';
 
 import '../utils.dart';
-import 'shared.dart';
+import 'file_tests.dart';
+import 'startup_race_tests.dart';
 
 void main() {
   watcherFactory = NativeFileWatcher.new;
 
-  setUp(() {
-    writeFile('file.txt');
-  });
-
-  sharedTests();
+  fileTests(isNative: true);
+  startupRaceTests(isNative: true);
 }

--- a/pkgs/watcher/test/file_watcher/polling_test.dart
+++ b/pkgs/watcher/test/file_watcher/polling_test.dart
@@ -2,19 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
 import '../utils.dart';
-import 'shared.dart';
+import 'file_tests.dart';
+import 'startup_race_tests.dart';
 
 void main() {
   watcherFactory = (file) =>
       PollingFileWatcher(file, pollingDelay: const Duration(milliseconds: 100));
 
-  setUp(() {
-    writeFile('file.txt');
-  });
-
-  sharedTests();
+  fileTests(isNative: false);
+  startupRaceTests(isNative: false);
 }

--- a/pkgs/watcher/test/file_watcher/startup_race_tests.dart
+++ b/pkgs/watcher/test/file_watcher/startup_race_tests.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+/// Tests for a startup race that affects MacOS.
+///
+/// As documented in `File.watch`, changes from shortly _before_ the `watch`
+/// method is called might be reported on MacOS. They should be ignored.
+void startupRaceTests({required bool isNative}) {
+  test('ignores events from before watch starts', () async {
+    // Write then immediately watch 100 times and count the events received.
+    var events = 0;
+    final futures = <Future<void>>[];
+    for (var i = 0; i != 100; ++i) {
+      writeFile('file$i.txt');
+      await startWatcher(path: 'file$i.txt');
+      futures.add(
+        waitForEvent().then((event) {
+          if (event != null) ++events;
+        }),
+      );
+    }
+    await Future.wait(futures);
+
+    // TODO(davidmorgan): the MacOS watcher currently does get unwanted events,
+    // fix it.
+    if (isNative && Platform.isMacOS) {
+      expect(events, greaterThan(10));
+    } else {
+      expect(events, 0);
+    }
+  });
+}


### PR DESCRIPTION
For #2170, start adding test coverage.

I initially started adding test coverage around symlinks, but encountered two existing issues that made it awkward

 - there is a race on startup on MacOS that means there might be events from before the watch; the existing tests are flaky because of this issue
 - the file watchers have inconsistent behavior if the file watched does not exist

Cover both of these with tests before making any changes :)

Add `expectNoEvents` and use it in one existing test as it's more readable than triggering then waiting for a different event.