### PR TITLE
Recover from custom tags in YAML

### DIFF
--- a/pkgs/yaml/lib/src/parser.dart
+++ b/pkgs/yaml/lib/src/parser.dart
@@ -290,16 +290,23 @@ class Parser {
     }
 
     String? tag;
-    if (tagToken != null) {
-      if (tagToken!.handle == null) {
-        tag = tagToken!.suffix;
+    if (tagToken
+        case TagToken(:final handle, :final suffix, :final isVerbatim)) {
+      /// Verbatim tags cannot be resolved as global tags.
+      ///
+      /// See: https://yaml.org/spec/1.2.2/#691-node-tags
+      ///   - Verbatim tags section
+      ///   - All 1.2.* versions behave this way
+      if (handle == null || isVerbatim) {
+        tag = suffix;
       } else {
-        var tagDirective = _tagDirectives[tagToken!.handle];
+        final tagDirective = _tagDirectives[handle];
+
         if (tagDirective == null) {
           throw YamlException('Undefined tag handle.', tagToken!.span);
         }
 
-        tag = tagDirective.prefix + (tagToken?.suffix ?? '');
+        tag = tagDirective.prefix + suffix;
       }
     }
 

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -1049,13 +1049,12 @@ class Scanner {
   /// [flowSeparators] indicates whether the tag URI can contain flow
   /// separators.
   String _scanTagUri({String? head, bool flowSeparators = true}) {
-    var length = head == null ? 0 : head.length;
-    var buffer = StringBuffer();
+    final buffer = StringBuffer();
 
     // Copy the head if needed.
     //
     // Note that we don't copy the leading '!' character.
-    if (length > 1) buffer.write(head!.substring(1));
+    if ((head?.length ?? 0) > 1) buffer.write(head!.substring(1));
 
     // The set of characters that may appear in URI is as follows:
     //
@@ -1075,7 +1074,7 @@ class Scanner {
     }
 
     // libyaml manually decodes the URL, but we don't have to do that.
-    return Uri.decodeFull(_scanner.substring(start));
+    return buffer.toString() + Uri.decodeFull(_scanner.substring(start));
   }
 
   /// Scans a block scalar.

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -934,21 +934,28 @@ class Scanner {
 
     _skipBlanks();
 
+    var prefix = '';
+
     /// Both tag uri and local tags can be used as prefixes.
     ///
     /// See: https://yaml.org/spec/1.2.2/#6822-tag-prefixes
-    var prefix = _scanner.peekChar() == EXCLAMATION
-        ? _scanTagHandle(directive: true, isGlobalTagPrefix: true).tagHandle
-        : '';
+    if (_scanner.peekChar() == EXCLAMATION) {
+      prefix = _scanTagHandle(
+        directive: true,
+        isGlobalTagPrefix: true,
+      ).tagHandle;
+    } else {
+      prefix = _scanTagUri();
 
-    prefix += _scanTagUri(); // Readability's sake
+      if (prefix.isEmpty) {
+        throw YamlException(
+          'Expected a non-empty global tag prefix',
+          _scanner.emptySpan,
+        );
+      }
+    }
 
-    if (prefix.isEmpty) {
-      throw YamlException(
-        'Expected a non-empty global tag prefix',
-        _scanner.emptySpan,
-      );
-    } else if (!_isBlankOrEnd) {
+    if (!_isBlankOrEnd) {
       throw YamlException('Expected whitespace.', _scanner.emptySpan);
     }
 

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -927,8 +927,15 @@ class Scanner {
   Token _scanTagDirectiveValue(LineScannerState start) {
     _skipBlanks();
 
-    final handle = _scanTagHandle(directive: true).tagHandle;
-    if (!_isBlank) {
+    final (:tagHandle, :isNamed) = _scanTagHandle(directive: true);
+
+    // !yaml! or ! or !!. Throw for !yaml
+    if (!isNamed && tagHandle != '!' && tagHandle != '!!') {
+      throw YamlException(
+        'Invalid global tag handle',
+        _scanner.spanFrom(start),
+      );
+    } else if (!_isBlank) {
       throw YamlException('Expected whitespace.', _scanner.emptySpan);
     }
 
@@ -959,7 +966,7 @@ class Scanner {
       throw YamlException('Expected whitespace.', _scanner.emptySpan);
     }
 
-    return TagDirectiveToken(_scanner.spanFrom(start), handle, prefix);
+    return TagDirectiveToken(_scanner.spanFrom(start), tagHandle, prefix);
   }
 
   /// Scans a [TokenType.anchor] token.

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -1068,16 +1068,14 @@ class Scanner {
     } else {
       tagUri = _scanTagUri(); // !<foo:uri>
 
-      // Expect !<foo:uri> to be !<tag:yaml.org,2002:*>
-      switch (tagUri.replaceFirst('tag:yaml.org,2002:', '')) {
-        case 'map' || 'seq' || 'str' || 'null' || 'bool' || 'int' || 'float':
-          break;
-
-        default:
-          throw YamlException(
-            'Invalid tag uri used as a verbatim tag',
-            _scanner.spanFrom(start),
-          );
+      /// Expect !<foo:uri> to be !<tag:*> (a global tag)
+      ///
+      /// See: https://yaml.org/spec/1.2.2/#3212-tags
+      if (!tagUri.startsWith('tag:') || tagUri.substring(4).isEmpty) {
+        throw YamlException(
+          'Invalid tag uri used as a verbatim tag',
+          _scanner.spanFrom(start),
+        );
       }
     }
 

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -1007,10 +1007,10 @@ class Scanner {
     String? handle = tagHandle;
     var suffix = '';
 
-    if (isNamed) {
+    if (isNamed || tagHandle == '!!') {
       suffix = _scanTagUri(flowSeparators: false);
 
-      /// Named tag handles cannot have an empty tag suffix.
+      /// Secondary and named tag handles cannot have an empty tag suffix.
       ///
       ///   c-ns-shorthand-tag ::=
       ///       c-tag-handle

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -1120,8 +1120,7 @@ class Scanner {
     final buffer = StringBuffer('!');
 
     if (_scanner.peekChar() == EXCLAMATION) {
-      // TODO: Do we really need this highlighted?
-      final char = _scanner.readCodePoint();
+      buffer.writeCharCode(_scanner.readChar());
 
       if (isGlobalTagPrefix) {
         throw YamlException(
@@ -1130,8 +1129,6 @@ class Scanner {
           _scanner.spanFrom(start),
         );
       }
-
-      buffer.writeCharCode(char);
     } else {
       // Both %TAG and tag shorthands can have named handles.
       buffer.write(_scanTagUri(flowSeparators: false));

--- a/pkgs/yaml/lib/src/token.dart
+++ b/pkgs/yaml/lib/src/token.dart
@@ -102,7 +102,10 @@ class TagToken implements Token {
   /// The tag suffix.
   final String suffix;
 
-  TagToken(this.span, this.handle, this.suffix);
+  /// Whether this tag is declared in its canonical form
+  final bool isVerbatim;
+
+  TagToken(this.span, this.handle, this.suffix, {required this.isVerbatim});
 
   @override
   String toString() => 'TAG $handle $suffix';

--- a/pkgs/yaml/lib/src/utils.dart
+++ b/pkgs/yaml/lib/src/utils.dart
@@ -49,4 +49,4 @@ bool isLowSurrogate(int codeUnit) => codeUnit >>> 10 == 0x37;
 bool isResolvedYamlTag(String? tag, String canonicalSuffix) =>
     tag == null ||
     !tag.startsWith('tag:yaml.org,2002:') || // Leaky prefix condition.
-    !tag.endsWith(canonicalSuffix);
+    tag.endsWith(canonicalSuffix);

--- a/pkgs/yaml/lib/src/utils.dart
+++ b/pkgs/yaml/lib/src/utils.dart
@@ -38,3 +38,15 @@ bool isHighSurrogate(int codeUnit) => codeUnit >>> 10 == 0x36;
 
 /// Whether [codeUnit] is a UTF-16 low surrogate.
 bool isLowSurrogate(int codeUnit) => codeUnit >>> 10 == 0x37;
+
+/// Whether a tag is a valid tag based on its [canonicalSuffix] as defined in
+/// the yaml spec. Always returns `true` if the caller has a custom tag and can
+/// be partially composed/represented (synthetic node).
+///
+///  - `seq` - for sequence
+///  - `map` - for map
+///  - `str` - for scalar
+bool isResolvedYamlTag(String? tag, String canonicalSuffix) =>
+    tag == null ||
+    !tag.startsWith('tag:yaml.org,2002:') || // Leaky prefix condition.
+    !tag.endsWith(canonicalSuffix);

--- a/pkgs/yaml/test/utils.dart
+++ b/pkgs/yaml/test/utils.dart
@@ -7,6 +7,8 @@
 
 import 'package:test/test.dart';
 import 'package:yaml/src/equality.dart' as equality;
+import 'package:yaml/src/scanner.dart';
+import 'package:yaml/src/token.dart';
 import 'package:yaml/yaml.dart';
 
 /// A matcher that validates that a closure or Future throws a [YamlException].
@@ -92,4 +94,35 @@ String indentLiteral(String text) {
   }
 
   return lines.join('\n');
+}
+
+/// Generates tokens that can be consumed by a yaml parser.
+Iterable<Token> generateTokens(String source) sync* {
+  final scanner = Scanner(source);
+
+  do {
+    if (scanner.peek() case Token token) {
+      yield token;
+      scanner.advance();
+      continue;
+    }
+
+    break;
+  } while (true);
+}
+
+/// Matches a [TagDirectiveToken] emitted by a [Scanner]
+Matcher isATagDirective(String handle, String prefix) =>
+    isA<TagDirectiveToken>()
+        .having((t) => t.handle, 'handle', equals(handle))
+        .having((t) => t.prefix, 'prefix', equals(prefix));
+
+extension PadUtil on String {
+  /// Applies an indent of 8 spaces to a multiline string to ensure strings
+  /// are compatible with existing matchers.
+  ///
+  /// See [cleanUpLiteral].
+  String asIndented() => split('\n')
+      .map((line) => line.isEmpty ? line : '${' ' * 8}$line')
+      .join('\n');
 }

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -1127,6 +1127,11 @@ void main() {
 
       expectYamlLoads(['bar'], source.asIndented());
     });
+
+    test('Throws for invalid global tag handles', () {
+      expectYamlFails('%TAG !not-allowed !birdbox');
+      expectYamlFails('%TAG uri:not-allowed !birdbox');
+    });
   });
 
   group('6.9: Node Properties', () {

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -993,21 +993,33 @@ void main() {
   });
 
   group('6.8: Directives', () {
-    // TODO(nweiz): assert that this produces a warning
     test('[Example 6.13]', () {
-      expectYamlLoads('foo', '''
+      expect(
+        () => expectYamlLoads(
+          'foo',
+          '''
         %FOO  bar baz # Should be ignored
                       # with a warning.
-        --- "foo"''');
+        --- "foo"''',
+        ),
+        prints(contains('Warning: unknown directive')),
+      );
     });
 
-    // TODO(nweiz): assert that this produces a warning.
     test('[Example 6.14]', () {
-      expectYamlLoads('foo', '''
+      expect(
+        () => expectYamlLoads(
+          'foo',
+          '''
         %YAML 1.3 # Attempt parsing
                    # with a warning
         ---
-        "foo"''');
+        "foo"''',
+        ),
+        prints(
+          contains('Warning: this parser only supports YAML 1.1 and 1.2.'),
+        ),
+      );
     });
 
     test('[Example 6.15]', () {

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -1140,6 +1140,8 @@ void main() {
     test('[Example 6.25]', () {
       expectYamlFails('- !<!> foo');
       expectYamlFails('- !<\$:?> foo');
+      expectYamlFails('- !<tag:>'); // Incomplete verbatim tag uri
+      expectYamlFails('- !<improvised:tag>');
     });
 
     test('[Example 6.26]', () {

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -9,6 +9,7 @@
 
 import 'package:test/test.dart';
 import 'package:yaml/src/error_listener.dart';
+import 'package:yaml/src/token.dart';
 import 'package:yaml/yaml.dart';
 
 import 'utils.dart';
@@ -1030,8 +1031,90 @@ void main() {
         bar''');
     });
 
-    // Examples 6.18 through 6.22 test custom tag URIs, which this
-    // implementation currently doesn't plan to support.
+    // Examples 6.18 through 6.22 test custom tag URIs. Inspect the lower level
+    // event generator to check correctness of the tag directives we parse
+    // (and ignore?)
+    test('[Example 6.18]', () {
+      const source = '''
+# Global
+%TAG ! tag:example.com,2000:app/
+---
+!foo "bar"
+''';
+
+      expect(
+        generateTokens(source),
+        anyElement(isATagDirective('!', 'tag:example.com,2000:app/')),
+      );
+
+      expectYamlLoads('bar', source.asIndented());
+    });
+
+    test('[Example 6.19]', () {
+      const source = '''
+%TAG !! tag:example.com,2000:app/
+---
+!!int 1 - 3 # Interval, not integer
+''';
+
+      expect(
+        generateTokens(source),
+        anyElement(isATagDirective('!!', 'tag:example.com,2000:app/')),
+      );
+
+      expectYamlLoads('1 - 3', source.asIndented());
+    });
+
+    test('[Example 6.20]', () {
+      const source = '''
+%TAG !e! tag:example.com,2000:app/
+---
+!e!foo "bar"
+''';
+
+      expect(
+        generateTokens(source),
+        anyElement(isATagDirective('!e!', 'tag:example.com,2000:app/')),
+      );
+
+      expectYamlLoads('bar', source.asIndented());
+    });
+
+    test('[Example 6.21]', () {
+      const source = '''
+%TAG !m! !my-
+--- # Bulb here
+!m!light fluorescent
+...
+%TAG !m! !my-
+--- # Color here
+!m!light green
+''';
+
+      expect(
+        generateTokens(source).whereType<TagDirectiveToken>(),
+
+        // Two different documents. Same directive
+        everyElement(isATagDirective('!m!', '!my-')),
+      );
+
+      expectYamlStreamLoads(['fluorescent', 'green'], source.asIndented());
+    });
+
+    test('[Example 6.22]', () {
+      const source = '''
+%TAG !e! tag:example.com,2000:app/
+---
+- !e!foo "bar"
+''';
+
+      expect(
+        generateTokens(source),
+        anyElement(isATagDirective('!e!', 'tag:example.com,2000:app/')),
+      );
+
+      expectYamlLoads(['bar'], source.asIndented());
+    });
   });
 
   group('6.9: Node Properties', () {
@@ -1048,16 +1131,37 @@ void main() {
         &a2 baz : *a1''');
     });
 
-    // Example 6.24 tests custom tag URIs, which this implementation currently
-    // doesn't plan to support.
+    test('[Example 6.24]', () {
+      expectYamlLoads({'foo': 'baz'}, '''
+        !<tag:yaml.org,2002:str> foo :
+          !<!bar> baz''');
+    });
 
     test('[Example 6.25]', () {
       expectYamlFails('- !<!> foo');
       expectYamlFails('- !<\$:?> foo');
     });
 
-    // Examples 6.26 and 6.27 test custom tag URIs, which this implementation
-    // currently doesn't plan to support.
+    test('[Example 6.26]', () {
+      expectYamlLoads(['foo', 'bar', 'baz'], '''
+        %TAG !e! tag:example.com,2000:app/
+        ---
+        - !local foo
+        - !!str bar
+        - !e!tag%21 baz''');
+    });
+
+    test('[Example 6.27]', () {
+      expectYamlFails('''
+        %TAG !e! tag:example,2000:app/
+        ---
+        - !e! foo''');
+
+      expectYamlFails('''
+        %TAG !e! tag:example,2000:app/
+        ---
+        - !h!bar foo''');
+    });
 
     test('[Example 6.28]', () {
       expectYamlLoads(['12', 12, '12'], '''
@@ -1072,6 +1176,33 @@ void main() {
           {'First occurrence': 'Value', 'Second occurrence': 'Value'}, '''
         First occurrence: &anchor Value
         Second occurrence: *anchor''');
+    });
+
+    // Custom & verbatim tags should nudge parser to a load node as a generic
+    // kind.
+    test('Represents scalars partially as strings', () {
+      expectYamlLoads(['3', 'false', '3.10'], '''
+        %TAG !! !no-type
+        %TAG !isA! !generic-kind
+        ---
+        - !!int 3
+        - !isA!bool false
+        - !<!generic> 3.10''');
+    });
+
+    test('Composes collections completely', () {
+      expectYamlLoads([
+        <Object?, Object?>{},
+        <Object?>[],
+        ['list']
+      ], '''
+        %TAG !! !no-type
+        %TAG !isA! !generic-kind
+        ---
+        - !!map {}
+        - !isA!list []
+        - !<!generic>
+          - list''');
     });
   });
 


### PR DESCRIPTION
This PR helps `package:yaml` recover in the face of custom tags. The YAML spec recommends this for a parser that doesn't not provide a way to externally resolve them. See more here:

  - https://yaml.org/spec/1.2.2/#3212-tag
  - https://yaml.org/spec/1.2.2/#332-resolved-tags
  - https://yaml.org/spec/1.2.2/#333-recognized-and-valid-tags
  - https://yaml.org/spec/1.2.2/#334-available-tags

No change here breaks existing functionality.

## TL;DR

Fixes how tags are parsed. 

It seems existing code knows it can handle named tags and verbatim tags but trips itself while scanning the tag and eventually tries to trick the parser into resolving a malformed (schema or verbatim) tag. A (custom) tag is never ignored unless it is a schema tags (`!!` resolving to prefix `tag:yaml.org,2002:`).

## Changes

1. Any non-schema tag (not `!!` resolving to prefix `tag:yaml.org,2002:`) is represented partially or completely based on its kind.

   - Scalars are defaulted to strings.
   - Collections (map or sequence) are constructed by default.

2. Improves support for named tag handles in both tag shorthands and global tags.

```yaml
%TAG !named! tag:hello
---
- !named!scalar 3.10
- !named!mapping { key: value }
- !named!sequence [ value ]
```

```dart
// Parsed as 
[ '3.10', {'key': 'value'}, ['value']]
```

3. Improves support for verbatim tags.

```yaml
- !<!i-feel-verbatim> 3.10
- !<tag:yeah-you-are> { key: value }
- !<tag:so-verbatim> [ ]
```

```dart
// Parsed as 
[ '3.10', {'key': 'value'}, []]
```

4. Added the remaining YAML spec tests (and a few more) for global tag directives, named tag handles and verbatim tags that were explicitly skipped.
5. Fixed a `TODO` in some directive tests that needed an assert.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
