### PR TITLE
Fix race with directory list on Windows

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -10,6 +10,9 @@
   the file was created immediately before the watcher was created. Now, if the
   file exists when the watcher is created then this modify event is not sent.
   This matches the Linux native and polling (Windows) watchers.
+- Bug fix: with `DirectoryWatcher` on Windows, the last of a rapid sequence of
+  modifications in a newly-created directory was sometimes dropped. Make it
+  reliably report the last modification.
 - Bug fix: with `DirectoryWatcher` on Windows, a move over an existing file was
   reported incorrectly. For example, if `a` and `b` already exist, then `a` is
   moved onto `b`, it would be reported as three events: delete `a`, delete `b`,

--- a/pkgs/watcher/lib/src/directory_watcher/windows.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/windows.dart
@@ -321,7 +321,16 @@ class _WindowsDirectoryWatcher
         types.contains(EventType.createFile)) {
       // Combine events of type [EventType.modifyFile] and
       // [EventType.createFile] to one event.
-      type = EventType.createFile;
+
+      // The file can be already in `_files` if it's in a recently-created
+      // directory, the directory list finds it and adds it. In that case a pair
+      // of "create"+"modify" should be reported as "modify".
+      //
+      // Otherwise, it's a new file, "create"+"modify" should be reported as
+      // "create".
+      type = _files.contains(batch.first.path)
+          ? EventType.modifyFile
+          : EventType.createFile;
     } else {
       // There are incompatible event types, check the filesystem.
       return null;

--- a/pkgs/watcher/test/directory_watcher/end_to_end_tests.dart
+++ b/pkgs/watcher/test/directory_watcher/end_to_end_tests.dart
@@ -57,10 +57,6 @@ void endToEndTests({required bool isNative}) {
           print('Ignoring expected failure for Linux native watcher.');
           return;
         }
-        if (Platform.isWindows && isNative) {
-          print('Ignoring expected failure for Windows native watcher.');
-          return;
-        }
 
         // Write the file operations before the failure to a log, fail the test.
         final logTemp = Directory.systemTemp.createTempSync();


### PR DESCRIPTION
Fix #2234 that was discovered by the e2e test, remove the test skip on Windows.