### PR TITLE
Update watcher overflow detection

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.4-wip
+
+- Improve handling of subdirectories on Linux: watching subdirectories is
+  inherently racy with file-system modifications so watcher must be prepared
+  for `Directory.watch` to fail with `PathNotFoundException`.
+
 ## 1.1.3
 
 - Improve handling of
@@ -6,7 +12,7 @@
   events. But, the restart would sometimes silently fail. Now, it is more
   reliable.
 - Improving handling of directories that are created then immediately deleted on
-  Windows. Previously, that could cause a `PathNotfoundException` to be thrown.
+  Windows. Previously, that could cause a `PathNotFoundException` to be thrown.
 
 ## 1.1.2
 

--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Improve handling of subdirectories on Linux: watching subdirectories is
   inherently racy with file-system modifications so watcher must be prepared
   for `Directory.watch` to fail with `PathNotFoundException`.
+- Improve handling of watcher overflow on Windows: prepare for future versions
+  of SDK to properly forward `FileSystemException` into the stream returned by
+  the watcher instead of throwing a synchronous exception instead.
 
 ## 1.1.3
 

--- a/pkgs/watcher/lib/src/directory_watcher/windows.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/windows.dart
@@ -398,33 +398,40 @@ class _WindowsDirectoryWatcher
 
   /// Start or restart the underlying [Directory.watch] stream.
   void _startWatch() {
-    // Note: "watcher closed" exceptions do not get sent over the stream
-    // returned by watch, and must be caught via a zone handler.
+    // Note: in older SDKs "watcher closed" exceptions might not get sent over
+    // the stream returned by watch, and must be caught via a zone handler.
     runZonedGuarded(
       () {
         var innerStream = Directory(path).watch(recursive: true);
         _watchSubscription = innerStream.listen(
           _onEvent,
-          onError: _eventsController.addError,
+          onError: _restartWatchOnOverflowOr(_eventsController.addError),
           onDone: _onDone,
         );
       },
-      (error, stackTrace) async {
-        if (error is FileSystemException &&
-            error.message.startsWith('Directory watcher closed unexpectedly')) {
-          // Wait to work around https://github.com/dart-lang/sdk/issues/61378.
-          // Give the VM time to reset state after the error. See the issue for
-          // more discussion of the workaround.
-          await _watchSubscription?.cancel();
-          await Future<void>.delayed(const Duration(milliseconds: 1));
-          _eventsController.addError(error, stackTrace);
-          _startWatch();
-        } else {
-          // ignore: only_throw_errors
-          throw error;
-        }
-      },
+      _restartWatchOnOverflowOr((error, stackTrace) {
+        // ignore: only_throw_errors
+        throw error;
+      }),
     );
+  }
+
+  void Function(Object, StackTrace) _restartWatchOnOverflowOr(
+      void Function(Object, StackTrace) otherwise) {
+    return (Object error, StackTrace stackTrace) async {
+      if (error is FileSystemException &&
+          error.message.startsWith('Directory watcher closed unexpectedly')) {
+        // Wait to work around https://github.com/dart-lang/sdk/issues/61378.
+        // Give the VM time to reset state after the error. See the issue for
+        // more discussion of the workaround.
+        await _watchSubscription?.cancel();
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        _eventsController.addError(error, stackTrace);
+        _startWatch();
+      } else {
+        otherwise(error, stackTrace);
+      }
+    };
   }
 
   /// Starts or restarts listing the watched directory to get an initial picture

--- a/pkgs/watcher/pubspec.yaml
+++ b/pkgs/watcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 1.1.3
+version: 1.1.4-wip
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.


### PR DESCRIPTION
- **Ignore PathNotFoundException when watching subdirs**
- **Prepare for changes to FileSystemEntity.watch**

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
