### PR TITLE
Remove test skip on Windows.

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -4,6 +4,9 @@
   the file was created immediately before the watcher was created. Now, if the
   file exists when the watcher is created then this modify event is not sent.
   This matches the Linux native and polling (Windows) watchers.
+- Bug fix: fix a spurious modify event with `DirectoryWatcher` on Windows that
+  was reported when a file or directory was renamed then another file or
+  directory was immediately renamed to its old name.
 
 ## 1.1.4
 

--- a/pkgs/watcher/test/directory_watcher/shared.dart
+++ b/pkgs/watcher/test/directory_watcher/shared.dart
@@ -137,8 +137,6 @@ void sharedTests() {
 
       renameFile('from.txt', 'to.txt');
       await inAnyOrder([isRemoveEvent('from.txt'), isModifyEvent('to.txt')]);
-    }, onPlatform: {
-      'windows': const Skip('https://github.com/dart-lang/watcher/issues/125')
     });
   });
 
@@ -280,8 +278,6 @@ void sharedTests() {
         isRemoveEvent('old'),
         isAddEvent('new')
       ]);
-    }, onPlatform: {
-      'windows': const Skip('https://github.com/dart-lang/watcher/issues/21')
     });
 
     test('emits events for many nested files added at once', () async {


### PR DESCRIPTION
Fix #1701 

The test was skipped because the expectations did not match, and the expectations did not match because there were extra incorrect "modify" events being reported.

`_sortEvents` was documented as "...won't return any `FileSystemMoveEvent`s", but actually it _did_ return `FileSystemMoveEvent`s. Fix the implementation to do what the comment says, and that also fixes the bug :) ... what was happening was that move caused `_canonicalEvent` to return `null`, then the filesystem would be checked and because before+after both had something at that path, a "modify" was reported.