### PR TITLE
Make test randomness repeatable.

### DIFF
--- a/pkgs/watcher/test/directory_watcher/file_changer.dart
+++ b/pkgs/watcher/test/directory_watcher/file_changer.dart
@@ -133,6 +133,7 @@ class FileChanger {
   /// Returns the path to an already-created file, or `null` if none exists.
   String? _randomExistingFilePath() =>
       (Directory(path).listSync(recursive: true).whereType<File>().toList()
+            ..sort((a, b) => a.path.compareTo(b.path))
             ..shuffle(_random))
           .firstOrNull
           ?.path;
@@ -142,6 +143,7 @@ class FileChanger {
   String? _randomExistingDirectoryPath() => (Directory(
         path,
       ).listSync(recursive: true).whereType<Directory>().toList()
+            ..sort((a, b) => a.path.compareTo(b.path))
             ..shuffle(_random))
           .firstOrNull
           ?.path;


### PR DESCRIPTION
The test tries to use repeatable random numbers, but depending on "Directory.list" order meant this did not always work.

Fix it by sorting before shuffling :)