### PR TITLE
Test new link to directory races, fix for them

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -12,6 +12,9 @@
   moved onto `b`, it would be reported as three events: delete `a`, delete `b`,
   create `b`. Now it's reported as two events: delete `a`, modify `b`. This
   matches the behavior of the Linux and MacOS watchers.
+- Bug fix: with `DirectoryWatcher` on Windows, new links to direcories were
+  sometimes incorrectly handled as actual directories. Now they are reported
+  as files, matching the behavior of the Linux and MacOS watchers.
 - Bug fix: with `PollingDirectoryWatcher`, fix spurious modify event emitted
   because of a file delete during polling.
 

--- a/pkgs/watcher/test/directory_watcher/link_tests.dart
+++ b/pkgs/watcher/test/directory_watcher/link_tests.dart
@@ -21,7 +21,8 @@ void _linkTests({required bool isNative}) {
     writeFile('targets/a.target');
     await startWatcher(path: 'links');
 
-    writeLink(link: 'links/a.link', target: 'targets/a.target');
+    writeLink(
+        link: 'links/a.link', target: 'targets/a.target', unawaitedAsync: true);
 
     await expectAddEvent('links/a.link');
   });
@@ -109,7 +110,10 @@ void _linkTests({required bool isNative}) {
     createDir('targets/a.targetdir');
     await startWatcher(path: 'links');
 
-    writeLink(link: 'links/a.link', target: 'targets/a.targetdir');
+    writeLink(
+        link: 'links/a.link',
+        target: 'targets/a.targetdir',
+        unawaitedAsync: true);
 
     // TODO(davidmorgan): reconcile differences.
     if (isNative) {
@@ -128,7 +132,10 @@ void _linkTests({required bool isNative}) {
     writeFile('targets/a.targetdir/a.target');
     await startWatcher(path: 'links');
 
-    writeLink(link: 'links/a.link', target: 'targets/a.targetdir');
+    writeLink(
+        link: 'links/a.link',
+        target: 'targets/a.targetdir',
+        unawaitedAsync: true);
 
     // TODO(davidmorgan): reconcile differences.
     if (isNative) {

--- a/pkgs/watcher/test/utils.dart
+++ b/pkgs/watcher/test/utils.dart
@@ -239,9 +239,14 @@ void writeFile(String path, {String? contents}) {
 /// Writes a file in the sandbox at [link] pointing to [target].
 ///
 /// [target] is relative to the sandbox, not to [link].
+///
+/// If [unawaitedAsync], the link is written asynchronously and not awaited.
+/// Otherwise, it's synchronous. See the note in `windows.dart` for issue 61797
+/// for why this is needed for testing on Windows.
 void writeLink({
   required String link,
   required String target,
+  bool unawaitedAsync = false,
 }) {
   var fullPath = p.join(d.sandbox, link);
 
@@ -251,7 +256,11 @@ void writeLink({
     dir.createSync(recursive: true);
   }
 
-  Link(fullPath).createSync(p.join(d.sandbox, target));
+  if (unawaitedAsync) {
+    unawaited(Link(fullPath).create(p.join(d.sandbox, target)));
+  } else {
+    Link(fullPath).createSync(p.join(d.sandbox, target));
+  }
 }
 
 /// Deletes a file in the sandbox at [path].


### PR DESCRIPTION
Improve tests so they cover the race between the OS and the VM when a link to a directory is created.

https://github.com/dart-lang/sdk/issues/61797

This causes multiple tests to start failing. Fix them :) by checking the actual filesystem type for "createDirectory" events.