### PR TITLE
Release watcher 1.2.0.

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.5-wip
+## 1.2.0
 
 - Polling watchers now check file sizes as well as "last modified" times, so
   they are less likely to miss changes on platforms with low resolution

--- a/pkgs/watcher/pubspec.yaml
+++ b/pkgs/watcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 1.1.5-wip
+version: 1.2.0
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.


### PR DESCRIPTION
The Linux watcher rewrite rolled into google3, Mac+Windows rewrites rolled into the SDK, all three watcher e2e tests have run overnight without errors, and I ran the build_runner e2e tests, so this is as tested as it's going to get :) let's release it!