### PR TITLE
Fix Linux watcher for entities recently moved between directories

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -10,15 +10,16 @@
   exhaustion, "Directory watcher closed unexpectedly", much less likely. The old
   implementation which does not use a separate Isolate is available as
   `DirectoryWatcher(path, runInIsolateOnWindows: false)`.
-- Bug fix: fix tracking failure on Linux. Before the fix, renaming a directory
-  would cause subdirectories of that directory to no longer be tracked.
-- Bug fix: while listing directories skip symlinks that lead to a directory
-  that has already been listed. This prevents a severe performance regression on
-  MacOS and Linux when there are more than a few symlink loops.
-- Bug fix: with `FileWatcher` on MacOS, a modify event was sometimes reported if
-  the file was created immediately before the watcher was created. Now, if the
-  file exists when the watcher is created then this modify event is not sent.
-  This matches the Linux native and polling (Windows) watchers.
+- Bug fix: fix `DirectoryWatcher` tracking failure on Linux. Before the fix,
+  renaming a directory would cause subdirectories of that directory to no
+  longer be tracked.
+- Bug fix: fix `DirectoryWatcher` incorrect events on Linux when a file or
+  directory is moved between directories then immediately modified or deleted.
+- Bug fix: fix `DirectoryWatcher` duplicate ADD events on Linux when a file
+  is created in a recently moved or created directory.
+- Bug fix: in `DirectoryWatcher` while listing directories skip symlinks that
+  lead to a directory that has already been listed. This prevents a severe
+  performance regression on MacOS and Linux when there are more than a few symlink loops.
 - Bug fix: with `DirectoryWatcher` on Windows, the last of a rapid sequence of
   modifications in a newly-created directory was sometimes dropped. Make it
   reliably report the last modification.
@@ -30,8 +31,14 @@
 - Bug fix: with `DirectoryWatcher` on Windows, new links to direcories were
   sometimes incorrectly handled as actual directories. Now they are reported
   as files, matching the behavior of the Linux and MacOS watchers.
+- Bug fix: with `DirectoryWatcher` on MacOS, fix events for changes in new
+  directories: don't emit duplicate ADD, don't emit MODIFY without ADD.
 - Bug fix: with `PollingDirectoryWatcher`, fix spurious modify event emitted
   because of a file delete during polling.
+- Bug fix: with `FileWatcher` on MacOS, a modify event was sometimes reported if
+  the file was created immediately before the watcher was created. Now, if the
+  file exists when the watcher is created then this modify event is not sent.
+  This matches the Linux native and polling (Windows) watchers.
 - Document behavior on Linux if the system watcher limit is hit.
 
 ## 1.1.4

--- a/pkgs/watcher/lib/src/directory_watcher/linux.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/linux.dart
@@ -154,10 +154,14 @@ class _LinuxDirectoryWatcher
     var dirs = <String>{};
     var changed = <String>{};
 
-    // inotify event batches are ordered by occurrence, so we treat them as a
-    // log of what happened to a file. We only emit events based on the
-    // difference between the state before the batch and the state after it, not
-    // the intermediate state.
+    // Inotify events are usually ordered by occurrence. But,
+    // https://github.com/dart-lang/sdk/issues/62014 means that moves between
+    // directories cause create/delete events to be placed out of order at the
+    // end of the batch. Catch these cases in order to do a check on the actual
+    // filesystem state.
+    var deletes = <String>{};
+    var creates = <String>{};
+
     for (var event in batch) {
       // If the watched directory is deleted or moved, we'll get a deletion
       // event for it. Ignore it; we handle closing [this] when the underlying
@@ -168,38 +172,68 @@ class _LinuxDirectoryWatcher
 
       switch (event.type) {
         case EventType.moveFile:
+          deletes.add(event.path);
           files.remove(event.path);
           dirs.remove(event.path);
           var destination = event.destination;
           if (destination != null) {
+            creates.add(destination);
             changed.add(destination);
             files.add(destination);
             dirs.remove(destination);
           }
 
         case EventType.moveDirectory:
+          deletes.add(event.path);
           files.remove(event.path);
           dirs.remove(event.path);
           var destination = event.destination;
           if (destination != null) {
+            creates.add(destination);
             changed.add(destination);
             files.remove(destination);
             dirs.add(destination);
           }
 
         case EventType.delete:
+          deletes.add(event.path);
           files.remove(event.path);
           dirs.remove(event.path);
 
         case EventType.createDirectory:
+          creates.add(event.path);
+          files.remove(event.path);
+          dirs.add(event.path);
+
         case EventType.modifyDirectory:
           files.remove(event.path);
           dirs.add(event.path);
 
         case EventType.createFile:
+          creates.add(event.path);
+          files.add(event.path);
+          dirs.remove(event.path);
+
         case EventType.modifyFile:
           files.add(event.path);
           dirs.remove(event.path);
+      }
+    }
+
+    // Check paths that might have been affected by out-of-order events, set
+    // the correct state in [files] and [dirs].
+    for (final path in deletes.intersection(creates)) {
+      final type = FileSystemEntity.typeSync(path, followLinks: false);
+      if (type == FileSystemEntityType.file ||
+          type == FileSystemEntityType.link) {
+        files.add(path);
+        dirs.remove(path);
+      } else if (type == FileSystemEntityType.directory) {
+        dirs.add(path);
+        files.remove(path);
+      } else {
+        files.remove(path);
+        dirs.remove(path);
       }
     }
 
@@ -244,8 +278,12 @@ class _LinuxDirectoryWatcher
       if (entity is Directory) {
         _watchSubdir(entity.path);
       } else {
-        _files.add(entity.path);
-        _emitEvent(ChangeType.ADD, entity.path);
+        // Only emit ADD if it hasn't already been emitted due to the file being
+        // modified or added after the directory was added.
+        if (!_files.contains(entity.path)) {
+          _files.add(entity.path);
+          _emitEvent(ChangeType.ADD, entity.path);
+        }
       }
     }, onError: (Object error, StackTrace stackTrace) {
       // Ignore an exception caused by the dir not existing. It's fine if it

--- a/pkgs/watcher/lib/src/directory_watcher/mac_os.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/mac_os.dart
@@ -136,10 +136,10 @@ class _MacOSDirectoryWatcher
       for (var event in events) {
         switch (event.type) {
           case EventType.createFile:
-            // If we already know about the file, treat it like a modification.
-            // This can happen if a file is copied on top of an existing one.
-            // We'll see an ADD event for the latter file when from the user's
-            // perspective, the file's contents just changed.
+          case EventType.modifyFile:
+            // The type can be incorrect due to a race with listing a new
+            // directory or due to a file being copied over an existing one.
+            // Choose the type to emit based on the previous emitted state.
             var type =
                 _files.contains(path) ? ChangeType.MODIFY : ChangeType.ADD;
 
@@ -152,7 +152,7 @@ class _MacOSDirectoryWatcher
             var stream = Directory(path).listRecursivelyIgnoringErrors();
             var subscription = stream.listen((entity) {
               if (entity is Directory) return;
-              if (_files.contains(path)) return;
+              if (_files.contains(entity.path)) return;
 
               _emitEvent(ChangeType.ADD, entity.path);
               _files.add(entity.path);
@@ -162,9 +162,6 @@ class _MacOSDirectoryWatcher
             });
             subscription.onError(_emitError);
             _listSubscriptions.add(subscription);
-
-          case EventType.modifyFile:
-            _emitEvent(ChangeType.MODIFY, path);
 
           case EventType.delete:
             for (var removedPath in _files.remove(path)) {

--- a/pkgs/watcher/test/directory_watcher/end_to_end_tests.dart
+++ b/pkgs/watcher/test/directory_watcher/end_to_end_tests.dart
@@ -27,10 +27,6 @@ void endToEndTests({required bool isNative}) {
     final temp = Directory.systemTemp.createTempSync();
     addTearDown(() => temp.deleteSync(recursive: true));
 
-    // Start with some files.
-    final changer = FileChanger(temp.path);
-    await changer.changeFiles(times: 100);
-
     // Create the watcher and [ClientSimulator].
     final watcher = createWatcher(path: temp.path);
     final client = await ClientSimulator.watch(watcher);
@@ -38,9 +34,13 @@ void endToEndTests({required bool isNative}) {
 
     // 20 iterations of making changes, waiting for events to settle, and
     // checking for consistency.
-    for (var i = 0; i != 20; ++i) {
+    final changer = FileChanger(temp.path);
+    for (var i = 0; i != 40; ++i) {
+      for (final entity in temp.listSync()) {
+        entity.deleteSync(recursive: true);
+      }
       // File changes.
-      final messages = await changer.changeFiles(times: 100);
+      final messages = await changer.changeFiles(times: 200);
 
       // Give time for events to arrive. To allow tests to run quickly when the
       // events are handled quickly, poll and continue if verification passes.

--- a/pkgs/watcher/test/directory_watcher/file_tests.dart
+++ b/pkgs/watcher/test/directory_watcher/file_tests.dart
@@ -251,6 +251,31 @@ void _fileTests({required bool isNative}) {
       deleteFile('file.txt');
     });
 
+    test('reports when a file is moved between directories then deleted',
+        () async {
+      writeFile('a/test.txt');
+      createDir('b');
+      await startWatcher(path: 'b');
+
+      renameFile('a/test.txt', 'b/test.txt');
+      deleteFile('b/test.txt');
+
+      final events =
+          await takeEvents(duration: const Duration(milliseconds: 500));
+
+      // It's correct to report either nothing or an add+remove.
+      expect(
+          events,
+          anyOf([
+            isEmpty,
+            containsAll([
+              isAddEvent('b/test.txt'),
+              isRemoveEvent('b/test.txt'),
+            ]),
+          ]));
+      expect(events, isNot(contains(isModifyEvent('b/test.txt'))));
+    });
+
     test(
         'reports a modification when a file is deleted and then immediately '
         'recreated', () async {


### PR DESCRIPTION
Fix #2249 

- Check filesystem state on Linux when there could be out-of-order events due to https://github.com/dart-lang/sdk/issues/62014
- Don't emit ADD events for already-added files
- Improve the e2e test:
   - fix random number handling to be repeatable, sort paths before shuffling
   - fix random number handling to be more random, update `Random` state before it's copied to the isolate
   - delete files between iterations because smaller number of files means more closely-related events which seems to trigger more issues
- Add retry rename in test utils.dart due to temporary failure on Windows

The improved e2e test also catches an issue on MacOS with races between new directory listing and events. Fix by checking the known emitted state.

The exception fix code at the end of `directory_list.dart` was not handling all error codes, so some types of failure on Windows would be handled incorrectly and not ignored. Copy from the actual SDK code as suggested in the linked issue so it's correct.

Tweak CHANGELOG, clarify what the changes affected and sort by it.