### PR TITLE
Use Event extension type for Windows DirectoryWatcher.

### DIFF
--- a/pkgs/watcher/lib/src/directory_watcher/mac_os.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/mac_os.dart
@@ -172,6 +172,7 @@ class _MacOSDirectoryWatcher
               _emitEvent(ChangeType.REMOVE, removedPath);
             }
 
+          // Dropped by [Event.checkAndConvert].
           case EventType.moveFile:
           case EventType.moveDirectory:
           case EventType.modifyDirectory:
@@ -183,7 +184,7 @@ class _MacOSDirectoryWatcher
 
   /// Sort all the events in a batch into sets based on their path.
   ///
-  /// Events for `path` are discarded.
+  /// Events for [path] are discarded.
   ///
   /// Events under directories that are created are discarded.
   Map<String, Set<Event>> _sortEvents(List<Event> batch) {


### PR DESCRIPTION
Use `Event` as for the other watchers.

Windows watcher only gets a "modify directory" event from the OS alongside "directory created" or "directory deleted", and was being ignored: make it clearer that it's ignored by ignoring sooner.

Simplify `_canonicalEvent`, removes don't specify isDirectory so those always conflict, it's only file add and file modify that can be reduced to a single "create" event.

Update doc for Windows _sortEvents which says it removes "move" events, it does not, they are handled later by checking the filesystem. Make this clearer too.

Make `Event.event` private because there's no reason for it to be public, and update a few docs.

Test failures on MacOS on dev SDK are unrelated, they are due to an SDK issue https://github.com/dart-lang/sdk/issues/61693