### PR TITLE
Fix exception on Linux due to unexpected "modify directory".

### DIFF
--- a/pkgs/watcher/lib/src/event.dart
+++ b/pkgs/watcher/lib/src/event.dart
@@ -32,6 +32,10 @@ extension type Event._(FileSystemEvent _event) {
       if (result.type.isIgnoredOnWindows) {
         return null;
       }
+    } else if (Platform.isLinux) {
+      if (result.type.isIgnoredOnLinux) {
+        return null;
+      }
     }
     return result;
   }
@@ -117,6 +121,12 @@ enum EventType {
   bool get isIgnoredOnWindows {
     // Ignore [modifyDirectory] because it's always accompanied by either
     // [createDirectory] or [deleteDirectory].
+    return this == modifyDirectory;
+  }
+
+  bool get isIgnoredOnLinux {
+    // Ignore [modifyDirectory], it arrives when the directory attributes
+    // changed which is not useful.
     return this == modifyDirectory;
   }
 }


### PR DESCRIPTION
Testing didn't see any modify directory events because they only happen when the directory attributes change, which we can't actually do from Dart :)

Spotted in analyzer logs for a dev build.