### PR TITLE
Fix `PollingDirectoryWatcher` for delete during poll.

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -9,6 +9,8 @@
   moved onto `b`, it would be reported as three events: delete `a`, delete `b`,
   create `b`. Now it's reported as two events: delete `a`, modify `b`. This
   matches the behavior of the Linux and MacOS watchers.
+- Bug fix: with `PollingDirectoryWatcher`, fix spurious modify event emitted
+  because of a file delete during polling.
 
 ## 1.1.4
 

--- a/pkgs/watcher/lib/src/directory_watcher/polling.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/polling.dart
@@ -160,8 +160,13 @@ class _PollingDirectoryWatcher
 
     if (_events.isClosed) return;
 
-    _lastModifieds[file] = modified;
     _polledFiles.add(file);
+    if (modified == null) {
+      // The file was in the directory listing but has been removed since then.
+      // Don't add to _lastModifieds, it will be reported as a REMOVE.
+      return;
+    }
+    _lastModifieds[file] = modified;
 
     // Only notify if we're ready to emit events.
     if (!isReady) return;


### PR DESCRIPTION
`PollingDirectoryWatcher` was not checking for null modification time.

`null` means the file was deleted since the directory listing, and should be reported as a remove; because it was not checking for null, it was instead reporting as a "modify".

Make it check for the null.

This breaks another test which was relying on incorrect handling of nulls because the mock modification times were not correctly updated, `replaceAll` with a path was matching too much and setting mock modification times for wrong paths. Just exactly remove the old path prefix instead.