### PR TITLE
Make subdirectory robustness test less strict

### DIFF
--- a/pkgs/watcher/test/directory_watcher/shared.dart
+++ b/pkgs/watcher/test/directory_watcher/shared.dart
@@ -363,11 +363,6 @@ void sharedTests() {
           ]);
         });
       }
-
-      writeFile('a/b/c/d/file.txt');
-      await inAnyOrder([
-        isAddEvent('a/b/c/d/file.txt'),
-      ]);
     });
   });
 }


### PR DESCRIPTION
This test does not need to check for any specific emitted events. We just want it to not crash.