### PR TITLE
Ignore PathNotFoundException in more places.

### DIFF
--- a/pkgs/watcher/lib/src/directory_watcher/linux.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/linux.dart
@@ -92,7 +92,7 @@ class _LinuxDirectoryWatcher
     });
 
     _listen(
-      Directory(path).list(recursive: true),
+      Directory(path).list(recursive: true).ignoring<PathNotFoundException>(),
       (FileSystemEntity entity) {
         if (entity is Directory) {
           _watchSubdir(entity.path);
@@ -136,17 +136,10 @@ class _LinuxDirectoryWatcher
     // top-level clients such as barback as well, and could be implemented with
     // a wrapper similar to how listening/canceling works now.
 
-    var stream = Directory(path).watch().transform(
-        StreamTransformer<FileSystemEvent, FileSystemEvent>.fromHandlers(
-      handleError: (error, st, sink) {
-        // Directory might no longer exist at the point where we try to
-        // start the watcher. Simply ignore this error and let the stream
-        // close.
-        if (error is! PathNotFoundException) {
-          sink.addError(error, st);
-        }
-      },
-    ));
+    // Directory might no longer exist at the point where we try to
+    // start the watcher. Simply ignore this error and let the stream
+    // close.
+    var stream = Directory(path).watch().ignoring<PathNotFoundException>();
     _subdirStreams[path] = stream;
     _nativeEvents.add(stream);
   }

--- a/pkgs/watcher/lib/src/directory_watcher/mac_os.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/mac_os.dart
@@ -148,7 +148,9 @@ class _MacOSDirectoryWatcher
 
           if (_files.containsDir(path)) continue;
 
-          var stream = Directory(path).list(recursive: true);
+          var stream = Directory(path)
+              .list(recursive: true)
+              .ignoring<PathNotFoundException>();
           var subscription = stream.listen((entity) {
             if (entity is Directory) return;
             if (_files.contains(path)) return;
@@ -373,7 +375,8 @@ class _MacOSDirectoryWatcher
 
     _files.clear();
     var completer = Completer<void>();
-    var stream = Directory(path).list(recursive: true);
+    var stream =
+        Directory(path).list(recursive: true).ignoring<PathNotFoundException>();
     _initialListSubscription = stream.listen((entity) {
       if (entity is! Directory) _files.add(entity.path);
     }, onError: _emitError, onDone: completer.complete, cancelOnError: true);

--- a/pkgs/watcher/lib/src/directory_watcher/polling.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/polling.dart
@@ -112,7 +112,8 @@ class _PollingDirectoryWatcher
       _filesToProcess.add(null);
     }
 
-    var stream = Directory(path).list(recursive: true);
+    var stream =
+        Directory(path).list(recursive: true).ignoring<PathNotFoundException>();
     _listSubscription = stream.listen((entity) {
       assert(!_events.isClosed);
 

--- a/pkgs/watcher/lib/src/utils.dart
+++ b/pkgs/watcher/lib/src/utils.dart
@@ -50,3 +50,18 @@ extension BatchEvents<T> on Stream<T> {
     }).bind(this);
   }
 }
+
+extension IgnoringError<T> on Stream<T> {
+  /// Ignore all errors of type [E] emitted by the given stream.
+  ///
+  /// Everything else gets forwarded through as-is.
+  Stream<T> ignoring<E>() {
+    return transform(StreamTransformer<T, T>.fromHandlers(
+      handleError: (error, st, sink) {
+        if (error is! E) {
+          sink.addError(error, st);
+        }
+      },
+    ));
+  }
+}

--- a/pkgs/watcher/test/directory_watcher/shared.dart
+++ b/pkgs/watcher/test/directory_watcher/shared.dart
@@ -347,7 +347,7 @@ void sharedTests() {
     test('subdirectory watching is robust against races', () async {
       // Make sandboxPath accessible to child isolates created by Isolate.run.
       final sandboxPath = d.sandbox;
-      final dirNames = [for (var i = 0; i < 50; i++) 'dir$i'];
+      final dirNames = [for (var i = 0; i < 500; i++) 'dir$i'];
       await startWatcher();
 
       // Repeatedly create and delete subdirectories in attempt to trigger


### PR DESCRIPTION
Directory.list() can fail with the same error
due to concurrent file system modifications.

Suppress this error uniformly across the code
base.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
