### PR TITLE
Add playback from logs to watcher e2e test, start collection of test cases.

### DIFF
--- a/pkgs/watcher/test/directory_watcher/end_to_end_test_runner.dart
+++ b/pkgs/watcher/test/directory_watcher/end_to_end_test_runner.dart
@@ -1,0 +1,203 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+// ignore_for_file: unreachable_from_main
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart' as package_test;
+import 'package:watcher/src/utils.dart';
+import 'package:watcher/watcher.dart';
+
+import '../utils.dart' as utils;
+import 'client_simulator.dart';
+import 'end_to_end_tests.dart';
+import 'file_changer.dart';
+
+/// Runs the test with [name] for logging.
+///
+/// To run without `package:test`, pass [addTearDown], [createWatcher], [fail]
+/// and [printOnFailure] replacements.
+///
+/// Runs [repeats] times, by default 50. Set to -1 to run until failure.
+///
+/// By default, runs through a fixed series of pseudo-random test cases. Or,
+/// pass [fixSeed] to run at a fixed seed. Or, pass [replayLog] to replay from a
+/// test log.
+Future<void> runTest({
+  required String name,
+  void Function(void Function())? addTearDown,
+  Watcher Function({required String path})? createWatcher,
+  void Function(String)? fail,
+  void Function(String)? printOnFailure,
+  int repeats = 50,
+  int? fixSeed,
+  String? replayLog,
+}) async {
+  addTearDown ??= package_test.addTearDown;
+  createWatcher ??= utils.createWatcher;
+  fail ??= package_test.fail;
+  printOnFailure ??= package_test.printOnFailure;
+
+  final temp = Directory.systemTemp.createTempSync();
+  addTearDown(() => temp.deleteSync(recursive: true));
+
+  // Turn on logging of the watchers.
+  final log = <LogEntry>[];
+  logForTesting = (message) => log.add(LogEntry('W $message'));
+
+  // Create the watcher and [ClientSimulator].
+  final watcher = createWatcher(path: temp.path);
+  final client = await ClientSimulator.watch(
+      watcher: watcher, log: (message) => log.add(LogEntry('C $message')));
+  addTearDown(client.close);
+
+  // Making changes, waiting for events to settle, check for consistency.
+  final changer = FileChanger(temp.path);
+  for (var i = 0; i != repeats; ++i) {
+    log.clear();
+    if (repeats < 0) stdout.write('.');
+    for (final entity in temp.listSync()) {
+      entity.deleteSync(recursive: true);
+    }
+
+    // File changes.
+    int? seed;
+    if (replayLog == null) {
+      seed ??= fixSeed ?? i;
+      log.addAll(await changer.changeFiles(times: 200, seed: seed));
+    } else {
+      log.addAll(await changer.replayLog(replayLog));
+    }
+
+    // Give time for events to arrive. To allow tests to run quickly when the
+    // events are handled quickly, poll and continue if verification passes.
+    var succeeded = false;
+    for (var waits = 0; waits != 20; ++waits) {
+      if (client.verify()) {
+        succeeded = true;
+        break;
+      }
+      await client.waitForNoEvents(const Duration(milliseconds: 100));
+    }
+
+    // Fail the test if still not consistent.
+    if (!succeeded) {
+      if (repeats < 0) print('');
+      client.verify(printOnFailure: printOnFailure);
+      // Write the file operations before the failure to a log, fail the test.
+      final logTemp = Directory.systemTemp.createTempSync();
+      final logPath = p.join(logTemp.path, 'log.txt');
+
+      // Sort the log entries by timestamp.
+      log.sort();
+
+      File(logPath).writeAsStringSync(log.map((m) => '$m\n').join(''));
+      final failMessage = StringBuffer('\n');
+
+      if (seed != null) {
+        failMessage.write('''
+Failed `$name` on run $i. Run in a loop with that seed using:
+
+  dart test/directory_watcher/end_to_end_test_runner.dart seed $seed
+''');
+      } else {
+        failMessage.write('''
+Failed `$name` on run $i.
+''');
+      }
+
+      failMessage.write('''
+
+Changes/watcher/client log: $logPath
+''');
+
+      fail(failMessage.toString());
+    }
+  }
+}
+
+/// Main method for running the e2e test without `package:test`.
+///
+/// By default runs endlessly with seeds starting at 0.
+///
+/// Pass `seed <number>` to fix the seed.
+///
+/// Pass `replay` to run endlessly with hardcoded test cases from
+/// `end_to_end_tests.dart`.
+///
+/// Exits on failure, or runs forever.
+Future<void> main(List<String> arguments) async {
+  final command = arguments.isEmpty ? null : arguments[0];
+  final fixSeed = command == 'seed' ? int.parse(arguments[1]) : null;
+  final replay = command == 'replay';
+
+  final teardowns = <void Function()>[];
+  try {
+    if (replay) {
+      while (true) {
+        stdout.write('.');
+        for (final testCase in testCases) {
+          await runTest(
+            name: testCase.name,
+            addTearDown: teardowns.add,
+            createWatcher: ({required String path}) => DirectoryWatcher(path),
+            fail: (message) {
+              print(message);
+              exit(1);
+            },
+            printOnFailure: print,
+            // Repeat a few times before moving onto the next test case to get
+            // any effect of multiple consecutive runs.
+            repeats: 3,
+            replayLog: testCase.log,
+          );
+        }
+      }
+    } else {
+      await runTest(
+        name: fixSeed == null ? 'random' : 'fixed seed $fixSeed',
+        addTearDown: teardowns.add,
+        createWatcher: ({required String path}) => DirectoryWatcher(path),
+        fail: (message) {
+          print(message);
+          exit(1);
+        },
+        printOnFailure: print,
+        repeats: -1,
+        fixSeed: fixSeed,
+      );
+    }
+  } finally {
+    for (final teardown in teardowns) {
+      teardown();
+    }
+  }
+}
+
+/// Log entry with timestamp.
+///
+/// Because file events happen on a different isolate the merged log uses
+/// timestamps to put entries in the correct order.
+class LogEntry implements Comparable<LogEntry> {
+  final DateTime timestamp;
+  final String message;
+
+  LogEntry(this.message) : timestamp = DateTime.now();
+
+  @override
+  int compareTo(LogEntry other) => timestamp.compareTo(other.timestamp);
+
+  @override
+  String toString() => message;
+}
+
+/// Test case using log replay.
+class TestCase {
+  final String name;
+  final String log;
+  final bool skipOnLinux;
+
+  TestCase(this.name, this.log, {this.skipOnLinux = false});
+}

--- a/pkgs/watcher/test/directory_watcher/end_to_end_tests.dart
+++ b/pkgs/watcher/test/directory_watcher/end_to_end_tests.dart
@@ -5,149 +5,51 @@
 
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-import 'package:test/test.dart' as package_test;
-import 'package:watcher/src/utils.dart';
-import 'package:watcher/watcher.dart';
+import 'package:test/test.dart';
 
-import '../utils.dart' as utils;
 import 'client_simulator.dart';
+import 'end_to_end_test_runner.dart';
 import 'file_changer.dart';
 
-/// End to end test using a [FileChanger] that randomly changes files, then a
+/// End to end test using a [FileChanger] to change files then a
 /// [ClientSimulator] that tracks state using a Watcher.
 ///
-/// The test passes if the [ClientSimulator] tracking matches what's actually on
+/// The tests pass if the [ClientSimulator] tracking matches what's actually on
 /// disk.
+///
+/// `end_to_end_test_runner` can be run as a binary to try random file changes
+/// until a failure, it outputs a log which can be turned into a test case here.
 void endToEndTests() {
-  package_test.test('end to end test',
-      timeout: const package_test.Timeout(Duration(minutes: 5)), () async {
-    await _runTest();
+  // Random test to cover a wide range of cases.
+  test('end to end test: random', timeout: const Timeout(Duration(minutes: 5)),
+      () async {
+    await runTest(name: 'random', repeats: 100);
   });
-}
 
-/// Runs the test.
-///
-/// To run without `package:test`, pass [addTearDown], [createWatcher], [fail]
-/// and [printOnFailure] replacements.
-///
-/// To run until failure, set [endlessMode] to `true`.
-///
-/// To fix the seed, set [seed]. The failure message prints the seed, so this
-/// can be used to run just the events that triggered the failure.
-Future<void> _runTest({
-  void Function(void Function())? addTearDown,
-  Watcher Function({required String path})? createWatcher,
-  void Function(String)? fail,
-  void Function(String)? printOnFailure,
-  bool endlessMode = false,
-  int? seed,
-}) async {
-  addTearDown ??= package_test.addTearDown;
-  createWatcher ??= utils.createWatcher;
-  fail ??= package_test.fail;
-  printOnFailure ??= package_test.printOnFailure;
-
-  final temp = Directory.systemTemp.createTempSync();
-  addTearDown(() => temp.deleteSync(recursive: true));
-
-  // Turn on logging of the watchers.
-  final log = <LogEntry>[];
-  logForTesting = (message) => log.add(LogEntry('W $message'));
-
-  // Create the watcher and [ClientSimulator].
-  final watcher = createWatcher(path: temp.path);
-  final client = await ClientSimulator.watch(
-      watcher: watcher, log: (message) => log.add(LogEntry('C $message')));
-  addTearDown(client.close);
-
-  // 40 iterations of making changes, waiting for events to settle, and
-  // checking for consistency.
-  final changer = FileChanger(temp.path);
-  for (var i = 0; endlessMode || i != 40; ++i) {
-    final runSeed = seed ?? i;
-    log.clear();
-    if (endlessMode) stdout.write('.');
-    for (final entity in temp.listSync()) {
-      entity.deleteSync(recursive: true);
-    }
-    // File changes.
-    log.addAll(await changer.changeFiles(times: 200, seed: runSeed));
-
-    // Give time for events to arrive. To allow tests to run quickly when the
-    // events are handled quickly, poll and continue if verification passes.
-    var succeeded = false;
-    for (var waits = 0; waits != 20; ++waits) {
-      if (client.verify()) {
-        succeeded = true;
-        break;
-      }
-      await client.waitForNoEvents(const Duration(milliseconds: 100));
-    }
-
-    // Fail the test if still not consistent.
-    if (!succeeded) {
-      if (endlessMode) print('');
-      client.verify(printOnFailure: printOnFailure);
-      // Write the file operations before the failure to a log, fail the test.
-      final logTemp = Directory.systemTemp.createTempSync();
-      final logPath = p.join(logTemp.path, 'log.txt');
-
-      // Sort the log entries by timestamp.
-      log.sort();
-
-      File(logPath).writeAsStringSync(log.map((m) => '$m\n').join(''));
-      fail('''
-Failed on run $i, seed $runSeed. Run in a loop with that seed using:
-
-  dart test/directory_watcher/end_to_end_tests.dart $runSeed
-
-Changes/watcher/client log: $logPath
-''');
-    }
+  // Specific test cases that have caught bugs.
+  for (final testCase in testCases) {
+    test('end to end test: ${testCase.name}',
+        timeout: const Timeout(Duration(minutes: 5)), () async {
+      await runTest(name: testCase.name, replayLog: testCase.log, repeats: 100);
+    }, skip: testCase.skipOnLinux && Platform.isLinux);
   }
 }
 
-/// Main method for running the e2e test without `package:test`.
-///
-/// Optionally, pass the seed to run with as the only argument.
-///
-/// Exits on failure, or runs forever.
-Future<void> main(List<String> arguments) async {
-  final seed = arguments.isNotEmpty ? int.parse(arguments.first) : null;
-  final teardowns = <void Function()>[];
-  try {
-    await _runTest(
-      addTearDown: teardowns.add,
-      createWatcher: ({required String path}) => DirectoryWatcher(path),
-      fail: (message) {
-        print(message);
-        exit(1);
-      },
-      printOnFailure: print,
-      endlessMode: true,
-      seed: seed,
-    );
-  } finally {
-    for (final teardown in teardowns) {
-      teardown();
-    }
-  }
-}
-
-/// Log entry with timestamp.
-///
-/// Because file events happen on a different isolate the merged log uses
-/// timestamps to put entries in the correct order.
-class LogEntry implements Comparable<LogEntry> {
-  final DateTime timestamp;
-  final String message;
-
-  LogEntry(this.message) : timestamp = DateTime.now();
-
-  @override
-  int compareTo(LogEntry other) => timestamp.compareTo(other.timestamp);
-
-  @override
-  String toString() => message;
-}
+final testCases = [
+  TestCase(
+    'move over, modify, delete in new directory',
+    '''
+F create,62543,809
+F wait
+F wait
+F wait
+F wait
+F create directory,a
+F create,a/63090,758
+F move file over file,62543,a/63090
+F modify,a/63090,439
+F delete,a/63090
+''',
+    skipOnLinux: true,
+  )
+];


### PR DESCRIPTION
The random and seeded tests are good, to actually make progress on the hard cases I need to minimize+keep the important randomly-generated tests.

So: log playback :) and a first test case from it, skipped on Linux since it doesn't pass right now.

Most of the new `end_to_end_test_runner.dart` is moved out of `end_to_end_tests.dart` rather than new code, then updated for the new option of passing a log. I don't know how to make GitHub show a better diff for that, sorry!