### PR TITLE
Set `package:watcher` language version to 3.8, reformat

### DIFF
--- a/.github/workflows/watcher.yaml
+++ b/.github/workflows/watcher.yaml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.4, dev]
+        sdk: [3.8, dev]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c

--- a/pkgs/watcher/CHANGELOG.md
+++ b/pkgs/watcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2-wip
+
+- Require Dart SDK `^3.8.0`.
+
 ## 1.2.1
 
 - Bug fix: versions before 1.2.0 would allow and ignore a trailing path

--- a/pkgs/watcher/lib/src/async_queue.dart
+++ b/pkgs/watcher/lib/src/async_queue.dart
@@ -33,9 +33,10 @@ class AsyncQueue<T> {
   /// Used to avoid top-leveling asynchronous errors.
   final void Function(Object, StackTrace) _errorHandler;
 
-  AsyncQueue(this._processor,
-      {required void Function(Object, StackTrace) onError})
-      : _errorHandler = onError;
+  AsyncQueue(
+    this._processor, {
+    required void Function(Object, StackTrace) onError,
+  }) : _errorHandler = onError;
 
   /// Enqueues [item] to be processed and starts asynchronously processing it
   /// if a process isn't already running.

--- a/pkgs/watcher/lib/src/custom_watcher_factory.dart
+++ b/pkgs/watcher/lib/src/custom_watcher_factory.dart
@@ -8,12 +8,15 @@ import '../watcher.dart';
 class _CustomWatcherFactory {
   final String id;
   final DirectoryWatcher? Function(String path, {Duration? pollingDelay})
-      createDirectoryWatcher;
+  createDirectoryWatcher;
   final FileWatcher? Function(String path, {Duration? pollingDelay})
-      createFileWatcher;
+  createFileWatcher;
 
   _CustomWatcherFactory(
-      this.id, this.createDirectoryWatcher, this.createFileWatcher);
+    this.id,
+    this.createDirectoryWatcher,
+    this.createFileWatcher,
+  );
 }
 
 /// Registers a custom watcher.
@@ -32,35 +35,44 @@ class _CustomWatcherFactory {
 void registerCustomWatcher(
   String id,
   DirectoryWatcher? Function(String path, {Duration? pollingDelay})?
-      createDirectoryWatcher,
+  createDirectoryWatcher,
   FileWatcher? Function(String path, {Duration? pollingDelay})?
-      createFileWatcher,
+  createFileWatcher,
 ) {
   if (_customWatcherFactories.containsKey(id)) {
-    throw ArgumentError('A custom watcher with id `$id` '
-        'has already been registered');
+    throw ArgumentError(
+      'A custom watcher with id `$id` '
+      'has already been registered',
+    );
   }
   _customWatcherFactories[id] = _CustomWatcherFactory(
-      id,
-      createDirectoryWatcher ?? (_, {pollingDelay}) => null,
-      createFileWatcher ?? (_, {pollingDelay}) => null);
+    id,
+    createDirectoryWatcher ?? (_, {pollingDelay}) => null,
+    createFileWatcher ?? (_, {pollingDelay}) => null,
+  );
 }
 
 /// Tries to create a custom [DirectoryWatcher] and returns it.
 ///
 /// Returns `null` if no custom watcher was applicable and throws a [StateError]
 /// if more than one was.
-DirectoryWatcher? createCustomDirectoryWatcher(String path,
-    {Duration? pollingDelay}) {
+DirectoryWatcher? createCustomDirectoryWatcher(
+  String path, {
+  Duration? pollingDelay,
+}) {
   DirectoryWatcher? customWatcher;
   String? customFactoryId;
   for (var watcherFactory in _customWatcherFactories.values) {
     if (customWatcher != null) {
-      throw StateError('Two `CustomWatcherFactory`s applicable: '
-          '`$customFactoryId` and `${watcherFactory.id}` for `$path`');
+      throw StateError(
+        'Two `CustomWatcherFactory`s applicable: '
+        '`$customFactoryId` and `${watcherFactory.id}` for `$path`',
+      );
     }
-    customWatcher =
-        watcherFactory.createDirectoryWatcher(path, pollingDelay: pollingDelay);
+    customWatcher = watcherFactory.createDirectoryWatcher(
+      path,
+      pollingDelay: pollingDelay,
+    );
     customFactoryId = watcherFactory.id;
   }
   return customWatcher;
@@ -75,11 +87,15 @@ FileWatcher? createCustomFileWatcher(String path, {Duration? pollingDelay}) {
   String? customFactoryId;
   for (var watcherFactory in _customWatcherFactories.values) {
     if (customWatcher != null) {
-      throw StateError('Two `CustomWatcherFactory`s applicable: '
-          '`$customFactoryId` and `${watcherFactory.id}` for `$path`');
+      throw StateError(
+        'Two `CustomWatcherFactory`s applicable: '
+        '`$customFactoryId` and `${watcherFactory.id}` for `$path`',
+      );
     }
-    customWatcher =
-        watcherFactory.createFileWatcher(path, pollingDelay: pollingDelay);
+    customWatcher = watcherFactory.createFileWatcher(
+      path,
+      pollingDelay: pollingDelay,
+    );
     customFactoryId = watcherFactory.id;
   }
   return customWatcher;

--- a/pkgs/watcher/lib/src/directory_watcher.dart
+++ b/pkgs/watcher/lib/src/directory_watcher.dart
@@ -42,8 +42,11 @@ abstract class DirectoryWatcher implements Watcher {
   ///
   /// On Windows, pass [runInIsolateOnWindows] `false` to not run the watcher
   /// in a separate isolate to reduce buffer exhaustion failures.
-  factory DirectoryWatcher(String directory,
-      {Duration? pollingDelay, bool runInIsolateOnWindows = true}) {
+  factory DirectoryWatcher(
+    String directory, {
+    Duration? pollingDelay,
+    bool runInIsolateOnWindows = true,
+  }) {
     if (FileSystemEntity.isWatchSupported) {
       var customWatcher = createCustomDirectoryWatcher(
         directory,
@@ -55,8 +58,10 @@ abstract class DirectoryWatcher implements Watcher {
         return RecursiveDirectoryWatcher(directory, runInIsolate: false);
       }
       if (Platform.isWindows) {
-        return RecursiveDirectoryWatcher(directory,
-            runInIsolate: runInIsolateOnWindows);
+        return RecursiveDirectoryWatcher(
+          directory,
+          runInIsolate: runInIsolateOnWindows,
+        );
       }
     }
     return PollingDirectoryWatcher(directory, pollingDelay: pollingDelay);

--- a/pkgs/watcher/lib/src/directory_watcher/linux/linux_directory_watcher.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/linux/linux_directory_watcher.dart
@@ -17,7 +17,7 @@ class LinuxDirectoryWatcher extends ResubscribableWatcher
   String get directory => path;
 
   LinuxDirectoryWatcher(String directory)
-      : super(directory, _LinuxDirectoryWatcher.new);
+    : super(directory, _LinuxDirectoryWatcher.new);
 }
 
 /// Linux directory watcher that watches using [WatchTreeRoot].
@@ -43,9 +43,10 @@ class _LinuxDirectoryWatcher
 
   _LinuxDirectoryWatcher(this.path) {
     _watchTree = WatchTreeRoot(
-        watchedDirectory: path,
-        eventsController: _eventsController,
-        readyCompleter: _readyCompleter);
+      watchedDirectory: path,
+      eventsController: _eventsController,
+      readyCompleter: _readyCompleter,
+    );
   }
 
   @override

--- a/pkgs/watcher/lib/src/directory_watcher/linux/native_watch.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/linux/native_watch.dart
@@ -82,10 +82,10 @@ class NativeWatch {
     required void Function() watchedDirectoryWasDeleted,
     required void Function(List<Event>) onEvents,
     required void Function(Object, StackTrace) onError,
-  })  : _onError = onError,
-        _onEvents = onEvents,
-        _watchedDirectoryWasDeleted = watchedDirectoryWasDeleted,
-        _restartWatching = restartWatching {
+  }) : _onError = onError,
+       _onEvents = onEvents,
+       _watchedDirectoryWasDeleted = watchedDirectoryWasDeleted,
+       _restartWatching = restartWatching {
     logForTesting?.call('NativeWatch(),$watchedDirectory');
     _subscription = watchedDirectory
         .watch()

--- a/pkgs/watcher/lib/src/directory_watcher/linux/watch_tree.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/linux/watch_tree.dart
@@ -47,9 +47,9 @@ class WatchTree {
     required void Function(WatchEvent) emitEvent,
     required void Function(Object, StackTrace) onError,
     required void Function() watchedDirectoryWasDeleted,
-  })  : _emitEvent = emitEvent,
-        _onError = onError,
-        _watchedDirectoryWasDeleted = watchedDirectoryWasDeleted {
+  }) : _emitEvent = emitEvent,
+       _onError = onError,
+       _watchedDirectoryWasDeleted = watchedDirectoryWasDeleted {
     logForTesting?.call('WatchTree(),$watchedDirectory');
     _watch(starting: starting, recovering: false);
   }
@@ -74,20 +74,22 @@ class WatchTree {
   /// for files that have disappeared, and "modify" for files that are still
   /// present.
   void _watch({required bool starting, required bool recovering}) {
-    logForTesting
-        ?.call('WatchTree,$watchedDirectory,_watch,$starting,$recovering');
+    logForTesting?.call(
+      'WatchTree,$watchedDirectory,_watch,$starting,$recovering',
+    );
     _nativeWatch?.close();
     _nativeWatch = NativeWatch(
-        watchedDirectory: watchedDirectory,
-        restartWatching: () {
-          _watch(starting: false, recovering: true);
-        },
-        watchedDirectoryWasDeleted: () {
-          _emitDeleteTree();
-          _watchedDirectoryWasDeleted();
-        },
-        onError: _onError,
-        onEvents: _onEvents);
+      watchedDirectory: watchedDirectory,
+      restartWatching: () {
+        _watch(starting: false, recovering: true);
+      },
+      watchedDirectoryWasDeleted: () {
+        _emitDeleteTree();
+        _watchedDirectoryWasDeleted();
+      },
+      onError: _onError,
+      onEvents: _onEvents,
+    );
 
     final listedFiles = <RelativePath>{};
     final listedDirectories = <RelativePath>{};
@@ -103,8 +105,10 @@ class WatchTree {
       // Nothing found, use empty sets so everything is handled as deleted.
     }
 
-    logForTesting?.call('Watch,$watchedDirectory,list,'
-        'files=$listedFiles,directories=$listedDirectories');
+    logForTesting?.call(
+      'Watch,$watchedDirectory,list,'
+      'files=$listedFiles,directories=$listedDirectories',
+    );
     if (recovering) {
       // Emit deletes for missing files.
       for (final file in _files.toList()) {
@@ -210,12 +214,14 @@ class WatchTree {
       final eventTypesSet = eventTypes.toSet();
 
       // Path needs polling if it had both a delete and a create.
-      final needsPolling = eventTypesSet.contains(EventType.delete) &&
+      final needsPolling =
+          eventTypesSet.contains(EventType.delete) &&
           (eventTypesSet.contains(EventType.createFile) ||
               eventTypesSet.contains(EventType.createDirectory));
       if (needsPolling) {
-        logForTesting
-            ?.call('Watch,$watchedDirectory,onEvents,$eventPath,ambiguous');
+        logForTesting?.call(
+          'Watch,$watchedDirectory,onEvents,$eventPath,ambiguous',
+        );
         pathsToPoll.add(eventPath);
         continue;
       }
@@ -291,21 +297,22 @@ class WatchTree {
     logForTesting?.call('Watch,$watchedDirectory,createDirectory,$directory');
     _directories.remove(directory)?._emitDeleteTree();
     _directories[directory] = WatchTree(
-        emitEvent: _emitEvent,
-        onError: (Object e, StackTrace s) {
-          // Ignore exceptions from subdirectories except "out of watchers"
-          // which is an unrecoverable error.
-          if (e is FileSystemException &&
-              e.message.contains('Failed to watch path') &&
-              e.osError?.errorCode == 28) {
-            _onError(e, s);
-          }
-        },
-        watchedDirectoryWasDeleted: () {
-          _emitDeleteDirectory(directory);
-        },
-        watchedDirectory: watchedDirectory.append(directory),
-        starting: starting);
+      emitEvent: _emitEvent,
+      onError: (Object e, StackTrace s) {
+        // Ignore exceptions from subdirectories except "out of watchers"
+        // which is an unrecoverable error.
+        if (e is FileSystemException &&
+            e.message.contains('Failed to watch path') &&
+            e.osError?.errorCode == 28) {
+          _onError(e, s);
+        }
+      },
+      watchedDirectoryWasDeleted: () {
+        _emitDeleteDirectory(directory);
+      },
+      watchedDirectory: watchedDirectory.append(directory),
+      starting: starting,
+    );
   }
 
   /// Adds [file] to known [_files].

--- a/pkgs/watcher/lib/src/directory_watcher/linux/watch_tree_root.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/linux/watch_tree_root.dart
@@ -17,20 +17,21 @@ class WatchTreeRoot {
 
   late final WatchTree watch;
 
-  WatchTreeRoot(
-      {required String watchedDirectory,
-      required Completer<void> readyCompleter,
-      required StreamController<WatchEvent> eventsController})
-      : _readyCompleter = readyCompleter,
-        _eventsController = eventsController,
-        watchedDirectory = AbsolutePath(watchedDirectory) {
+  WatchTreeRoot({
+    required String watchedDirectory,
+    required Completer<void> readyCompleter,
+    required StreamController<WatchEvent> eventsController,
+  }) : _readyCompleter = readyCompleter,
+       _eventsController = eventsController,
+       watchedDirectory = AbsolutePath(watchedDirectory) {
     logForTesting?.call('WatchTree(),$watchedDirectory');
     watch = WatchTree(
-        watchedDirectory: this.watchedDirectory,
-        starting: true,
-        emitEvent: _emit,
-        onError: _emitError,
-        watchedDirectoryWasDeleted: _watchedDirectoryWasDeleted);
+      watchedDirectory: this.watchedDirectory,
+      starting: true,
+      emitEvent: _emit,
+      onError: _emitError,
+      watchedDirectoryWasDeleted: _watchedDirectoryWasDeleted,
+    );
     _ready();
   }
 
@@ -44,8 +45,9 @@ class WatchTreeRoot {
 
   /// Handler for when [watchedDirectory] is deleted.
   void _watchedDirectoryWasDeleted() {
-    logForTesting
-        ?.call('WatchTree,$watchedDirectory,_watchedDirectoryWasDeleted');
+    logForTesting?.call(
+      'WatchTree,$watchedDirectory,_watchedDirectoryWasDeleted',
+    );
     _ready();
     _eventsController.close();
   }

--- a/pkgs/watcher/lib/src/directory_watcher/polling/polling_directory_watcher.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/polling/polling_directory_watcher.dart
@@ -28,10 +28,12 @@ class PollingDirectoryWatcher extends ResubscribableWatcher
   /// shorter will give more immediate feedback at the expense of doing more IO
   /// and higher CPU usage. Defaults to one second.
   PollingDirectoryWatcher(String directory, {Duration? pollingDelay})
-      : super(directory, (path) {
-          return _PollingDirectoryWatcher(
-              path, pollingDelay ?? const Duration(seconds: 1));
-        });
+    : super(directory, (path) {
+        return _PollingDirectoryWatcher(
+          path,
+          pollingDelay ?? const Duration(seconds: 1),
+        );
+      });
 }
 
 class _PollingDirectoryWatcher
@@ -70,10 +72,12 @@ class _PollingDirectoryWatcher
   /// queue exists to let each of those proceed at their own rate. The lister
   /// will enqueue files as quickly as it can. Meanwhile, files are dequeued
   /// and processed sequentially.
-  late final AsyncQueue<String?> _filesToProcess =
-      AsyncQueue<String?>(_processFile, onError: (error, stackTrace) {
-    if (!_events.isClosed) _events.addError(error, stackTrace);
-  });
+  late final AsyncQueue<String?> _filesToProcess = AsyncQueue<String?>(
+    _processFile,
+    onError: (error, stackTrace) {
+      if (!_events.isClosed) _events.addError(error, stackTrace);
+    },
+  );
 
   /// The set of files that have been seen in the current directory listing.
   ///
@@ -114,27 +118,32 @@ class _PollingDirectoryWatcher
     }
 
     var stream = Directory(path).listRecursivelyIgnoringErrors();
-    _listSubscription = stream.listen((entity) {
-      assert(!_events.isClosed);
+    _listSubscription = stream.listen(
+      (entity) {
+        assert(!_events.isClosed);
 
-      if (entity is! File) return;
-      _filesToProcess.add(entity.path);
-    }, onError: (Object error, StackTrace stackTrace) {
-      // Guarantee that ready always completes.
-      if (!isReady) {
-        _readyCompleter.complete();
-      }
-      if (!isDirectoryNotFoundException(error)) {
-        // It's some unknown error. Pipe it over to the event stream so the
-        // user can see it.
-        _events.addError(error, stackTrace);
-      }
+        if (entity is! File) return;
+        _filesToProcess.add(entity.path);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        // Guarantee that ready always completes.
+        if (!isReady) {
+          _readyCompleter.complete();
+        }
+        if (!isDirectoryNotFoundException(error)) {
+          // It's some unknown error. Pipe it over to the event stream so the
+          // user can see it.
+          _events.addError(error, stackTrace);
+        }
 
-      // When an error occurs, we end the listing normally, which has the
-      // desired effect of marking all files that were in the directory as
-      // being removed.
-      endListing();
-    }, onDone: endListing, cancelOnError: true);
+        // When an error occurs, we end the listing normally, which has the
+        // desired effect of marking all files that were in the directory as
+        // being removed.
+        endListing();
+      },
+      onDone: endListing,
+      cancelOnError: true,
+    );
   }
 
   /// Processes [file] to determine if it has been modified since the last
@@ -181,8 +190,9 @@ class _PollingDirectoryWatcher
   Future<void> _completePoll() async {
     // Any files that were not seen in the last poll but that we have a
     // status for must have been removed.
-    var removedFiles =
-        _previousPollResults.keys.toSet().difference(_polledFiles);
+    var removedFiles = _previousPollResults.keys.toSet().difference(
+      _polledFiles,
+    );
     for (var removed in removedFiles) {
       if (isReady) _events.add(WatchEvent(ChangeType.REMOVE, removed));
       _previousPollResults.remove(removed);

--- a/pkgs/watcher/lib/src/directory_watcher/recursive/directory_tree.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/recursive/directory_tree.dart
@@ -101,8 +101,10 @@ class DirectoryTree {
       // Nothing found, use empty sets so everything is handled as deleted.
     }
 
-    logForTesting?.call('Watch,$watchedDirectory,list,'
-        'files=$listedFiles,directories=$listedDirectories');
+    logForTesting?.call(
+      'Watch,$watchedDirectory,list,'
+      'files=$listedFiles,directories=$listedDirectories',
+    );
     // Emit deletes for missing files.
     for (final file in _files.toList()) {
       if (!listedFiles.contains(file)) {
@@ -140,8 +142,9 @@ class DirectoryTree {
   /// was a known file. If it's not now a file and it was before, emits a
   /// delete.
   void _pollPathSegment(PathSegment segment) {
-    logForTesting
-        ?.call('DirectoryTree,$watchedDirectory,_pollPathSegment,$segment');
+    logForTesting?.call(
+      'DirectoryTree,$watchedDirectory,_pollPathSegment,$segment',
+    );
 
     final type = watchedDirectory.append(segment).typeSync();
 
@@ -183,16 +186,18 @@ class DirectoryTree {
   /// If [directory] is known, polls it. If not, starts tracking it, emitting
   /// "add" events for discovered files.
   void _trackOrPollDirectory(PathSegment directory) {
-    logForTesting
-        ?.call('Watch,$watchedDirectory,_trackOrPollDirectory,$directory');
+    logForTesting?.call(
+      'Watch,$watchedDirectory,_trackOrPollDirectory,$directory',
+    );
     if (_directories.containsKey(directory)) {
       // Poll known directories.
       _directories[directory]!.poll(EventTree.singleEvent());
     } else {
       /// Start tracking new directories.
       _directories[directory] = DirectoryTree(
-          emitEvent: _emitEvent,
-          watchedDirectory: watchedDirectory.append(directory));
+        emitEvent: _emitEvent,
+        watchedDirectory: watchedDirectory.append(directory),
+      );
     }
   }
 

--- a/pkgs/watcher/lib/src/directory_watcher/recursive/isolate_recursive_directory_watcher.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/recursive/isolate_recursive_directory_watcher.dart
@@ -34,7 +34,7 @@ class IsolateRecursiveDirectoryWatcher implements ManuallyClosedWatcher {
   final void Function(LogEntry)? _log;
 
   IsolateRecursiveDirectoryWatcher(this.path)
-      : _log = logSeparateIsolateForTesting {
+    : _log = logSeparateIsolateForTesting {
     _startIsolate(path, _receivePort.sendPort, log: _log != null);
     _receivePort.listen((event) => _receiveFromIsolate(event as Event));
   }
@@ -81,8 +81,11 @@ class IsolateRecursiveDirectoryWatcher implements ManuallyClosedWatcher {
 ///
 /// [log] is whether to send test log messages from the isolate.
 void _startIsolate(String path, SendPort sendPort, {required bool log}) async {
-  unawaited(Isolate.run(
-      () async => await _WatcherIsolate(path, sendPort, log: log).closed));
+  unawaited(
+    Isolate.run(
+      () async => await _WatcherIsolate(path, sendPort, log: log).closed,
+    ),
+  );
 }
 
 class _WatcherIsolate {
@@ -96,7 +99,7 @@ class _WatcherIsolate {
   final Completer<void> _closeCompleter = Completer();
 
   _WatcherIsolate(this.path, this.sendPort, {required this.log})
-      : watcher = ManuallyClosedRecursiveDirectoryWatcher(path) {
+    : watcher = ManuallyClosedRecursiveDirectoryWatcher(path) {
     if (log) {
       logForTesting = (message) => sendPort.send(Event.log(message));
     }
@@ -113,16 +116,20 @@ class _WatcherIsolate {
       sendPort.send(Event.ready());
     });
 
-    watcher.events.listen((event) {
-      // The watcher events.
-      sendPort.send(Event.watchEvent(event));
-    }, onDone: () {
-      // `Event.close` if the watcher event stream closes.
-      sendPort.send(Event.close());
-    }, onError: (Object e, StackTrace s) {
-      // `Event.error` on error.
-      sendPort.send(Event.error(e, s));
-    });
+    watcher.events.listen(
+      (event) {
+        // The watcher events.
+        sendPort.send(Event.watchEvent(event));
+      },
+      onDone: () {
+        // `Event.close` if the watcher event stream closes.
+        sendPort.send(Event.close());
+      },
+      onError: (Object e, StackTrace s) {
+        // `Event.error` on error.
+        sendPort.send(Event.error(e, s));
+      },
+    );
 
     receivePort.listen((event) {
       // The only event sent from the host to the isolate is "close", no need
@@ -144,55 +151,48 @@ class Event {
   final LogEntry? logEntry;
 
   Event.sendPort(this.sendPort)
-      : type = EventType.sendPort,
-        watchEvent = null,
-        error = null,
-        stackTrace = null,
-        logEntry = null;
+    : type = EventType.sendPort,
+      watchEvent = null,
+      error = null,
+      stackTrace = null,
+      logEntry = null;
 
   Event.ready()
-      : type = EventType.ready,
-        sendPort = null,
-        watchEvent = null,
-        error = null,
-        stackTrace = null,
-        logEntry = null;
+    : type = EventType.ready,
+      sendPort = null,
+      watchEvent = null,
+      error = null,
+      stackTrace = null,
+      logEntry = null;
 
   Event.watchEvent(this.watchEvent)
-      : type = EventType.watchEvent,
-        sendPort = null,
-        error = null,
-        stackTrace = null,
-        logEntry = null;
+    : type = EventType.watchEvent,
+      sendPort = null,
+      error = null,
+      stackTrace = null,
+      logEntry = null;
 
   Event.close()
-      : type = EventType.close,
-        sendPort = null,
-        watchEvent = null,
-        error = null,
-        stackTrace = null,
-        logEntry = null;
+    : type = EventType.close,
+      sendPort = null,
+      watchEvent = null,
+      error = null,
+      stackTrace = null,
+      logEntry = null;
 
   Event.error(this.error, this.stackTrace)
-      : type = EventType.error,
-        sendPort = null,
-        watchEvent = null,
-        logEntry = null;
+    : type = EventType.error,
+      sendPort = null,
+      watchEvent = null,
+      logEntry = null;
 
   Event.log(String message)
-      : type = EventType.log,
-        sendPort = null,
-        watchEvent = null,
-        error = null,
-        stackTrace = null,
-        logEntry = LogEntry(message);
+    : type = EventType.log,
+      sendPort = null,
+      watchEvent = null,
+      error = null,
+      stackTrace = null,
+      logEntry = LogEntry(message);
 }
 
-enum EventType {
-  sendPort,
-  ready,
-  watchEvent,
-  close,
-  error,
-  log;
-}
+enum EventType { sendPort, ready, watchEvent, close, error, log }

--- a/pkgs/watcher/lib/src/directory_watcher/recursive/recursive_directory_watcher.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/recursive/recursive_directory_watcher.dart
@@ -23,11 +23,12 @@ class RecursiveDirectoryWatcher extends ResubscribableWatcher
   /// If [runInIsolate], runs the watcher in an isolate to reduce the chance of
   /// hitting the Windows-specific buffer exhaustion failure.
   RecursiveDirectoryWatcher(String directory, {required bool runInIsolate})
-      : super(
-            directory,
-            (path) => runInIsolate
-                ? IsolateRecursiveDirectoryWatcher(path)
-                : ManuallyClosedRecursiveDirectoryWatcher(path));
+    : super(
+        directory,
+        (path) => runInIsolate
+            ? IsolateRecursiveDirectoryWatcher(path)
+            : ManuallyClosedRecursiveDirectoryWatcher(path),
+      );
 }
 
 /// Manually closed directory watcher that watches using [WatchedDirectoryTree].
@@ -53,9 +54,10 @@ class ManuallyClosedRecursiveDirectoryWatcher
 
   ManuallyClosedRecursiveDirectoryWatcher(this.path) {
     _watchTree = WatchedDirectoryTree(
-        watchedDirectory: path,
-        eventsController: _eventsController,
-        readyCompleter: _readyCompleter);
+      watchedDirectory: path,
+      eventsController: _eventsController,
+      readyCompleter: _readyCompleter,
+    );
   }
 
   @override

--- a/pkgs/watcher/lib/src/directory_watcher/recursive/recursive_native_watch.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/recursive/recursive_native_watch.dart
@@ -50,10 +50,10 @@ class RecursiveNativeWatch {
     required void Function() watchedDirectoryWasDeleted,
     required void Function(EventTree) onEvents,
     required void Function(Object, StackTrace) onError,
-  })  : _onError = onError,
-        _onEvents = onEvents,
-        _watchedDirectoryWasRecreated = watchedDirectoryWasRecreated,
-        _watchedDirectoryWasDeleted = watchedDirectoryWasDeleted {
+  }) : _onError = onError,
+       _onEvents = onEvents,
+       _watchedDirectoryWasRecreated = watchedDirectoryWasRecreated,
+       _watchedDirectoryWasDeleted = watchedDirectoryWasDeleted {
     logForTesting?.call('NativeWatch(),$watchedDirectory');
     _watch();
     if (Platform.isWindows) _watchParent();
@@ -63,16 +63,16 @@ class RecursiveNativeWatch {
     _subscription?.cancel();
     // In older SDKs watcher exceptions on Windows are not sent over the stream
     // and must be caught with a zone handler.
-    runZonedGuarded(
-      () {
-        _subscription = watchedDirectory
-            .watch(recursive: true)
-            .batchAndConvertEventsForPlatform()
-            .listen(_onData,
-                onError: _restartWatchOnOverflowOr(_onError), onDone: _onDone);
-      },
-      _restartWatchOnOverflowOr(Error.throwWithStackTrace),
-    );
+    runZonedGuarded(() {
+      _subscription = watchedDirectory
+          .watch(recursive: true)
+          .batchAndConvertEventsForPlatform()
+          .listen(
+            _onData,
+            onError: _restartWatchOnOverflowOr(_onError),
+            onDone: _onDone,
+          );
+    }, _restartWatchOnOverflowOr(Error.throwWithStackTrace));
   }
 
   /// Handles deletes and moves of [watchedDirectory] on Windows.
@@ -167,7 +167,8 @@ class RecursiveNativeWatch {
   /// And, a `SocketException` happens on Windows when the watched directory
   /// is deleted.
   void Function(Object, StackTrace) _restartWatchOnOverflowOr(
-      void Function(Object, StackTrace) otherwise) {
+    void Function(Object, StackTrace) otherwise,
+  ) {
     return (error, stackTrace) async {
       if (error is FileSystemException &&
           error.message.startsWith('Directory watcher closed unexpectedly')) {
@@ -211,7 +212,8 @@ extension _BatchEvents on Stream<FileSystemEvent> {
   Stream<List<Event>> batchAndConvertEventsForPlatform() {
     return Platform.isWindows
         ? batchBufferedByPathAndConvertEvents(
-            duration: const Duration(milliseconds: 5))
+            duration: const Duration(milliseconds: 5),
+          )
         : batchNearbyMicrotasksAndConvertEvents();
   }
 }

--- a/pkgs/watcher/lib/src/directory_watcher/recursive/watched_directory_tree.dart
+++ b/pkgs/watcher/lib/src/directory_watcher/recursive/watched_directory_tree.dart
@@ -53,13 +53,13 @@ class WatchedDirectoryTree {
   late final RecursiveNativeWatch nativeWatch;
   late final DirectoryTree directoryTree;
 
-  WatchedDirectoryTree(
-      {required String watchedDirectory,
-      required Completer<void> readyCompleter,
-      required StreamController<WatchEvent> eventsController})
-      : _readyCompleter = readyCompleter,
-        _eventsController = eventsController,
-        watchedDirectory = AbsolutePath(watchedDirectory) {
+  WatchedDirectoryTree({
+    required String watchedDirectory,
+    required Completer<void> readyCompleter,
+    required StreamController<WatchEvent> eventsController,
+  }) : _readyCompleter = readyCompleter,
+       _eventsController = eventsController,
+       watchedDirectory = AbsolutePath(watchedDirectory) {
     logForTesting?.call('WatchedDirectoryTree(),$watchedDirectory');
     _watch();
   }
@@ -72,8 +72,10 @@ class WatchedDirectoryTree {
       onEvents: _onEvents,
       onError: _emitError,
     );
-    directoryTree =
-        DirectoryTree(watchedDirectory: watchedDirectory, emitEvent: _emit);
+    directoryTree = DirectoryTree(
+      watchedDirectory: watchedDirectory,
+      emitEvent: _emit,
+    );
 
     // The native watcher can emit events from before the watch started. Add
     // a delay before marking "ready" to allow those events to arrive and be
@@ -97,7 +99,8 @@ class WatchedDirectoryTree {
   /// Handler for when [watchedDirectory] is recreated.
   void _watchedDirectoryWasRecreated() {
     logForTesting?.call(
-        'WatchedDirectoryTree,$watchedDirectory,_watchedDirectoryWasRecreated');
+      'WatchedDirectoryTree,$watchedDirectory,_watchedDirectoryWasRecreated',
+    );
     // Poll the whole directory and emit events.
     directoryTree.poll(EventTree.singleEvent());
   }
@@ -105,7 +108,8 @@ class WatchedDirectoryTree {
   /// Handler for when [watchedDirectory] is deleted.
   void _watchedDirectoryWasDeleted() {
     logForTesting?.call(
-        'WatchedDirectoryTree,$watchedDirectory,_watchedDirectoryWasDeleted');
+      'WatchedDirectoryTree,$watchedDirectory,_watchedDirectoryWasDeleted',
+    );
     _ready();
     nativeWatch.close();
     directoryTree.emitDeleteTree();

--- a/pkgs/watcher/lib/src/event.dart
+++ b/pkgs/watcher/lib/src/event.dart
@@ -42,7 +42,8 @@ extension type Event._(FileSystemEvent _event) {
     yield Event._(FileSystemDeleteEvent(path, type == EventType.moveDirectory));
     if (destination != null) {
       yield Event._(
-          FileSystemCreateEvent(destination, type == EventType.moveDirectory));
+        FileSystemCreateEvent(destination, type == EventType.moveDirectory),
+      );
     }
   }
 
@@ -57,18 +58,24 @@ extension type Event._(FileSystemEvent _event) {
   /// A delete event for [path].
   ///
   /// Delete events do not specify whether they are for files or directories.
-  static Event delete(String path) => Event._(FileSystemDeleteEvent(
+  static Event delete(String path) => Event._(
+    FileSystemDeleteEvent(
       path,
       // `FileSystemDeleteEvent` just discards `isDirectory`.
-      false /* isDirectory */));
+      false /* isDirectory */,
+    ),
+  );
 
   /// A modify event for the file at [path].
-  static Event modifyFile(String path) => Event._(FileSystemModifyEvent(
+  static Event modifyFile(String path) => Event._(
+    FileSystemModifyEvent(
       path,
       false /* isDirectory */,
       // Don't set `contentChanged`, even pass through from the OS, as
       // `package:watcher` never reads it.
-      false /* contentChanged */));
+      false /* contentChanged */,
+    ),
+  );
 
   /// See [FileSystemEvent.path].
   String get path => _event.path;

--- a/pkgs/watcher/lib/src/file_watcher.dart
+++ b/pkgs/watcher/lib/src/file_watcher.dart
@@ -34,8 +34,10 @@ abstract class FileWatcher implements Watcher {
   /// and higher CPU usage. Defaults to one second. Ignored for non-polling
   /// watchers.
   factory FileWatcher(String file, {Duration? pollingDelay}) {
-    var customWatcher =
-        createCustomFileWatcher(file, pollingDelay: pollingDelay);
+    var customWatcher = createCustomFileWatcher(
+      file,
+      pollingDelay: pollingDelay,
+    );
     if (customWatcher != null) return customWatcher;
 
     // [File.watch] doesn't work on Windows, but

--- a/pkgs/watcher/lib/src/file_watcher/native.dart
+++ b/pkgs/watcher/lib/src/file_watcher/native.dart
@@ -62,8 +62,11 @@ class _NativeFileWatcher implements FileWatcher, ManuallyClosedWatcher {
       });
     }
 
-    _subscription = stream.listen(_onBatch,
-        onError: _eventsController.addError, onDone: _onDone);
+    _subscription = stream.listen(
+      _onBatch,
+      onError: _eventsController.addError,
+      onDone: _onDone,
+    );
   }
 
   void _onBatch(List<Event> batch) {

--- a/pkgs/watcher/lib/src/file_watcher/polling.dart
+++ b/pkgs/watcher/lib/src/file_watcher/polling.dart
@@ -13,10 +13,12 @@ import '../watch_event.dart';
 /// Periodically polls a file for changes.
 class PollingFileWatcher extends ResubscribableWatcher implements FileWatcher {
   PollingFileWatcher(String path, {Duration? pollingDelay})
-      : super(path, (path) {
-          return _PollingFileWatcher(
-              path, pollingDelay ?? const Duration(seconds: 1));
-        });
+    : super(path, (path) {
+        return _PollingFileWatcher(
+          path,
+          pollingDelay ?? const Duration(seconds: 1),
+        );
+      });
 }
 
 class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {

--- a/pkgs/watcher/lib/src/paths.dart
+++ b/pkgs/watcher/lib/src/paths.dart
@@ -121,7 +121,9 @@ extension type PathSegment._(String _string) implements RelativePath {
     if (segment.isEmpty) throw ArgumentError('Segment cannot be empty.');
     if (segment.contains(Platform.pathSeparator)) {
       throw ArgumentError(
-          'Segment cannot contain `${Platform.pathSeparator}`.', segment);
+        'Segment cannot contain `${Platform.pathSeparator}`.',
+        segment,
+      );
     }
     return PathSegment._(segment);
   }

--- a/pkgs/watcher/pubspec.yaml
+++ b/pkgs/watcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 1.2.1
+version: 1.2.2-wip
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.
@@ -7,7 +7,7 @@ repository: https://github.com/dart-lang/tools/tree/main/pkgs/watcher
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Awatcher
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.8.0
 
 dependencies:
   async: ^2.5.0

--- a/pkgs/watcher/test/custom_watcher_factory_test.dart
+++ b/pkgs/watcher/test/custom_watcher_factory_test.dart
@@ -13,13 +13,15 @@ void main() {
     var memFsWatcherFactory = _MemFsWatcherFactory(memFs);
     var noOpWatcherFactory = _NoOpWatcherFactory();
     registerCustomWatcher(
-        noOpFactoryId,
-        noOpWatcherFactory.createDirectoryWatcher,
-        noOpWatcherFactory.createFileWatcher);
+      noOpFactoryId,
+      noOpWatcherFactory.createDirectoryWatcher,
+      noOpWatcherFactory.createFileWatcher,
+    );
     registerCustomWatcher(
-        memFsFactoryId,
-        memFsWatcherFactory.createDirectoryWatcher,
-        memFsWatcherFactory.createFileWatcher);
+      memFsFactoryId,
+      memFsWatcherFactory.createDirectoryWatcher,
+      memFsWatcherFactory.createFileWatcher,
+    );
   });
 
   test('notifies for files', () async {
@@ -51,9 +53,10 @@ void main() {
   test('registering twice throws', () async {
     expect(
       () => registerCustomWatcher(
-          memFsFactoryId,
-          (_, {pollingDelay}) => throw UnimplementedError(),
-          (_, {pollingDelay}) => throw UnimplementedError()),
+        memFsFactoryId,
+        (_, {pollingDelay}) => throw UnimplementedError(),
+        (_, {pollingDelay}) => throw UnimplementedError(),
+      ),
       throwsA(isA<ArgumentError>()),
     );
   });
@@ -62,8 +65,11 @@ void main() {
     // Note that _MemFsWatcherFactory always returns a watcher, so having two
     // will always produce a conflict.
     var watcherFactory = _MemFsWatcherFactory(memFs);
-    registerCustomWatcher('Different id', watcherFactory.createDirectoryWatcher,
-        watcherFactory.createFileWatcher);
+    registerCustomWatcher(
+      'Different id',
+      watcherFactory.createDirectoryWatcher,
+      watcherFactory.createFileWatcher,
+    );
     expect(() => FileWatcher('file.txt'), throwsA(isA<StateError>()));
     expect(() => DirectoryWatcher('/dir'), throwsA(isA<StateError>()));
   });
@@ -125,18 +131,20 @@ class _MemFsWatcherFactory {
   final _MemFs _memFs;
   _MemFsWatcherFactory(this._memFs);
 
-  DirectoryWatcher? createDirectoryWatcher(String path,
-          {Duration? pollingDelay}) =>
-      _MemFsWatcher(path, _memFs.watchStream(path));
+  DirectoryWatcher? createDirectoryWatcher(
+    String path, {
+    Duration? pollingDelay,
+  }) => _MemFsWatcher(path, _memFs.watchStream(path));
 
   FileWatcher? createFileWatcher(String path, {Duration? pollingDelay}) =>
       _MemFsWatcher(path, _memFs.watchStream(path));
 }
 
 class _NoOpWatcherFactory {
-  DirectoryWatcher? createDirectoryWatcher(String path,
-          {Duration? pollingDelay}) =>
-      null;
+  DirectoryWatcher? createDirectoryWatcher(
+    String path, {
+    Duration? pollingDelay,
+  }) => null;
 
   FileWatcher? createFileWatcher(String path, {Duration? pollingDelay}) => null;
 }

--- a/pkgs/watcher/test/directory_watcher/client_simulator.dart
+++ b/pkgs/watcher/test/directory_watcher/client_simulator.dart
@@ -28,8 +28,10 @@ class ClientSimulator {
   ///
   /// When returned, it has already read the filesystem state and started
   /// tracking file lengths using watcher events.
-  static Future<ClientSimulator> watch(
-      {required Watcher watcher, required void Function(String) log}) async {
+  static Future<ClientSimulator> watch({
+    required Watcher watcher,
+    required void Function(String) log,
+  }) async {
     final result = ClientSimulator._(watcher: watcher, log: log);
     result._initialRead();
     result._subscription = watcher.events.listen(result._handleEvent);
@@ -126,26 +128,30 @@ class ClientSimulator {
 
     var result = true;
 
-    final unexpectedFiles =
-        fileLengths.keys.toSet().difference(_trackedFileLengths.keys.toSet());
+    final unexpectedFiles = fileLengths.keys.toSet().difference(
+      _trackedFileLengths.keys.toSet(),
+    );
     if (unexpectedFiles.isNotEmpty) {
       result = false;
 
       if (printOnFailure != null) {
         printOnFailure('Failed, on disk but not tracked:');
         printOnFailure(
-            unexpectedFiles.map((path) => path.padLeft(4)).join('\n'));
+          unexpectedFiles.map((path) => path.padLeft(4)).join('\n'),
+        );
       }
     }
 
-    final missingExpectedFiles =
-        _trackedFileLengths.keys.toSet().difference(fileLengths.keys.toSet());
+    final missingExpectedFiles = _trackedFileLengths.keys.toSet().difference(
+      fileLengths.keys.toSet(),
+    );
     if (missingExpectedFiles.isNotEmpty) {
       result = false;
       if (printOnFailure != null) {
         printOnFailure('Failed, tracked but not on disk:');
         printOnFailure(
-            missingExpectedFiles.map((path) => path.padLeft(4)).join('\n'));
+          missingExpectedFiles.map((path) => path.padLeft(4)).join('\n'),
+        );
       }
     }
 
@@ -175,8 +181,10 @@ class ClientSimulator {
 
   void _log(String message) {
     // Remove the tmp folder from the message.
-    message =
-        message.replaceAll('${watcher.path}${Platform.pathSeparator}', '');
+    message = message.replaceAll(
+      '${watcher.path}${Platform.pathSeparator}',
+      '',
+    );
     log(message);
   }
 }

--- a/pkgs/watcher/test/directory_watcher/end_to_end_test_runner.dart
+++ b/pkgs/watcher/test/directory_watcher/end_to_end_test_runner.dart
@@ -50,15 +50,18 @@ Future<void> runTest({
     log.add(LogEntry('W $message'));
   };
   logSeparateIsolateForTesting = (entry) {
-    final message =
-        entry.message.replaceAll('${temp.path}/', '').replaceAll(temp.path, '');
+    final message = entry.message
+        .replaceAll('${temp.path}/', '')
+        .replaceAll(temp.path, '');
     log.add(entry.withMessage('W $message'));
   };
 
   // Create the watcher and [ClientSimulator].
   final watcher = createWatcher(path: temp.path);
   final client = await ClientSimulator.watch(
-      watcher: watcher, log: (message) => log.add(LogEntry('C $message')));
+    watcher: watcher,
+    log: (message) => log.add(LogEntry('C $message')),
+  );
   addTearDown(client.close);
 
   // Making changes, waiting for events to settle, check for consistency.
@@ -150,8 +153,9 @@ Future<void> main(List<String> arguments) async {
     if (replay) {
       final filteredTestCases = testCases;
       if (specifiedName != null) {
-        filteredTestCases
-            .retainWhere((testCase) => testCase.name == specifiedName);
+        filteredTestCases.retainWhere(
+          (testCase) => testCase.name == specifiedName,
+        );
       }
       if (filteredTestCases.isEmpty) {
         throw ArgumentError('No test case matching `$specifiedName`.');

--- a/pkgs/watcher/test/directory_watcher/end_to_end_tests.dart
+++ b/pkgs/watcher/test/directory_watcher/end_to_end_tests.dart
@@ -23,17 +23,28 @@ import 'file_changer.dart';
 /// See `README.md` for more detail.
 void endToEndTests() {
   // Random test to cover a wide range of cases.
-  test('end to end test: random', timeout: const Timeout(Duration(minutes: 10)),
-      () async {
-    await runTest(name: 'random', repeats: 100);
-  });
+  test(
+    'end to end test: random',
+    timeout: const Timeout(Duration(minutes: 10)),
+    () async {
+      await runTest(name: 'random', repeats: 100);
+    },
+  );
 
   // Specific test cases that have caught bugs.
   for (final testCase in testCases) {
-    test('end to end test: ${testCase.name}',
-        timeout: const Timeout(Duration(minutes: 5)), () async {
-      await runTest(name: testCase.name, replayLog: testCase.log, repeats: 50);
-    }, skip: testCase.skipOnLinux && Platform.isLinux);
+    test(
+      'end to end test: ${testCase.name}',
+      timeout: const Timeout(Duration(minutes: 5)),
+      () async {
+        await runTest(
+          name: testCase.name,
+          replayLog: testCase.log,
+          repeats: 50,
+        );
+      },
+      skip: testCase.skipOnLinux && Platform.isLinux,
+    );
   }
 }
 
@@ -84,17 +95,12 @@ F modify,f/8110,250
 F create,52267,858
 F move directory to new,f,g
 '''),
-  TestCase(
-    'moves and modifies',
-    '''
+  TestCase('moves and modifies', '''
 F create directory,1
 F create,1/1,1
 ${_movesAndModifies()}
-''',
-  ),
-  TestCase(
-    'move directory in, move file over',
-    '''
+'''),
+  TestCase('move directory in, move file over', '''
 F create directory,a
 F create,a/1,1
 F create directory,b
@@ -103,11 +109,8 @@ F move directory to new,a,b/a
 F create directory,c
 F create,c/3,3
 F move file over file,b/2,b/a/1
-''',
-  ),
-  TestCase(
-    'move new file over recently-moved file',
-    '''
+'''),
+  TestCase('move new file over recently-moved file', '''
 F create directory,b/g
 F create,b/g/67046,94
 F create directory,d
@@ -117,11 +120,8 @@ F create directory,a/j
 F create,a/j/85244,308
 F wait
 F move file over file,a/j/85244,d/f/g/67046
-''',
-  ),
-  TestCase(
-    'move over, modify, delete in new directory',
-    '''
+'''),
+  TestCase('move over, modify, delete in new directory', '''
 F create,62543,809
 F wait
 F wait
@@ -132,8 +132,7 @@ F create,a/63090,758
 F move file over file,62543,a/63090
 F modify,a/63090,439
 F delete,a/63090
-''',
-  ),
+'''),
 ];
 
 String _movesAndModifies() {

--- a/pkgs/watcher/test/directory_watcher/file_changer.dart
+++ b/pkgs/watcher/test/directory_watcher/file_changer.dart
@@ -99,7 +99,8 @@ class FileChanger {
         _log('move file over file,$existingPath,$existingPath2');
         // Fails sometimes on Windows, so guard+retry.
         retryForPathAccessException(
-            () => File(existingPath).renameSync(existingPath2));
+          () => File(existingPath).renameSync(existingPath2),
+        );
 
       case 6:
         final existingDirectory = _randomExistingDirectoryPath();
@@ -111,7 +112,8 @@ class FileChanger {
         _log('move directory to new,$existingDirectory,$newDirectory');
         // Fails sometimes on Windows, so guard+retry.
         retryForPathAccessException(
-            () => Directory(existingDirectory).renameSync(newDirectory));
+          () => Directory(existingDirectory).renameSync(newDirectory),
+        );
 
       case 7:
         final existingPath = _randomExistingFilePath();
@@ -156,9 +158,8 @@ class FileChanger {
 
   /// Returns the path to an already-created directory, or `null` if none
   /// exists.
-  String? _randomExistingDirectoryPath() => (Directory(
-        path,
-      ).listSync(recursive: true).whereType<Directory>().toList()
+  String? _randomExistingDirectoryPath() =>
+      (Directory(path).listSync(recursive: true).whereType<Directory>().toList()
             ..sort((a, b) => a.path.compareTo(b.path))
             ..shuffle(_random))
           .firstOrNull
@@ -233,14 +234,16 @@ class FileChanger {
         final existingPath2 = p.join(path, parameters[1]);
         _log('move file over file,$existingPath,$existingPath2');
         retryForPathAccessException(
-            () => File(existingPath).renameSync(existingPath2));
+          () => File(existingPath).renameSync(existingPath2),
+        );
 
       case 'move directory to new':
         final existingDirectory = p.join(path, parameters[0]);
         final newDirectory = p.join(path, parameters[1]);
         _log('move directory to new,$existingDirectory,$newDirectory');
         retryForPathAccessException(
-            () => Directory(existingDirectory).renameSync(newDirectory));
+          () => Directory(existingDirectory).renameSync(newDirectory),
+        );
 
       case 'delete':
         final existingPath = p.join(path, parameters[0]);

--- a/pkgs/watcher/test/directory_watcher/file_tests.dart
+++ b/pkgs/watcher/test/directory_watcher/file_tests.dart
@@ -124,8 +124,9 @@ void _fileTests({required bool isNative}) {
     createDir('a');
     final separator = Platform.pathSeparator;
     await startWatcher(
-        exactPath:
-            '${d.sandbox}${separator * 5}a${separator * 4}b${separator * 3}..');
+      exactPath:
+          '${d.sandbox}${separator * 5}a${separator * 4}b${separator * 3}..',
+    );
 
     writeFile('a/a.txt');
     await expectAddEvent('a/a.txt');
@@ -208,8 +209,7 @@ void _fileTests({required bool isNative}) {
   });
 
   // Regression test for b/30768513.
-  test(
-      "doesn't crash when the directory is moved immediately after a subdir "
+  test("doesn't crash when the directory is moved immediately after a subdir "
       'is added', () async {
     writeFile('dir/a.txt');
     writeFile('dir/b.txt');
@@ -223,33 +223,39 @@ void _fileTests({required bool isNative}) {
   });
 
   group('moves', () {
-    test('notifies when a file is moved within the watched directory',
-        () async {
-      writeFile('old.txt');
-      await startWatcher();
-      renameFile('old.txt', 'new.txt');
+    test(
+      'notifies when a file is moved within the watched directory',
+      () async {
+        writeFile('old.txt');
+        await startWatcher();
+        renameFile('old.txt', 'new.txt');
 
-      await inAnyOrder([isAddEvent('new.txt'), isRemoveEvent('old.txt')]);
-    });
+        await inAnyOrder([isAddEvent('new.txt'), isRemoveEvent('old.txt')]);
+      },
+    );
 
-    test('notifies when a file is moved from outside the watched directory',
-        () async {
-      writeFile('old.txt');
-      createDir('dir');
-      await startWatcher(path: 'dir');
+    test(
+      'notifies when a file is moved from outside the watched directory',
+      () async {
+        writeFile('old.txt');
+        createDir('dir');
+        await startWatcher(path: 'dir');
 
-      renameFile('old.txt', 'dir/new.txt');
-      await expectAddEvent('dir/new.txt');
-    });
+        renameFile('old.txt', 'dir/new.txt');
+        await expectAddEvent('dir/new.txt');
+      },
+    );
 
-    test('notifies when a file is moved outside the watched directory',
-        () async {
-      writeFile('dir/old.txt');
-      await startWatcher(path: 'dir');
+    test(
+      'notifies when a file is moved outside the watched directory',
+      () async {
+        writeFile('dir/old.txt');
+        await startWatcher(path: 'dir');
 
-      renameFile('dir/old.txt', 'new.txt');
-      await expectRemoveEvent('dir/old.txt');
-    });
+        renameFile('dir/old.txt', 'new.txt');
+        await expectRemoveEvent('dir/old.txt');
+      },
+    );
 
     test('notifies when a file is moved onto an existing one', () async {
       writeFile('from.txt');
@@ -262,28 +268,32 @@ void _fileTests({required bool isNative}) {
   });
 
   group('clustered changes', () {
-    test("doesn't notify when a file is created and then immediately removed",
-        () async {
-      writeFile('test.txt');
-      await startWatcher();
-      writeFile('file.txt');
-      deleteFile('file.txt');
-    });
+    test(
+      "doesn't notify when a file is created and then immediately removed",
+      () async {
+        writeFile('test.txt');
+        await startWatcher();
+        writeFile('file.txt');
+        deleteFile('file.txt');
+      },
+    );
 
-    test('reports when a file is moved between directories then deleted',
-        () async {
-      writeFile('a/test.txt');
-      createDir('b');
-      await startWatcher(path: 'b');
+    test(
+      'reports when a file is moved between directories then deleted',
+      () async {
+        writeFile('a/test.txt');
+        createDir('b');
+        await startWatcher(path: 'b');
 
-      renameFile('a/test.txt', 'b/test.txt');
-      deleteFile('b/test.txt');
+        renameFile('a/test.txt', 'b/test.txt');
+        deleteFile('b/test.txt');
 
-      final events =
-          await takeEvents(duration: const Duration(milliseconds: 500));
+        final events = await takeEvents(
+          duration: const Duration(milliseconds: 500),
+        );
 
-      // It's correct to report either nothing or an add+remove.
-      expect(
+        // It's correct to report either nothing or an add+remove.
+        expect(
           events,
           anyOf([
             isEmpty,
@@ -291,12 +301,13 @@ void _fileTests({required bool isNative}) {
               isAddEvent('b/test.txt'),
               isRemoveEvent('b/test.txt'),
             ]),
-          ]));
-      expect(events, isNot(contains(isModifyEvent('b/test.txt'))));
-    });
+          ]),
+        );
+        expect(events, isNot(contains(isModifyEvent('b/test.txt'))));
+      },
+    );
 
-    test(
-        'reports a modification when a file is deleted and then immediately '
+    test('reports a modification when a file is deleted and then immediately '
         'recreated', () async {
       writeFile('file.txt');
       await startWatcher();
@@ -307,8 +318,7 @@ void _fileTests({required bool isNative}) {
       await expectModifyEvent('file.txt');
     });
 
-    test(
-        'reports a modification when a file is moved and then immediately '
+    test('reports a modification when a file is moved and then immediately '
         'recreated', () async {
       writeFile('old.txt');
       await startWatcher();
@@ -319,8 +329,7 @@ void _fileTests({required bool isNative}) {
       await inAnyOrder([isModifyEvent('old.txt'), isAddEvent('new.txt')]);
     });
 
-    test(
-        'reports a removal when a file is modified and then immediately '
+    test('reports a removal when a file is modified and then immediately '
         'removed', () async {
       writeFile('file.txt');
       await startWatcher();
@@ -331,15 +340,17 @@ void _fileTests({required bool isNative}) {
       await expectRemoveEvent('file.txt');
     });
 
-    test('reports an add when a file is added and then immediately modified',
-        () async {
-      await startWatcher();
+    test(
+      'reports an add when a file is added and then immediately modified',
+      () async {
+        await startWatcher();
 
-      writeFile('file.txt');
-      writeFile('file.txt', contents: 'modified');
+        writeFile('file.txt');
+        writeFile('file.txt', contents: 'modified');
 
-      await expectAddEvent('file.txt');
-    });
+        await expectAddEvent('file.txt');
+      },
+    );
   });
 
   group('subdirectories', () {
@@ -349,15 +360,16 @@ void _fileTests({required bool isNative}) {
       await expectAddEvent('a/b/c/d/file.txt');
     });
 
-    test(
-        'notifies when a subdirectory is moved within the watched directory '
+    test('notifies when a subdirectory is moved within the watched directory '
         'and then its contents are modified', () async {
       writeFile('old/file.txt');
       await startWatcher();
 
       renameDir('old', 'new');
-      await inAnyOrder(
-          [isRemoveEvent('old/file.txt'), isAddEvent('new/file.txt')]);
+      await inAnyOrder([
+        isRemoveEvent('old/file.txt'),
+        isAddEvent('new/file.txt'),
+      ]);
 
       writeFile('new/file.txt', contents: 'modified');
       await expectModifyEvent('new/file.txt');
@@ -373,7 +385,7 @@ void _fileTests({required bool isNative}) {
       await inAnyOrder([
         isRemoveEvent('new'),
         isRemoveEvent('old/file.txt'),
-        isAddEvent('new/file.txt')
+        isAddEvent('new/file.txt'),
       ]);
     });
 
@@ -388,7 +400,7 @@ void _fileTests({required bool isNative}) {
         isRemoveEvent('new/file.txt'),
         isAddEvent('newer/file.txt'),
         isRemoveEvent('old'),
-        isAddEvent('new')
+        isAddEvent('new'),
       ]);
     });
 
@@ -399,13 +411,17 @@ void _fileTests({required bool isNative}) {
       await startWatcher(path: 'dir');
       renameDir('sub', 'dir/sub');
 
-      await inAnyOrder(withPermutations(
-          (i, j, k) => isAddEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
+      await inAnyOrder(
+        withPermutations(
+          (i, j, k) => isAddEvent('dir/sub/sub-$i/sub-$j/file-$k.txt'),
+        ),
+      );
     });
 
     test('emits events for many nested files removed at once', () async {
       withPermutations(
-          (i, j, k) => writeFile('dir/sub/sub-$i/sub-$j/file-$k.txt'));
+        (i, j, k) => writeFile('dir/sub/sub-$i/sub-$j/file-$k.txt'),
+      );
 
       createDir('dir');
       await startWatcher(path: 'dir');
@@ -416,57 +432,75 @@ void _fileTests({required bool isNative}) {
       // directory.
       renameDir('dir/sub', 'sub');
 
-      await inAnyOrder(withPermutations(
-          (i, j, k) => isRemoveEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
+      await inAnyOrder(
+        withPermutations(
+          (i, j, k) => isRemoveEvent('dir/sub/sub-$i/sub-$j/file-$k.txt'),
+        ),
+      );
     });
 
     test('emits events for many nested files moved at once', () async {
       withPermutations(
-          (i, j, k) => writeFile('dir/old/sub-$i/sub-$j/file-$k.txt'));
+        (i, j, k) => writeFile('dir/old/sub-$i/sub-$j/file-$k.txt'),
+      );
 
       createDir('dir');
       await startWatcher(path: 'dir');
       renameDir('dir/old', 'dir/new');
 
-      await inAnyOrder(unionAll(withPermutations((i, j, k) {
-        return {
-          isRemoveEvent('dir/old/sub-$i/sub-$j/file-$k.txt'),
-          isAddEvent('dir/new/sub-$i/sub-$j/file-$k.txt')
-        };
-      })));
+      await inAnyOrder(
+        unionAll(
+          withPermutations((i, j, k) {
+            return {
+              isRemoveEvent('dir/old/sub-$i/sub-$j/file-$k.txt'),
+              isAddEvent('dir/new/sub-$i/sub-$j/file-$k.txt'),
+            };
+          }),
+        ),
+      );
     });
 
     test(
-        'emits events for many nested files moved out then immediately back in',
-        () async {
-      withPermutations(
-          (i, j, k) => writeFile('dir/sub/sub-$i/sub-$j/file-$k.txt'));
+      'emits events for many nested files moved out then immediately back in',
+      () async {
+        withPermutations(
+          (i, j, k) => writeFile('dir/sub/sub-$i/sub-$j/file-$k.txt'),
+        );
 
-      await startWatcher(path: 'dir');
+        await startWatcher(path: 'dir');
 
-      renameDir('dir/sub', 'sub');
-      renameDir('sub', 'dir/sub');
+        renameDir('dir/sub', 'sub');
+        renameDir('sub', 'dir/sub');
 
-      if (isNative) {
-        if (Platform.isMacOS || Platform.isWindows) {
-          // MacOS/Windows watcher reports as "modify" instead of remove then add.
-          await inAnyOrder(withPermutations(
-              (i, j, k) => isModifyEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
+        if (isNative) {
+          if (Platform.isMacOS || Platform.isWindows) {
+            // MacOS/Windows watcher reports as "modify" instead of remove then add.
+            await inAnyOrder(
+              withPermutations(
+                (i, j, k) => isModifyEvent('dir/sub/sub-$i/sub-$j/file-$k.txt'),
+              ),
+            );
+          } else {
+            await inAnyOrder(
+              withPermutations(
+                (i, j, k) => isRemoveEvent('dir/sub/sub-$i/sub-$j/file-$k.txt'),
+              ),
+            );
+            await inAnyOrder(
+              withPermutations(
+                (i, j, k) => isAddEvent('dir/sub/sub-$i/sub-$j/file-$k.txt'),
+              ),
+            );
+          }
         } else {
-          await inAnyOrder(withPermutations(
-              (i, j, k) => isRemoveEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
-          await inAnyOrder(withPermutations(
-              (i, j, k) => isAddEvent('dir/sub/sub-$i/sub-$j/file-$k.txt')));
+          // Polling watchers can't detect this as directory contents mtimes
+          // aren't updated when the directory is moved.
+          await expectNoEvents();
         }
-      } else {
-        // Polling watchers can't detect this as directory contents mtimes
-        // aren't updated when the directory is moved.
-        await expectNoEvents();
-      }
-    });
+      },
+    );
 
-    test(
-        'emits events for many files added at once in a subdirectory with the '
+    test('emits events for many files added at once in a subdirectory with the '
         'same name as a removed file', () async {
       writeFile('dir/sub');
       withPermutations((i, j, k) => writeFile('old/sub-$i/sub-$j/file-$k.txt'));
@@ -476,7 +510,8 @@ void _fileTests({required bool isNative}) {
       renameDir('old', 'dir/sub');
 
       var events = withPermutations(
-          (i, j, k) => isAddEvent('dir/sub/sub-$i/sub-$j/file-$k.txt'));
+        (i, j, k) => isAddEvent('dir/sub/sub-$i/sub-$j/file-$k.txt'),
+      );
       events.add(isRemoveEvent('dir/sub'));
       await inAnyOrder(events);
     });
@@ -488,8 +523,10 @@ void _fileTests({required bool isNative}) {
       await expectAddEvent('a/b/file.txt');
 
       renameDir('a', 'c');
-      await inAnyOrder(
-          [isRemoveEvent('a/b/file.txt'), isAddEvent('c/b/file.txt')]);
+      await inAnyOrder([
+        isRemoveEvent('a/b/file.txt'),
+        isAddEvent('c/b/file.txt'),
+      ]);
 
       writeFile('c/b/file2.txt');
       await expectAddEvent('c/b/file2.txt');
@@ -513,8 +550,9 @@ void _fileTests({required bool isNative}) {
       renameDir('watched/x', 'b');
 
       expect(
-          foldDeletes(await takeEvents(duration: const Duration(seconds: 1))),
-          isEmpty);
+        foldDeletes(await takeEvents(duration: const Duration(seconds: 1))),
+        isEmpty,
+      );
     });
 
     test('subdirectory watching is robust against races', () async {
@@ -539,8 +577,7 @@ void _fileTests({required bool isNative}) {
     });
   });
 
-  test(
-      'does not notify about the watched directory being deleted and '
+  test('does not notify about the watched directory being deleted and '
       'recreated immediately before watching', () async {
     createDir('dir');
     writeFile('dir/old.txt');
@@ -563,7 +600,7 @@ void _fileTests({required bool isNative}) {
 
     await inAnyOrder([
       isAddEvent('some_name/some_name.txt'),
-      isRemoveEvent('some_name.txt')
+      isRemoveEvent('some_name.txt'),
     ]);
   });
 
@@ -576,8 +613,9 @@ void _fileTests({required bool isNative}) {
     return result;
   }
 
-  group('on case-insensitive filesystem', skip: filesystemIsCaseSensitive(),
-      () {
+  final skipCaseInsensitiveTests = filesystemIsCaseSensitive();
+
+  group('on case-insensitive filesystem', skip: skipCaseInsensitiveTests, () {
     test('events with case-only changes', () async {
       if (filesystemIsCaseSensitive()) return;
 

--- a/pkgs/watcher/test/directory_watcher/link_tests.dart
+++ b/pkgs/watcher/test/directory_watcher/link_tests.dart
@@ -20,13 +20,15 @@ void _linkTests({required bool isNative}) {
     await startWatcher(path: 'links');
 
     writeLink(
-        link: 'links/a.link', target: 'targets/a.target', unawaitedAsync: true);
+      link: 'links/a.link',
+      target: 'targets/a.target',
+      unawaitedAsync: true,
+    );
 
     await expectAddEvent('links/a.link');
   });
 
-  test(
-      'notifies when a link is replaced with a link to a different target '
+  test('notifies when a link is replaced with a link to a different target '
       'with the same contents', () async {
     createDir('targets');
     createDir('links');
@@ -42,8 +44,7 @@ void _linkTests({required bool isNative}) {
     await expectModifyEvent('links/a.link');
   });
 
-  test(
-      'notifies when a link is replaced with a link to a different target '
+  test('notifies when a link is replaced with a link to a different target '
       'with different contents', () async {
     writeFile('targets/a.target', contents: 'a');
     writeFile('targets/b.target', contents: 'ab');
@@ -98,8 +99,10 @@ void _linkTests({required bool isNative}) {
 
     renameLink('links/a.link', 'links/b.link');
 
-    await inAnyOrder(
-        [isAddEvent('links/b.link'), isRemoveEvent('links/a.link')]);
+    await inAnyOrder([
+      isAddEvent('links/b.link'),
+      isRemoveEvent('links/a.link'),
+    ]);
   });
 
   test('notifies when a link to an empty directory is added', () async {
@@ -109,9 +112,10 @@ void _linkTests({required bool isNative}) {
     await startWatcher(path: 'links');
 
     writeLink(
-        link: 'links/a.link',
-        target: 'targets/a.targetdir',
-        unawaitedAsync: true);
+      link: 'links/a.link',
+      target: 'targets/a.targetdir',
+      unawaitedAsync: true,
+    );
 
     // Native watchers treat links as files, polling watcher polls through them.
     if (isNative) {
@@ -121,8 +125,7 @@ void _linkTests({required bool isNative}) {
     }
   });
 
-  test(
-      'does not notify about directory contents '
+  test('does not notify about directory contents '
       'when a link to a directory is added', () async {
     createDir('targets');
     createDir('links');
@@ -131,9 +134,10 @@ void _linkTests({required bool isNative}) {
     await startWatcher(path: 'links');
 
     writeLink(
-        link: 'links/a.link',
-        target: 'targets/a.targetdir',
-        unawaitedAsync: true);
+      link: 'links/a.link',
+      target: 'targets/a.targetdir',
+      unawaitedAsync: true,
+    );
 
     // Native watchers treat links as files, polling watcher polls through them.
     if (isNative) {
@@ -177,9 +181,8 @@ void _linkTests({required bool isNative}) {
     }
   });
 
-  test(
-      'notifies about linked directory contents when a directory with a linked '
-      'subdirectory is moved in', () async {
+  test('notifies about linked directory contents when a directory with a '
+      'linked subdirectory is moved in', () async {
     createDir('targets');
     createDir('links');
     createDir('targets/a.targetdir');
@@ -198,9 +201,8 @@ void _linkTests({required bool isNative}) {
     }
   });
 
-  test(
-      'notifies about linked directory contents when a directory with a linked '
-      'subdirectory containing a link loop is moved in', () async {
+  test('notifies about linked directory contents when a directory with a '
+      'linked subdirectory containing a link loop is moved in', () async {
     createDir('targets');
     createDir('links');
     createDir('targets/a.targetdir');
@@ -208,7 +210,9 @@ void _linkTests({required bool isNative}) {
     writeFile('targets/a.targetdir/a.txt');
     writeLink(link: 'links/a.link', target: 'targets/a.targetdir');
     writeLink(
-        link: 'targets/a.targetdir/cycle.link', target: 'targets/a.targetdir');
+      link: 'targets/a.targetdir/cycle.link',
+      target: 'targets/a.targetdir',
+    );
     await startWatcher(path: 'watched');
 
     renameDir('links', 'watched/links');
@@ -222,9 +226,8 @@ void _linkTests({required bool isNative}) {
     await expectNoEvents();
   });
 
-  test(
-      'notifies about linked directory contents when a directory with a linked '
-      'subdirectory containing two link loops is moved in', () async {
+  test('notifies about linked directory contents when a directory with a '
+      'linked subdirectory containing two link loops is moved in', () async {
     createDir('targets');
     createDir('links');
     createDir('targets/a.targetdir');
@@ -232,9 +235,13 @@ void _linkTests({required bool isNative}) {
     writeFile('targets/a.targetdir/a.txt');
     writeLink(link: 'links/a.link', target: 'targets/a.targetdir');
     writeLink(
-        link: 'targets/a.targetdir/cycle1.link', target: 'targets/a.targetdir');
+      link: 'targets/a.targetdir/cycle1.link',
+      target: 'targets/a.targetdir',
+    );
     writeLink(
-        link: 'targets/a.targetdir/cycle2.link', target: 'targets/a.targetdir');
+      link: 'targets/a.targetdir/cycle2.link',
+      target: 'targets/a.targetdir',
+    );
     await startWatcher(path: 'watched');
 
     renameDir('links', 'watched/links');

--- a/pkgs/watcher/test/directory_watcher/macos_test.dart
+++ b/pkgs/watcher/test/directory_watcher/macos_test.dart
@@ -15,8 +15,8 @@ import 'file_tests.dart';
 import 'link_tests.dart';
 
 void main() {
-  watcherFactory =
-      (directory) => RecursiveDirectoryWatcher(directory, runInIsolate: false);
+  watcherFactory = (directory) =>
+      RecursiveDirectoryWatcher(directory, runInIsolate: false);
 
   fileTests(isNative: true);
   linkTests(isNative: true);
@@ -24,6 +24,8 @@ void main() {
 
   test('DirectoryWatcher creates a RecursiveDirectoryWatcher on Mac OS', () {
     expect(
-        DirectoryWatcher('.'), const TypeMatcher<RecursiveDirectoryWatcher>());
+      DirectoryWatcher('.'),
+      const TypeMatcher<RecursiveDirectoryWatcher>(),
+    );
   });
 }

--- a/pkgs/watcher/test/directory_watcher/polling/directory_list_test.dart
+++ b/pkgs/watcher/test/directory_watcher/polling/directory_list_test.dart
@@ -42,21 +42,14 @@ void main() {
     test('reports broken link as a link', () async {
       writeLink(link: '1', target: '0');
 
-      expect(await list(''), {
-        'l:1',
-      });
+      expect(await list(''), {'l:1'});
     });
 
     test('follows a link to a file', () async {
       writeFile('a/1');
       writeLink(link: 'b/1', target: 'a/1');
 
-      expect(await list(''), {
-        'd:a',
-        'd:b',
-        'f:a/1',
-        'f:b/1',
-      });
+      expect(await list(''), {'d:a', 'd:b', 'f:a/1', 'f:b/1'});
     });
 
     test('follows a link to a link of a file', () async {
@@ -64,36 +57,21 @@ void main() {
       writeLink(link: 'b/1', target: 'a/1');
       writeLink(link: 'c/1', target: 'b/1');
 
-      expect(await list(''), {
-        'd:a',
-        'd:b',
-        'd:c',
-        'f:a/1',
-        'f:b/1',
-        'f:c/1',
-      });
+      expect(await list(''), {'d:a', 'd:b', 'd:c', 'f:a/1', 'f:b/1', 'f:c/1'});
     });
 
     test('follows a link to a peer directory', () async {
       writeFile('a/1');
       writeLink(link: 'b', target: 'a');
 
-      expect(await list(''), {
-        'd:a',
-        'd:b',
-        'f:a/1',
-        'f:b/1',
-      });
+      expect(await list(''), {'d:a', 'd:b', 'f:a/1', 'f:b/1'});
     });
 
     test('ignores a link to a parent directory within the list root', () async {
       writeFile('a/1');
       writeLink(link: 'a/b', target: 'a');
 
-      expect(await list(''), {
-        'd:a',
-        'f:a/1',
-      });
+      expect(await list(''), {'d:a', 'f:a/1'});
     });
 
     test('correctly reports a two link loop', () async {
@@ -103,11 +81,7 @@ void main() {
       writeLink(link: 'b/a', target: 'a');
 
       // Listing from within the loop, all files are found once.
-      expect(await list('a'), {
-        'd:b',
-        'f:1',
-        'f:b/2',
-      });
+      expect(await list('a'), {'d:b', 'f:1', 'f:b/2'});
 
       // Listing from outside the loop each file is found twice, once via each
       // entrypoint into the loop.
@@ -133,13 +107,7 @@ void main() {
     writeLink(link: 'c/a', target: 'a');
 
     // Listing from within the loop, all files are found once.
-    expect(await list('a'), {
-      'd:b',
-      'd:b/c',
-      'f:1',
-      'f:b/2',
-      'f:b/c/3',
-    });
+    expect(await list('a'), {'d:b', 'd:b/c', 'f:1', 'f:b/2', 'f:b/c/3'});
 
     // Listing from outside the loop each file is found three times, once via
     // each entrypoint into the loop.
@@ -173,13 +141,7 @@ void main() {
 
     // Linking to above the list root finds `1`, which is above the list root,
     // but does not enter the root again. So each file is listed once.
-    expect(await list('a'), {
-      'd:b',
-      'd:b/c',
-      'f:2',
-      'f:b/3',
-      'f:b/c/1',
-    });
+    expect(await list('a'), {'d:b', 'd:b/c', 'f:2', 'f:b/3', 'f:b/c/1'});
   });
 
   test('correctly reports with double links to parent directories', () async {
@@ -216,8 +178,9 @@ Future<Set<String>> list(String directory) async {
     return path.substring(directory.length + 1).replaceAll('\\', '/');
   }
 
-  final fileSystemEntities =
-      await Directory(directory).listRecursively().toList();
+  final fileSystemEntities = await Directory(
+    directory,
+  ).listRecursively().toList();
   final result = <String>[];
   for (final entity in fileSystemEntities) {
     final path = normalizePath(entity.path);
@@ -239,8 +202,10 @@ Future<Set<String>> list(String directory) async {
   // If on Linux, run `find -L` and compare.
   if (Platform.isLinux) {
     Iterable<String> listForType(String type) {
-      final result = Process.runSync(
-          'bash', ['-c', 'find -L $directory -type $type -mindepth 1']);
+      final result = Process.runSync('bash', [
+        '-c',
+        'find -L $directory -type $type -mindepth 1',
+      ]);
       return (result.stdout as String).split('\n').where((l) => l.isNotEmpty);
     }
 

--- a/pkgs/watcher/test/directory_watcher/polling_test.dart
+++ b/pkgs/watcher/test/directory_watcher/polling_test.dart
@@ -15,8 +15,10 @@ import 'link_tests.dart';
 
 void main() {
   // Use a short delay to make the tests run quickly.
-  watcherFactory = (dir) => PollingDirectoryWatcher(dir,
-      pollingDelay: const Duration(milliseconds: 10));
+  watcherFactory = (dir) => PollingDirectoryWatcher(
+    dir,
+    pollingDelay: const Duration(milliseconds: 10),
+  );
 
   /// See [enableSleepUntilNewModificationTime] for a note about the "polling"
   /// tests.
@@ -41,8 +43,9 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 1));
     }
 
-    final events =
-        await takeEvents(duration: const Duration(milliseconds: 500));
+    final events = await takeEvents(
+      duration: const Duration(milliseconds: 500),
+    );
 
     // Events should be adds and removes that pair up, with no modify events.
     final adds = <String>{};

--- a/pkgs/watcher/test/directory_watcher/recursive/event_tree_test.dart
+++ b/pkgs/watcher/test/directory_watcher/recursive/event_tree_test.dart
@@ -37,7 +37,9 @@ void main() {
 
       expect(eventTree[PathSegment('a')]!.isSingleEvent, false);
       expect(
-          eventTree[PathSegment('a')]![PathSegment('b')]!.isSingleEvent, true);
+        eventTree[PathSegment('a')]![PathSegment('b')]!.isSingleEvent,
+        true,
+      );
     });
 
     test('adding event removes tree under it', () {

--- a/pkgs/watcher/test/directory_watcher/relative_directory_test.dart
+++ b/pkgs/watcher/test/directory_watcher/relative_directory_test.dart
@@ -29,8 +29,10 @@ void main() {
 
       for (final watcherFactory in [
         DirectoryWatcher.new,
-        (String path) => PollingDirectoryWatcher(path,
-            pollingDelay: const Duration(milliseconds: 1))
+        (String path) => PollingDirectoryWatcher(
+          path,
+          pollingDelay: const Duration(milliseconds: 1),
+        ),
       ]) {
         writeFile('dir/a.txt');
         writeFile('dir/b.txt');
@@ -49,16 +51,13 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 500));
         await subscription.cancel();
 
-        expect(
-            events.map((e) => e.toString()).toSet(),
-            {
-              'modify ${p.join('dir', 'a.txt')}',
-              'remove ${p.join('dir', 'b.txt')}',
-              'add ${p.join('dir', 'e.txt')}',
-              'remove ${p.join('dir', 'c.txt')}',
-              'add ${p.join('dir', 'd.txt')}',
-            },
-            reason: 'With watcher $watcher.');
+        expect(events.map((e) => e.toString()).toSet(), {
+          'modify ${p.join('dir', 'a.txt')}',
+          'remove ${p.join('dir', 'b.txt')}',
+          'add ${p.join('dir', 'e.txt')}',
+          'remove ${p.join('dir', 'c.txt')}',
+          'add ${p.join('dir', 'd.txt')}',
+        }, reason: 'With watcher $watcher.');
 
         deleteDir('dir');
       }

--- a/pkgs/watcher/test/directory_watcher/windows_isolate_test.dart
+++ b/pkgs/watcher/test/directory_watcher/windows_isolate_test.dart
@@ -27,8 +27,10 @@ void main() {
 
     setUp(() async {
       temp = Directory.systemTemp.createTempSync();
-      final watcher =
-          DirectoryWatcher(temp.path, runInIsolateOnWindows: runInIsolate);
+      final watcher = DirectoryWatcher(
+        temp.path,
+        runInIsolateOnWindows: runInIsolate,
+      );
       // To recover from an error "modify" is sent for files that still exist,
       // so any event on this file indicates a recovery.
       File('${temp.path}\\recovery.txt').writeAsStringSync('');
@@ -36,15 +38,13 @@ void main() {
       eventsSeen = 0;
       recoveriesSeen = 0;
       totalRecoveriesSeen = 0;
-      subscription = watcher.events.listen(
-        (e) {
-          if (e.path.contains('recovery.txt')) {
-            ++recoveriesSeen;
-          } else {
-            ++eventsSeen;
-          }
-        },
-      );
+      subscription = watcher.events.listen((e) {
+        if (e.path.contains('recovery.txt')) {
+          ++recoveriesSeen;
+        } else {
+          ++eventsSeen;
+        }
+      });
       await watcher.ready;
     });
 
@@ -53,67 +53,68 @@ void main() {
     });
 
     test(
-        runInIsolate
-            ? 'No buffer exhaustion if running in isolate'
-            : 'Recover from buffer exhaustion if not running in isolate',
-        () async {
-      // Use a long filename to fill the buffer.
-      final file = File('${temp.path}\\file'.padRight(255, 'a'));
+      runInIsolate
+          ? 'No buffer exhaustion if running in isolate'
+          : 'Recover from buffer exhaustion if not running in isolate',
+      () async {
+        // Use a long filename to fill the buffer.
+        final file = File('${temp.path}\\file'.padRight(255, 'a'));
 
-      // Repeatedly trigger buffer exhaustion, to check that recovery is
-      // reliable.
-      for (var times = 0; times != 200; ++times) {
-        recoveriesSeen = 0;
-        eventsSeen = 0;
+        // Repeatedly trigger buffer exhaustion, to check that recovery is
+        // reliable.
+        for (var times = 0; times != 200; ++times) {
+          recoveriesSeen = 0;
+          eventsSeen = 0;
 
-        // Syncronously trigger 200 events. Because this is a sync block, the VM
-        // won't handle the events, so this has a very high chance of triggering
-        // a buffer exhaustion.
-        //
-        // If a buffer exhaustion happens, `package:watcher` turns this into an
-        // error on the event stream, so `errorsSeen` will get incremented once.
-        // The number of changes 200 is chosen so this is very likely to happen.
-        // If there is _not_ an exhaustion, the 200 events will show on the
-        // stream as a single event because they are changes of the same file.
-        // So, `eventsSeen` will instead be incremented once.
-        for (var i = 0; i != 200; ++i) {
-          file.writeAsStringSync('');
-        }
-
-        // Events only happen when there is an async gap, wait for such a gap.
-        // The event usually arrives in under 10ms, try for 100ms.
-        var tries = 0;
-        while (recoveriesSeen == 0 && eventsSeen == 0 && tries < 10) {
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-          ++tries;
-        }
-
-        totalRecoveriesSeen += recoveriesSeen;
-
-        // If everything is going well, there should have been either one event
-        // seen or one error seen.
-        if (recoveriesSeen == 0 && eventsSeen == 0) {
-          // It looks like the watcher is now broken: there were file changes
-          // but no event and no error. Do some non-sync writes to confirm
-          // whether the watcher really is now broken.
-          for (var i = 0; i != 5; ++i) {
-            await file.writeAsString('');
+          // Syncronously trigger 200 events. Because this is a sync block, the
+          // VM won't handle the events, so this has a very high chance of
+          // triggering a buffer exhaustion.
+          //
+          // If a buffer exhaustion happens, `package:watcher` turns this into
+          // an error on the event stream, so `errorsSeen` will get incremented
+          // once. The number of changes 200 is chosen so this is very likely to
+          // happen. If there is _not_ an exhaustion, the 200 events will show
+          // on the stream as a single event because they are changes of the
+          // same file. So, `eventsSeen` will instead be incremented once.
+          for (var i = 0; i != 200; ++i) {
+            file.writeAsStringSync('');
           }
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-          fail(
-            'On attempt ${times + 1}, watcher registered nothing. '
-            'On retry, it registered: $recoveriesSeen recoveries, $eventsSeen '
-            'event(s).',
-          );
-        }
-      }
 
-      // Buffer exhaustion is likely without the isolate but not guaranteed.
-      if (runInIsolate) {
-        expect(totalRecoveriesSeen, 0);
-      } else {
-        expect(totalRecoveriesSeen, greaterThan(150));
-      }
-    });
+          // Events only happen when there is an async gap, wait for such a gap.
+          // The event usually arrives in under 10ms, try for 100ms.
+          var tries = 0;
+          while (recoveriesSeen == 0 && eventsSeen == 0 && tries < 10) {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            ++tries;
+          }
+
+          totalRecoveriesSeen += recoveriesSeen;
+
+          // If everything is going well, there should have been either one
+          // event seen or one error seen.
+          if (recoveriesSeen == 0 && eventsSeen == 0) {
+            // It looks like the watcher is now broken: there were file changes
+            // but no event and no error. Do some non-sync writes to confirm
+            // whether the watcher really is now broken.
+            for (var i = 0; i != 5; ++i) {
+              await file.writeAsString('');
+            }
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            fail(
+              'On attempt ${times + 1}, watcher registered nothing. '
+              'On retry, it registered: $recoveriesSeen recoveries, '
+              '$eventsSeen event(s).',
+            );
+          }
+        }
+
+        // Buffer exhaustion is likely without the isolate but not guaranteed.
+        if (runInIsolate) {
+          expect(totalRecoveriesSeen, 0);
+        } else {
+          expect(totalRecoveriesSeen, greaterThan(150));
+        }
+      },
+    );
   }
 }

--- a/pkgs/watcher/test/directory_watcher/windows_test.dart
+++ b/pkgs/watcher/test/directory_watcher/windows_test.dart
@@ -16,8 +16,8 @@ import 'file_tests.dart';
 import 'link_tests.dart';
 
 void main() {
-  watcherFactory =
-      (directory) => RecursiveDirectoryWatcher(directory, runInIsolate: true);
+  watcherFactory = (directory) =>
+      RecursiveDirectoryWatcher(directory, runInIsolate: true);
 
   fileTests(isNative: true);
   linkTests(isNative: true);
@@ -25,6 +25,8 @@ void main() {
 
   test('DirectoryWatcher creates a RecursiveDirectoryWatcher on Windows', () {
     expect(
-        DirectoryWatcher('.'), const TypeMatcher<RecursiveDirectoryWatcher>());
+      DirectoryWatcher('.'),
+      const TypeMatcher<RecursiveDirectoryWatcher>(),
+    );
   });
 }

--- a/pkgs/watcher/test/file_watcher/file_tests.dart
+++ b/pkgs/watcher/test/file_watcher/file_tests.dart
@@ -57,8 +57,7 @@ void _fileTests({required bool isNative}) {
     await expectRemoveEvent('file.txt');
   });
 
-  test(
-      'emits a modify event when another file is moved on top of the watched '
+  test('emits a modify event when another file is moved on top of the watched '
       'file', () async {
     writeFile('old.txt', contents: 'different');
     await startWatcher(path: 'file.txt');

--- a/pkgs/watcher/test/no_subscription/macos_test.dart
+++ b/pkgs/watcher/test/no_subscription/macos_test.dart
@@ -12,8 +12,8 @@ import '../utils.dart';
 import 'shared.dart';
 
 void main() {
-  watcherFactory =
-      (directory) => RecursiveDirectoryWatcher(directory, runInIsolate: false);
+  watcherFactory = (directory) =>
+      RecursiveDirectoryWatcher(directory, runInIsolate: false);
 
   sharedTests();
 }

--- a/pkgs/watcher/test/no_subscription/shared.dart
+++ b/pkgs/watcher/test/no_subscription/shared.dart
@@ -19,8 +19,10 @@ void sharedTests() {
     var queue = StreamQueue(watcher.events);
     unawaited(queue.hasNext);
 
-    var future =
-        expectLater(queue, emits(isWatchEvent(ChangeType.ADD, 'file.txt')));
+    var future = expectLater(
+      queue,
+      emits(isWatchEvent(ChangeType.ADD, 'file.txt')),
+    );
     expect(queue, neverEmits(anything));
 
     await watcher.ready;
@@ -36,8 +38,10 @@ void sharedTests() {
     writeFile('unwatched.txt');
 
     queue = StreamQueue(watcher.events);
-    future =
-        expectLater(queue, emits(isWatchEvent(ChangeType.ADD, 'added.txt')));
+    future = expectLater(
+      queue,
+      emits(isWatchEvent(ChangeType.ADD, 'added.txt')),
+    );
     expect(queue, neverEmits(isWatchEvent(ChangeType.ADD, 'unwatched.txt')));
 
     // Wait until the watcher is ready to dispatch events again.

--- a/pkgs/watcher/test/no_subscription/windows_test.dart
+++ b/pkgs/watcher/test/no_subscription/windows_test.dart
@@ -12,8 +12,8 @@ import '../utils.dart';
 import 'shared.dart';
 
 void main() {
-  watcherFactory =
-      (directory) => RecursiveDirectoryWatcher(directory, runInIsolate: true);
+  watcherFactory = (directory) =>
+      RecursiveDirectoryWatcher(directory, runInIsolate: true);
 
   sharedTests();
 }

--- a/pkgs/watcher/test/paths_test.dart
+++ b/pkgs/watcher/test/paths_test.dart
@@ -13,23 +13,29 @@ void main() {
   group('AbsolutePath', () {
     test('tryRelativeTo extracts path segment', () {
       expect(
-          AbsolutePath('a${separator}b${separator}c')
-              .tryRelativeTo(AbsolutePath('a${separator}b')),
-          'c');
+        AbsolutePath(
+          'a${separator}b${separator}c',
+        ).tryRelativeTo(AbsolutePath('a${separator}b')),
+        'c',
+      );
     });
 
     test('tryRelativeTo extracts many path segments', () {
       expect(
-          AbsolutePath('a${separator}b${separator}c${separator}d')
-              .tryRelativeTo(AbsolutePath('a${separator}b')),
-          'c${separator}d');
+        AbsolutePath(
+          'a${separator}b${separator}c${separator}d',
+        ).tryRelativeTo(AbsolutePath('a${separator}b')),
+        'c${separator}d',
+      );
     });
 
     test('tryRelativeTo checks for final separator', () {
       expect(
-          AbsolutePath('a${separator}bbc')
-              .tryRelativeTo(AbsolutePath('a${separator}b')),
-          null);
+        AbsolutePath(
+          'a${separator}bbc',
+        ).tryRelativeTo(AbsolutePath('a${separator}b')),
+        null,
+      );
     });
   });
 }

--- a/pkgs/watcher/test/ready/macos_test.dart
+++ b/pkgs/watcher/test/ready/macos_test.dart
@@ -12,8 +12,8 @@ import '../utils.dart';
 import 'shared.dart';
 
 void main() {
-  watcherFactory =
-      (directory) => RecursiveDirectoryWatcher(directory, runInIsolate: false);
+  watcherFactory = (directory) =>
+      RecursiveDirectoryWatcher(directory, runInIsolate: false);
 
   sharedTests();
 }

--- a/pkgs/watcher/test/ready/shared.dart
+++ b/pkgs/watcher/test/ready/shared.dart
@@ -13,9 +13,11 @@ void sharedTests() {
     var watcher = createWatcher();
 
     var ready = false;
-    unawaited(watcher.ready.then((_) {
-      ready = true;
-    }));
+    unawaited(
+      watcher.ready.then((_) {
+        ready = true;
+      }),
+    );
     await pumpEventQueue();
 
     expect(ready, isFalse);
@@ -52,22 +54,24 @@ void sharedTests() {
     await subscription.cancel();
   });
 
-  test('ready returns a future that does not complete after unsubscribing',
-      () async {
-    var watcher = createWatcher();
+  test(
+    'ready returns a future that does not complete after unsubscribing',
+    () async {
+      var watcher = createWatcher();
 
-    // Subscribe to the events.
-    var subscription = watcher.events.listen((event) {});
+      // Subscribe to the events.
+      var subscription = watcher.events.listen((event) {});
 
-    // Wait until ready.
-    await watcher.ready;
+      // Wait until ready.
+      await watcher.ready;
 
-    // Now unsubscribe.
-    await subscription.cancel();
+      // Now unsubscribe.
+      await subscription.cancel();
 
-    // Should be back to not ready.
-    expect(watcher.ready, doesNotComplete);
-  });
+      // Should be back to not ready.
+      expect(watcher.ready, doesNotComplete);
+    },
+  );
 
   test('ready completes even if directory does not exist', () async {
     var watcher = createWatcher(path: 'does/not/exist');

--- a/pkgs/watcher/test/ready/windows_test.dart
+++ b/pkgs/watcher/test/ready/windows_test.dart
@@ -12,8 +12,8 @@ import '../utils.dart';
 import 'shared.dart';
 
 void main() {
-  watcherFactory =
-      (directory) => RecursiveDirectoryWatcher(directory, runInIsolate: true);
+  watcherFactory = (directory) =>
+      RecursiveDirectoryWatcher(directory, runInIsolate: true);
 
   sharedTests();
 }

--- a/pkgs/watcher/test/utils.dart
+++ b/pkgs/watcher/test/utils.dart
@@ -74,8 +74,9 @@ var _hasClosedStream = true;
 /// than other platforms, at 1s.
 void enableSleepUntilNewModificationTime() {
   if (_waitForModificationTimesDirectory != null) return;
-  _waitForModificationTimesDirectory =
-      Directory.systemTemp.createTempSync('dart_test_');
+  _waitForModificationTimesDirectory = Directory.systemTemp.createTempSync(
+    'dart_test_',
+  );
   addTearDown(() {
     _waitForModificationTimesDirectory!.deleteSync(recursive: true);
     _waitForModificationTimesDirectory = null;
@@ -292,16 +293,20 @@ void writeLink({
 /// Deletes a file in the sandbox at [path].
 void deleteFile(String path) {
   final fullPath = p.join(d.sandbox, path);
-  expect(FileSystemEntity.typeSync(fullPath, followLinks: false),
-      FileSystemEntityType.file);
+  expect(
+    FileSystemEntity.typeSync(fullPath, followLinks: false),
+    FileSystemEntityType.file,
+  );
   File(fullPath).deleteSync();
 }
 
 /// Deletes a link in the sandbox at [path].
 void deleteLink(String path) {
   final fullPath = p.join(d.sandbox, path);
-  expect(FileSystemEntity.typeSync(fullPath, followLinks: false),
-      FileSystemEntityType.link);
+  expect(
+    FileSystemEntity.typeSync(fullPath, followLinks: false),
+    FileSystemEntityType.link,
+  );
   Link(fullPath).deleteSync();
 }
 
@@ -309,8 +314,10 @@ void deleteLink(String path) {
 void renameFile(String from, String to) {
   var absoluteTo = p.join(d.sandbox, to);
   File(p.join(d.sandbox, from)).renameSync(absoluteTo);
-  expect(FileSystemEntity.typeSync(absoluteTo, followLinks: false),
-      FileSystemEntityType.file);
+  expect(
+    FileSystemEntity.typeSync(absoluteTo, followLinks: false),
+    FileSystemEntityType.file,
+  );
 }
 
 /// Renames a link in the sandbox from [from] to [to].
@@ -320,8 +327,10 @@ void renameFile(String from, String to) {
 void renameLink(String from, String to) {
   var absoluteTo = p.join(d.sandbox, to);
   Link(p.join(d.sandbox, from)).renameSync(absoluteTo);
-  expect(FileSystemEntity.typeSync(absoluteTo, followLinks: false),
-      FileSystemEntityType.link);
+  expect(
+    FileSystemEntity.typeSync(absoluteTo, followLinks: false),
+    FileSystemEntityType.link,
+  );
 }
 
 /// Creates a directory in the sandbox at [path].
@@ -334,16 +343,21 @@ void renameDir(String from, String to) {
   var absoluteTo = p.join(d.sandbox, to);
   // Fails sometimes on Windows, so guard+retry.
   retryForPathAccessException(
-      () => Directory(p.join(d.sandbox, from)).renameSync(absoluteTo));
-  expect(FileSystemEntity.typeSync(absoluteTo, followLinks: false),
-      FileSystemEntityType.directory);
+    () => Directory(p.join(d.sandbox, from)).renameSync(absoluteTo),
+  );
+  expect(
+    FileSystemEntity.typeSync(absoluteTo, followLinks: false),
+    FileSystemEntityType.directory,
+  );
 }
 
 /// Deletes a directory in the sandbox at [path].
 void deleteDir(String path) {
   final fullPath = p.join(d.sandbox, path);
-  expect(FileSystemEntity.typeSync(fullPath, followLinks: false),
-      FileSystemEntityType.directory);
+  expect(
+    FileSystemEntity.typeSync(fullPath, followLinks: false),
+    FileSystemEntityType.directory,
+  );
   Directory(fullPath).deleteSync(recursive: true);
 }
 


### PR DESCRIPTION
Checking in on some recent test flakiness, a lot of them are on SDK 3.4, which is not particularly interesting to investigate/support.

Bumping to 3.8 seems to help, and it gets the code past the big reformat, so this seems worth merging.