### PR TITLE
Use markdown lists in doc comments

### DIFF
--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -218,8 +218,8 @@ final class Event {
   /// If the method is `workspace/didChangeWorkspaceFolders`, then the following
   /// parameters should be included:
   ///
-  /// * [added] - JSON-encoded percentile values indicating the number of folders
-  ///   that were added.
+  /// * [added] - JSON-encoded percentile values indicating the number of
+  ///   folders that were added.
   ///
   /// * [removed] - JSON-encoded percentile values indicating the number of
   ///   folders that were removed.
@@ -244,7 +244,6 @@ final class Event {
   ///
   /// * [files] - JSON-encoded percentile values indicating the number of
   ///   priority files.
-  ///
   Event.clientRequest({
     required String duration,
     required String latency,


### PR DESCRIPTION
I notice that there was an _intention_ for the parameter documentations to be indented in order to make the parameter names vertically scannable. But no markdown lists were used, so they are not vertically scannable in [the generated documentation](https://pub.dev/documentation/unified_analytics/latest/unified_analytics/Event/Event.clientNotification.html).

This change makes each parameter's documentation into a list item. We could go the other way and remove all of the indented wrapped lines, and just write the text as standard paragraphs.