### PR TITLE
Remove deprecated Chrome flag --disable-blink-features=TimerThrottlin…

### DIFF
--- a/pkgs/browser_launcher/lib/src/chrome.dart
+++ b/pkgs/browser_launcher/lib/src/chrome.dart
@@ -102,7 +102,6 @@ class Chrome {
       '--remote-debugging-port=$port',
       // When the DevTools has focus we don't want to slow down the application.
       '--disable-background-timer-throttling',
-      '--disable-blink-features=TimerThrottlingForBackgroundTabs',
       '--disable-features=IntensiveWakeUpThrottling',
       // Since we are using a temp profile, disable features that slow the
       // Chrome launch.


### PR DESCRIPTION
Remove the deprecated Chrome argument `--disable-blink-features=TimerThrottlingForBackgroundTabs`, which is no longer supported by recent Chrome versions. This avoids passing invalid flags and keeps the launch configuration aligned with current Chromium behavior.

- [ ✅] I’ve reviewed the contributor guide and applied the relevant portions to this PR.


