### PR TITLE
Prevent `YamlEditor.update` from affecting block scalars

### DIFF
--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -134,7 +134,7 @@ SourceEdit _appendToBlockList(
 }
 
 /// Formats [item] into a new node for block lists.
-(int indentSize, String valueStringToIndent) _formatNewBlock(
+({int entryIndent, String lineEnding, String formattedEntry}) _formatNewBlock(
     YamlEditor yamlEdit, YamlList list, YamlNode item) {
   final yaml = yamlEdit.toString();
   final listIndentation = getListIndentation(yaml, list);
@@ -146,7 +146,11 @@ SourceEdit _appendToBlockList(
     valueString = valueString.substring(newIndentation);
   }
 
-  return (listIndentation, '- $valueString$lineEnding');
+  return (
+    entryIndent: listIndentation,
+    lineEnding: lineEnding,
+    formattedEntry: '- $valueString$lineEnding'
+  );
 }
 
 /// Formats [item] into a new node for flow lists.
@@ -174,7 +178,11 @@ SourceEdit _insertInBlockList(
 
   if (index == list.length) return _appendToBlockList(yamlEdit, list, item);
 
-  var (indentSize, formattedValue) = _formatNewBlock(yamlEdit, list, item);
+  var (:entryIndent, :formattedEntry, lineEnding: _) = _formatNewBlock(
+    yamlEdit,
+    list,
+    item,
+  );
 
   final currNode = list.nodes[index];
   final currNodeStart = currNode.span.start.offset;
@@ -206,16 +214,16 @@ SourceEdit _insertInBlockList(
     final leftPad = currSequenceOffset - offset;
     final padding = ' ' * leftPad;
 
-    final indent = ' ' * (indentSize - leftPad);
+    final indent = ' ' * (entryIndent - leftPad);
 
     // Give the indent to the first element
-    formattedValue = '$padding${formattedValue.trimLeft()}$indent';
+    formattedEntry = '$padding${formattedEntry.trimLeft()}$indent';
   } else {
-    final indent = ' ' * indentSize; // Calculate indent normally
-    formattedValue = '$indent$formattedValue';
+    final indent = ' ' * entryIndent; // Calculate indent normally
+    formattedEntry = '$indent$formattedEntry';
   }
 
-  return SourceEdit(offset, 0, formattedValue);
+  return SourceEdit(offset, 0, formattedEntry);
 }
 
 /// Determines if the list containing an element is nested within another list.

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -20,43 +20,61 @@ SourceEdit updateInList(
   RangeError.checkValueInInterval(index, 0, list.length - 1);
 
   final currValue = list.nodes[index];
-  var offset = currValue.span.start.offset;
+  var start = currValue.span.start.offset;
   final yaml = yamlEdit.toString();
-  String valueString;
+
+  if (list.style != CollectionStyle.BLOCK) {
+    return SourceEdit(start, currValue.span.length, yamlEncodeFlow(newValue));
+  }
+
+  final listIndentation = getListIndentation(yaml, list);
+  final indentation = listIndentation + getIndentation(yamlEdit);
+  final lineEnding = getLineEnding(yaml);
 
   /// We do not use [_formatNewBlock] since we want to only replace the contents
   /// of this node while preserving comments/whitespace, while [_formatNewBlock]
   /// produces a string representation of a new node.
-  if (list.style == CollectionStyle.BLOCK) {
-    final listIndentation = getListIndentation(yaml, list);
-    final indentation = listIndentation + getIndentation(yamlEdit);
-    final lineEnding = getLineEnding(yaml);
-    valueString =
-        yamlEncodeBlock(wrapAsYamlNode(newValue), indentation, lineEnding);
+  var formattedValue =
+      yamlEncodeBlock(wrapAsYamlNode(newValue), indentation, lineEnding);
 
-    /// We prefer the compact nested notation for collections.
-    ///
-    /// By virtue of [yamlEncodeBlockString], collections automatically
-    /// have the necessary line endings.
-    if ((newValue is List && (newValue as List).isNotEmpty) ||
-        (newValue is Map && (newValue as Map).isNotEmpty)) {
-      valueString = valueString.substring(indentation);
-    } else if (currValue.collectionStyle == CollectionStyle.BLOCK) {
-      valueString += lineEnding;
-    }
-
-    var end = getContentSensitiveEnd(currValue);
-    if (end <= offset) {
-      offset++;
-      end = offset;
-      valueString = ' $valueString';
-    }
-
-    return SourceEdit(offset, end - offset, valueString);
-  } else {
-    valueString = yamlEncodeFlow(newValue);
-    return SourceEdit(offset, currValue.span.length, valueString);
+  /// We prefer the compact nested notation for collections.
+  ///
+  /// By virtue of [yamlEncodeBlockString], collections automatically
+  /// have the necessary line endings.
+  if ((newValue is List && (newValue as List).isNotEmpty) ||
+      (newValue is Map && (newValue as Map).isNotEmpty)) {
+    formattedValue = formattedValue.substring(indentation);
+  } else if (currValue.collectionStyle == CollectionStyle.BLOCK &&
+      !formattedValue.endsWith('\n')) {
+    formattedValue += lineEnding;
   }
+
+  var end = getContentSensitiveEnd(currValue);
+
+  // `package:yaml` quirk when the value is empty.
+  if (end <= start) {
+    start++;
+    end = start;
+    formattedValue = ' $formattedValue';
+  }
+
+  end = indexOfLastLineEnding(
+    yaml,
+    offset: yaml.indexOf('\n', end),
+    blockIndent: listIndentation,
+  );
+
+  // Consume the line ending to prevent any dangling line breaks. Update
+  // replaces the existing value when sandwiched or trailing. We may need to
+  // preserve the line ending whenever possible.
+  if (formattedValue.endsWith('\n') ||
+      (end >= yaml.length - 1 && !yaml.endsWith('\n'))) {
+    end = min(yaml.length, ++end);
+  } else if (lineEnding == '\r\n') {
+    --end;
+  }
+
+  return SourceEdit(start, end - start, formattedValue);
 }
 
 /// Returns a [SourceEdit] describing the change to be made on [yamlEdit] to

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -121,8 +121,9 @@ SourceEdit _appendToBlockList(
   // It's just a flow list if it's empty.
   assert(list.isNotEmpty, 'Expected a non-empty block list');
 
-  final entry = _formatNewBlock(yamlEdit, list, item);
-  var formattedValue = '${' ' * entry.entryIndent}${entry.formattedEntry}';
+  var (:entryIndent, :formattedEntry, :lineEnding) =
+      _formatNewBlock(yamlEdit, list, item);
+  formattedEntry = '${' ' * entryIndent}$formattedEntry';
 
   final yaml = yamlEdit.toString();
   final maxLength = yaml.length;
@@ -130,15 +131,15 @@ SourceEdit _appendToBlockList(
   var endOffset = indexOfLastLineEnding(
     yaml,
     offset: yaml.indexOf('\n', list.nodes.last.span.end.offset - 1),
-    blockIndent: entry.entryIndent, // Equal to the list's indent.
+    blockIndent: entryIndent, // Equal to the list's indent.
   );
 
   if (endOffset >= (maxLength - 1) && !yaml.endsWith('\n')) {
-    formattedValue = entry.lineEnding + formattedValue;
+    formattedEntry = lineEnding + formattedEntry;
   }
 
   endOffset = min(maxLength, endOffset + 1);
-  return SourceEdit(endOffset, 0, formattedValue);
+  return SourceEdit(endOffset, 0, formattedEntry);
 }
 
 /// Formats [item] into a new node for block lists.

--- a/pkgs/yaml_edit/test/append_test.dart
+++ b/pkgs/yaml_edit/test/append_test.dart
@@ -218,7 +218,7 @@ b:
 '''));
     });
 
-    test('block append nested and with comments', () {
+    test('block append nested and with comments (1)', () {
       final yamlEditor = YamlEditor('''
 a:
   b:
@@ -241,6 +241,46 @@ a:
                 'g': {'e': 3, 'f': 4}
               }),
           returnsNormally);
+    });
+
+    test('block append with a single trailing comment (no EOF)', () {
+      final yamlEditor = YamlEditor('- value # comment')
+        ..appendToList([], 'next');
+
+      expect(yamlEditor.toString(), equals('''
+- value # comment
+- next
+'''));
+    });
+
+    test('block append with multiple trailing comments', () {
+      final yamlEditor = YamlEditor('''
+- value # comment
+        # comment
+''')
+        ..appendToList([], 'next');
+
+      expect(yamlEditor.toString(), equals('''
+- value # comment
+        # comment
+- next
+'''));
+    });
+
+    test('block append nested with multiple comments', () {
+      final yamlEditor = YamlEditor('''
+- - value # comment
+      # comment
+        # comment
+''')
+        ..appendToList([0], 'next');
+
+      expect(yamlEditor.toString(), equals('''
+- - value # comment
+      # comment
+        # comment
+  - next
+'''));
     });
   });
 

--- a/pkgs/yaml_edit/test/append_test.dart
+++ b/pkgs/yaml_edit/test/append_test.dart
@@ -257,8 +257,7 @@ a:
       final yamlEditor = YamlEditor('''
 - value # comment
         # comment
-''')
-        ..appendToList([], 'next');
+''')..appendToList([], 'next');
 
       expect(yamlEditor.toString(), equals('''
 - value # comment
@@ -272,8 +271,7 @@ a:
 - - value # comment
       # comment
         # comment
-''')
-        ..appendToList([0], 'next');
+''')..appendToList([0], 'next');
 
       expect(yamlEditor.toString(), equals('''
 - - value # comment


### PR DESCRIPTION
Draft fix for `YamlEditor.update`. Follow up for #2240 lessens work for #1944.

- Prevents inline updates from affecting block scalars in both maps and lists.

Will contain final decision from #2316 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
