### PR TITLE
Fix for skipped tests on Windows.

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -4,6 +4,11 @@
   the file was created immediately before the watcher was created. Now, if the
   file exists when the watcher is created then this modify event is not sent.
   This matches the Linux native and polling (Windows) watchers.
+- Bug fix: with `DirectoryWatcher` on Windows, a move over an existing file was
+  reported incorrectly. For example, if `a` and `b` already exist, then `a` is
+  moved onto `b`, it would be reported as three events: delete `a`, delete `b`,
+  create `b`. Now it's reported as two events: delete `a`, modify `b`. This
+  matches the behavior of the Linux and MacOS watchers.
 
 ## 1.1.4
 

--- a/pkgs/watcher/test/directory_watcher/shared.dart
+++ b/pkgs/watcher/test/directory_watcher/shared.dart
@@ -137,8 +137,6 @@ void sharedTests() {
 
       renameFile('from.txt', 'to.txt');
       await inAnyOrder([isRemoveEvent('from.txt'), isModifyEvent('to.txt')]);
-    }, onPlatform: {
-      'windows': const Skip('https://github.com/dart-lang/watcher/issues/125')
     });
   });
 
@@ -280,8 +278,6 @@ void sharedTests() {
         isRemoveEvent('old'),
         isAddEvent('new')
       ]);
-    }, onPlatform: {
-      'windows': const Skip('https://github.com/dart-lang/watcher/issues/21')
     });
 
     test('emits events for many nested files added at once', () async {


### PR DESCRIPTION
Fix https://github.com/dart-lang/tools/issues/1734
Fix https://github.com/dart-lang/tools/issues/1701

Stop skipping two tests, fix Windows directory watcher for those tests.

How it was supposed to work was that a move gets treated like a remove and an add; and that the add can combine with another remove event to turn into "check filesystem" and get reported as a "modify" event.

So for example if `a` and `b` are files that already exist, then `a` is moved over `b`:

- Windows sends events: `a` was moved onto `b`, `b` was deleted
- These should get translated into: `a` was deleted, `b` was created, `b` was deleted
- Then `package:watcher` combines the `b` events and goes and check if the file exists, because it existed before and still exists this turns into "`b` was modified"

But, this was not happening because of an implementation detail of the Windows `DirectoryWatcher`: it buffers events for 100ms keyed by path, and the move events went through this as single events with the "from" path as the key. So the create of the move destination would never be processed together with other events for that path, and the two events for `b` in the example above would always be reported separately.

Fix this by splitting the "move" events in two _before_ the buffering.

Simplify `_sortEvents` as move events have been turned into other event types by this point. Remove an incorrect comment about dropping events that match `path`, only the MacOS version of `_sortEvents` does that.

Test failures on MacOS on dev SDK are unrelated, they are due to an SDK issue https://github.com/dart-lang/sdk/issues/61693