### PR TITLE
fix: autolink extension double-encoding of percent-escaped URLs

### DIFF
--- a/pkgs/markdown/lib/src/inline_syntaxes/autolink_extension_syntax.dart
+++ b/pkgs/markdown/lib/src/inline_syntaxes/autolink_extension_syntax.dart
@@ -89,10 +89,10 @@ class AutolinkExtensionSyntax extends InlineSyntax {
       consumeLength = _getConsumeLength(match.match);
     }
 
-    var text = match.match.substring(0, consumeLength);
-    text = parser.encodeHtml ? escapeHtml(text) : text;
+    final rawText = match.match.substring(0, consumeLength);
+    final text = parser.encodeHtml ? escapeHtml(rawText) : rawText;
 
-    var destination = text;
+    var destination = rawText;
     if (isEmailLink) {
       destination = 'mailto:$destination';
     } else if (destination[0] == 'w') {
@@ -100,8 +100,12 @@ class AutolinkExtensionSyntax extends InlineSyntax {
       destination = 'http://$destination';
     }
 
+    final normalizedDestination = normalizeLinkDestination(destination);
+
     final anchor = Element.text('a', text)
-      ..attributes['href'] = Uri.encodeFull(destination);
+      ..attributes['href'] = parser.encodeHtml
+          ? escapeHtml(normalizedDestination)
+          : normalizedDestination;
 
     parser
       ..addNode(anchor)

--- a/pkgs/markdown/test/regression_test.dart
+++ b/pkgs/markdown/test/regression_test.dart
@@ -53,4 +53,16 @@ a <!--
     final html = markdownToHtml(input);
     expect(html, '<p>$input</p>\n');
   });
+
+  test('autolink extension keeps existing percent escapes', () {
+    const input = 'https://uploads.swee.codes/swee/Djjaner%20-%20Hyperscan.opus';
+    final html = markdownToHtml(
+      input,
+      extensionSet: ExtensionSet.gitHubFlavored,
+    );
+    expect(
+      html,
+      '<p><a href="https://uploads.swee.codes/swee/Djjaner%20-%20Hyperscan.opus">$input</a></p>\n',
+    );
+  });
 }


### PR DESCRIPTION
fixes #2169

## Summary
This fixes a bug where autolinked URLs containing existing percent escapes (for example %20) were encoded again in href, producing %2520 and breaking links.

## Root cause
AutolinkExtensionSyntax used Uri.encodeFull(...) directly when setting href.
That path re-encoded % from already-escaped URL segments.

## Changes
In AutolinkExtensionSyntax, switched href generation to normalizeLinkDestination(...).
Preserve display text behavior (encodeHtml still applies to rendered text as before).
Added regression test:
autolink extension keeps existing percent escapes
Verifies %20 remains %20 in generated href (not %2520).
