### PR TITLE
Analytics. Add libraryDiagnosticsBundleFailures to Event.analysisStatistics

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.0.9
+- Added `libraryDiagnosticsBundleFailures` to `Event.analysisStatistics`.
+
 ## 8.0.8
 - More data for `Event.analysisStatistics` for events from Dart Analysis Server.
 

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '8.0.8';
+const String kPackageVersion = '8.0.9';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -147,6 +147,9 @@ final class Event {
   ///   producing diagnostics.
   /// * [produceErrorsElementsDurationMs] - the total duration in milliseconds
   ///   for preparing elements before analysis.
+  /// * [libraryDiagnosticsBundleFailures] - the counts of requirement failures
+  ///   for library diagnostics bundles. The key is the `kindId` of the
+  ///   `RequirementFailure`.
   ///
   /// This allows us to understand how many files were scheduled for analysis,
   /// and how many of these files are served from the cache, because we
@@ -171,6 +174,7 @@ final class Event {
     required int produceErrorsActualFileLineCount,
     required int produceErrorsDurationMs,
     required int produceErrorsElementsDurationMs,
+    required String libraryDiagnosticsBundleFailures,
   }) : this._(
           eventName: DashEvent.analysisStatistics,
           eventData: {
@@ -194,6 +198,8 @@ final class Event {
                 produceErrorsActualFileLineCount,
             'produceErrorsDurationMs': produceErrorsDurationMs,
             'produceErrorsElementsDurationMs': produceErrorsElementsDurationMs,
+            'libraryDiagnosticsBundleFailures':
+                libraryDiagnosticsBundleFailures,
           },
         );
 

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 8.0.8
+version: 8.0.9
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aunified_analytics

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -30,6 +30,7 @@ void main() {
           produceErrorsActualFileLineCount: 13,
           produceErrorsDurationMs: 14,
           produceErrorsElementsDurationMs: 15,
+          libraryDiagnosticsBundleFailures: 'id1:1,id2:2',
         );
 
     final constructedEvent = generateEvent();
@@ -57,7 +58,11 @@ void main() {
     expect(constructedEvent.eventData['produceErrorsActualFileLineCount'], 13);
     expect(constructedEvent.eventData['produceErrorsDurationMs'], 14);
     expect(constructedEvent.eventData['produceErrorsElementsDurationMs'], 15);
-    expect(constructedEvent.eventData.length, 16);
+    expect(
+      constructedEvent.eventData['libraryDiagnosticsBundleFailures'],
+      'id1:1,id2:2',
+    );
+    expect(constructedEvent.eventData.length, 17);
   });
 
   test('Event.analyticsCollectionEnabled constructed', () {


### PR DESCRIPTION
I'd like to get better understanding how often each requirements failure kind prevents reusing library diagnostics.