### PR TITLE
Ignore directory modify events on Mac.

### DIFF
--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.1-wip
+## 1.2.1
 
 - Bug fix: versions before 1.2.0 would allow and ignore a trailing path
   separator passed to `DirectoryWatcher` or `FileWatcher` constructors, restore
@@ -6,6 +6,9 @@
 - In paths passed to `DirectoryWatcher` or `FileWatcher` constructors, remove
   multiple adjacent separators and `.` and `..`, so they will not be returned in
   events.
+- Bug fix: on Mac, stop issuing `assert(false)` when a `modifyDirectory` event
+  is ignored, so the unused events are silently ignored instead of throwing in
+  debug builds.
 
 ## 1.2.0
 

--- a/pkgs/watcher/pubspec.yaml
+++ b/pkgs/watcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 1.2.1-wip
+version: 1.2.1
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.


### PR DESCRIPTION
For #2283.

Directory modify event is never useful, either it's about changing directory attributes that we don't care about or it's (on Windows) a change that also fires a create/delete event.

File move events still trigger an assert failure on Mac as the SDK does not currently send such events, so if it does start sending them we'll find out as tests start failing.

(The branch name says "directory move", that's a typo, sorry! It's the _directory modify_ event that's unhelpful+ignored.)