### PR TITLE
Report out of watchers error from subdirectories.

### DIFF
--- a/pkgs/watcher/lib/src/directory_watcher/linux/watch_tree.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/linux/watch_tree.dart
@@ -292,8 +292,15 @@ class WatchTree {
     _directories.remove(directory)?._emitDeleteTree();
     _directories[directory] = WatchTree(
         emitEvent: _emitEvent,
-        // Ignore exceptions from subdirectories.
-        onError: (Object e, StackTrace s) {},
+        onError: (Object e, StackTrace s) {
+          // Ignore exceptions from subdirectories except "out of watchers"
+          // which is an unrecoverable error.
+          if (e is FileSystemException &&
+              e.message.contains('Failed to watch path') &&
+              e.osError?.errorCode == 28) {
+            _onError(e, s);
+          }
+        },
         watchedDirectoryWasDeleted: () {
           _emitDeleteDirectory(directory);
         },


### PR DESCRIPTION
I don't see any way to add a test for this :(

I tried writing a test that creates lots of files/folders to exhaust watchers, but on my system the default is four million, it would take much too long :) ... and I think you need `sudo` to change the max.

So, tested manually by setting the watcher max to a number that allows initial watch but throws when a subdirectory is watched.