### PR TITLE
Unify watcher tests

### DIFF
--- a/pkgs/watcher/test/directory_watcher/linux_test.dart
+++ b/pkgs/watcher/test/directory_watcher/linux_test.dart
@@ -16,25 +16,10 @@ import 'link_tests.dart';
 void main() {
   watcherFactory = LinuxDirectoryWatcher.new;
 
-  fileTests();
+  fileTests(isNative: true);
   linkTests(isNative: true);
 
   test('DirectoryWatcher creates a LinuxDirectoryWatcher on Linux', () {
     expect(DirectoryWatcher('.'), const TypeMatcher<LinuxDirectoryWatcher>());
-  });
-
-  test('emits events for many nested files moved out then immediately back in',
-      () async {
-    withPermutations(
-        (i, j, k) => writeFile('dir/sub/sub-$i/sub-$j/file-$k.txt'));
-    await startWatcher(path: 'dir');
-
-    renameDir('dir/sub', 'sub');
-    renameDir('sub', 'dir/sub');
-
-    await inAnyOrder(withPermutations(
-        (i, j, k) => isRemoveEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
-    await inAnyOrder(withPermutations(
-        (i, j, k) => isAddEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
   });
 }

--- a/pkgs/watcher/test/directory_watcher/mac_os_test.dart
+++ b/pkgs/watcher/test/directory_watcher/mac_os_test.dart
@@ -16,50 +16,10 @@ import 'link_tests.dart';
 void main() {
   watcherFactory = MacOSDirectoryWatcher.new;
 
-  fileTests();
+  fileTests(isNative: true);
   linkTests(isNative: true);
 
   test('DirectoryWatcher creates a MacOSDirectoryWatcher on Mac OS', () {
     expect(DirectoryWatcher('.'), const TypeMatcher<MacOSDirectoryWatcher>());
-  });
-
-  test(
-      'does not notify about the watched directory being deleted and '
-      'recreated immediately before watching', () async {
-    createDir('dir');
-    writeFile('dir/old.txt');
-    deleteDir('dir');
-    createDir('dir');
-
-    await startWatcher(path: 'dir');
-    writeFile('dir/newer.txt');
-    await expectAddEvent('dir/newer.txt');
-  });
-
-  test('emits events for many nested files moved out then immediately back in',
-      () async {
-    withPermutations(
-        (i, j, k) => writeFile('dir/sub/sub-$i/sub-$j/file-$k.txt'));
-
-    await startWatcher(path: 'dir');
-
-    renameDir('dir/sub', 'sub');
-    renameDir('sub', 'dir/sub');
-
-    await inAnyOrder(withPermutations(
-        (i, j, k) => isRemoveEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
-    await inAnyOrder(withPermutations(
-        (i, j, k) => isAddEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
-  });
-  test('does not suppress files with the same prefix as a directory', () async {
-    // Regression test for https://github.com/dart-lang/watcher/issues/83
-    writeFile('some_name.txt');
-
-    await startWatcher();
-
-    writeFile('some_name/some_name.txt');
-    deleteFile('some_name.txt');
-
-    await expectRemoveEvent('some_name.txt');
   });
 }

--- a/pkgs/watcher/test/directory_watcher/polling_test.dart
+++ b/pkgs/watcher/test/directory_watcher/polling_test.dart
@@ -21,7 +21,7 @@ void main() {
   group('with mock mtime', () {
     setUp(enableMockModificationTimes);
 
-    fileTests();
+    fileTests(isNative: false);
     linkTests(isNative: false);
 
     test('does not notify if the modification time did not change', () async {
@@ -71,7 +71,7 @@ void main() {
   group('with real mtime', () {
     setUp(enableWaitingForDifferentModificationTimes);
 
-    fileTests();
+    fileTests(isNative: false);
     linkTests(isNative: false);
   });
 }

--- a/pkgs/watcher/test/directory_watcher/windows_test.dart
+++ b/pkgs/watcher/test/directory_watcher/windows_test.dart
@@ -21,7 +21,7 @@ import 'link_tests.dart';
 void main() {
   watcherFactory = WindowsDirectoryWatcher.new;
 
-  fileTests();
+  fileTests(isNative: true);
   linkTests(isNative: true);
 
   test('DirectoryWatcher creates a WindowsDirectoryWatcher on Windows', () {


### PR DESCRIPTION
Move most platform-specific test cases into all platform test cases, it's free test coverage :)

This turned out to be a good idea as it caught a bug, but I already split that out as https://github.com/dart-lang/tools/pull/2212