### PR TITLE
[test_reflective_loader] Don't add setUp/tearDown if not defined, and provide correct locations

### DIFF
--- a/pkgs/test_reflective_loader/lib/test_reflective_loader.dart
+++ b/pkgs/test_reflective_loader/lib/test_reflective_loader.dart
@@ -208,8 +208,8 @@ bool _hasFailingTestAnnotation(MethodMirror method) =>
 bool _hasSkippedTestAnnotation(MethodMirror method) =>
     _hasAnnotationInstance(method, skippedTest);
 
-/// Returns the result of invoking [symbol] on [objectMirror] if it is a
-/// closure.
+/// Invokes [symbol] on [objectMirror] if it is a closure and returns the
+/// result.
 Future<Object?> _invokeSymbolIfExists(
     ObjectMirror objectMirror, Symbol symbol) {
   Object? invocationResult;
@@ -218,7 +218,7 @@ Future<Object?> _invokeSymbolIfExists(
   return Future.value(invocationResult);
 }
 
-/// Returns [symbol] from [objectMirror] if it is a closure.
+/// Gets [symbol] from [objectMirror] if it is a closure.
 ClosureMirror? _getClosureMember(ObjectMirror objectMirror, Symbol symbol) {
   try {
     var member = objectMirror.getField(symbol);

--- a/pkgs/test_reflective_loader/lib/test_reflective_loader.dart
+++ b/pkgs/test_reflective_loader/lib/test_reflective_loader.dart
@@ -146,10 +146,20 @@ void _addTestsIfTopLevelSuite() {
               solo: group.solo,
               () {
                 // If this group is a class, it may have class-wide
-                // setUp/tearDown.
-                if (group.classMirror != null) {
-                  test_package.setUpAll(group.ensureSetUpClass);
-                  test_package.tearDownAll(group.tearDownClass);
+                // setUp/tearDown. Only add the methods if they exist so that
+                // they don't show in the results/IDE if not.
+                if (group.classMirror case var classMirror?) {
+                  var setUp = _getClosureMember(classMirror, #setUpClass);
+                  if (setUp != null) {
+                    test_package.setUpAll(group.ensureSetUpClass,
+                        location: setUp.function.testLocation);
+                  }
+
+                  var tearDown = _getClosureMember(classMirror, #tearDownClass);
+                  if (tearDown != null) {
+                    test_package.tearDownAll(group.tearDownClass,
+                        location: tearDown.function.testLocation);
+                  }
                 }
                 addGroupsAndTests(group.children);
               },
@@ -198,21 +208,27 @@ bool _hasFailingTestAnnotation(MethodMirror method) =>
 bool _hasSkippedTestAnnotation(MethodMirror method) =>
     _hasAnnotationInstance(method, skippedTest);
 
+/// Returns the result of invoking [symbol] on [objectMirror] if it is a
+/// closure.
 Future<Object?> _invokeSymbolIfExists(
     ObjectMirror objectMirror, Symbol symbol) {
   Object? invocationResult;
-  InstanceMirror? closure;
+  var closure = _getClosureMember(objectMirror, symbol);
+  invocationResult = closure?.apply([]).reflectee;
+  return Future.value(invocationResult);
+}
+
+/// Returns [symbol] from [objectMirror] if it is a closure.
+ClosureMirror? _getClosureMember(ObjectMirror objectMirror, Symbol symbol) {
   try {
-    closure = objectMirror.getField(symbol);
+    var member = objectMirror.getField(symbol);
+    return member is ClosureMirror ? member : null;
     // ignore: avoid_catching_errors
   } on NoSuchMethodError {
     // ignore: empty_catches
   }
 
-  if (closure is ClosureMirror) {
-    invocationResult = closure.apply([]).reflectee;
-  }
-  return Future.value(invocationResult);
+  return null;
 }
 
 /// Adds a group to the current stack and executes [define] for child group

--- a/pkgs/test_reflective_loader/test/location_test.dart
+++ b/pkgs/test_reflective_loader/test/location_test.dart
@@ -21,7 +21,7 @@ void main() {
         testPackagePath, '..', 'test', 'test_reflective_loader_test.dart'));
     var testFileContent = File(testFilePath).readAsLinesSync();
 
-    var (:stdout, :stderr) = await runTestFile(testFilePath, ['-r', 'json']);
+    var (:stdout, :stderr) = await runTestFile(testFilePath, reporter: 'json');
 
     expect(stderr, isEmpty);
     expect(stdout, isNotEmpty);

--- a/pkgs/test_reflective_loader/test/location_test.dart
+++ b/pkgs/test_reflective_loader/test/location_test.dart
@@ -9,6 +9,8 @@ import 'dart:isolate';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 void main() {
   test("reports correct locations in the JSON output from 'dart test'",
       () async {
@@ -18,16 +20,13 @@ void main() {
     var testFilePath = path.normalize(path.join(
         testPackagePath, '..', 'test', 'test_reflective_loader_test.dart'));
     var testFileContent = File(testFilePath).readAsLinesSync();
-    var result = await Process.run(
-        Platform.resolvedExecutable, ['test', '-r', 'json', testFilePath]);
 
-    var error = result.stderr.toString().trim();
-    var output = result.stdout.toString().trim();
+    var (:stdout, :stderr) = await runTestFile(testFilePath, ['-r', 'json']);
 
-    expect(error, isEmpty);
-    expect(output, isNotEmpty);
+    expect(stderr, isEmpty);
+    expect(stdout, isNotEmpty);
 
-    for (var event in LineSplitter.split(output).map(jsonDecode)) {
+    for (var event in LineSplitter.split(stdout).map(jsonDecode)) {
       if (event case {'type': 'testStart', 'test': Map<String, Object?> test}) {
         var name = test['name'] as String;
 
@@ -40,9 +39,14 @@ void main() {
         // the source code to ensure the locations match up.
         name = name.split(' ').last.trim();
 
-        // Skip "tearDownAll" or "setUpAll", it never has a location.
-        if (name case '(tearDownAll)' || '(setUpAll)') {
-          continue;
+        // The test names "(setUpAll)" and "(tearDownAll)" can be calls to
+        // setUpAll() and tearDownAll() or methods named "setUpClass" and
+        // "tearDownClass" so just expect to find "setUp" or "tearDown" on lines
+        // at the provided locations.
+        if (name == '(setUpAll)') {
+          name = 'setUp';
+        } else if (name == '(tearDownAll)') {
+          name = 'tearDown';
         }
 
         // Expect locations for all remaining fields.

--- a/pkgs/test_reflective_loader/test/set_up_tear_down_test.dart
+++ b/pkgs/test_reflective_loader/test/set_up_tear_down_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 void main() {
-  test('builds the correct hierarchy of group names / test names', () async {
+  test('includes setUp and tearDown results only when defined', () async {
     var (:stdout, :stderr) =
         await runTestFile('set_up_tear_down_test.data.dart');
 

--- a/pkgs/test_reflective_loader/test/set_up_tear_down_test.dart
+++ b/pkgs/test_reflective_loader/test/set_up_tear_down_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -8,15 +8,17 @@ import 'utils.dart';
 
 void main() {
   test('builds the correct hierarchy of group names / test names', () async {
-    var (:stdout, :stderr) = await runTestFile('hierarchy_test.data.dart');
+    var (:stdout, :stderr) =
+        await runTestFile('set_up_tear_down_test.data.dart');
 
     expect(stderr, isEmpty);
     expect(
         stdout,
         allOf([
-          contains('SimpleTest test_foo'),
-          contains('level_1.1 level_2.1 SimpleTest test_foo'),
-          contains('level_1.1 level_2.2 SimpleTest test_foo'),
+          contains('WithSetUpTearDownTest (setUpAll)'),
+          contains('WithSetUpTearDownTest test_pass'),
+          contains('WithSetUpTearDownTest (tearDownAll)'),
+          contains('NoSetUpTearDownTest test_pass'),
           contains('All tests passed!'),
         ]));
   });

--- a/pkgs/test_reflective_loader/test/set_up_tear_down_test.data.dart
+++ b/pkgs/test_reflective_loader/test/set_up_tear_down_test.data.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: non_constant_identifier_names
+
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+/// This file is not intended to be run directly, but is run by
+/// `set_up_tear_down_test.dart`.
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(WithSetUpTearDownTest);
+    defineReflectiveTests(NoSetUpTearDownTest);
+  });
+}
+
+@reflectiveTest
+class NoSetUpTearDownTest {
+  void test_pass() {
+    expect(1, 1);
+  }
+}
+
+@reflectiveTest
+class WithSetUpTearDownTest {
+  static void setUpClass() {}
+  static void tearDownClass() {}
+
+  void test_pass() {
+    expect(1, 1);
+  }
+}

--- a/pkgs/test_reflective_loader/test/test_reflective_loader_test.dart
+++ b/pkgs/test_reflective_loader/test/test_reflective_loader_test.dart
@@ -35,20 +35,12 @@ class TestReflectiveLoaderTest {
   static bool didSetUpClass = false;
   static bool didTearDownClass = false;
 
-  // TODO(scheglov): Linter was updated to automatically ignore
-  // this but needs time before it is actually used. Remove this
-  // ignore and others like it in this file once the linter
-  // change is active in this project:
-  // ignore: unreachable_from_main
   static void setUpClass() {
     expect(didSetUpClass, false);
     didSetUpClass = true;
     expect(didTearDownClass, false);
   }
 
-  // TODO(scheglov): See comment directly above
-  // "TestReflectiveLoaderTest.setUpClass" for info about this ignore:
-  // ignore: unreachable_from_main
   static void tearDownClass() {
     expect(didSetUpClass, true);
     expect(didTearDownClass, false);
@@ -109,18 +101,12 @@ class SecondTest {
   static bool didSetUpClass = false;
   static bool didTearDownClass = false;
 
-  // TODO(scheglov): See comment directly above
-  // "TestReflectiveLoaderTest.setUpClass" for info about this ignore:
-  // ignore: unreachable_from_main
   static void setUpClass() {
     expect(didSetUpClass, false);
     didSetUpClass = true;
     expect(didTearDownClass, false);
   }
 
-  // TODO(scheglov): See comment directly above
-  // "TestReflectiveLoaderTest.setUpClass" for info about this ignore:
-  // ignore: unreachable_from_main
   static void tearDownClass() {
     expect(didSetUpClass, true);
     expect(didTearDownClass, false);

--- a/pkgs/test_reflective_loader/test/utils.dart
+++ b/pkgs/test_reflective_loader/test/utils.dart
@@ -7,23 +7,24 @@ import 'dart:isolate';
 
 import 'package:path/path.dart' as path;
 
+/// Runs the test file at [filename] and returns its stdout and stderr.
+///
+/// [filename] can be a relative path from the `test/` directory, or an
+/// absolute path.
+///
+/// Defaults to the expanded reporter (because the default reporter may differ
+/// between GitHub and running locally) but this can be overridden with
+/// [reporter].
 Future<({String stdout, String stderr})> runTestFile(String filename,
-    [List<String> args = const []]) async {
+    {String reporter = 'expanded'}) async {
   var testPackagePath = (await Isolate.resolvePackageUri(
           Uri.parse('package:test_reflective_loader/')))!
       .toFilePath();
   var testFilePath = path.isAbsolute(filename)
       ? filename
       : path.normalize(path.join(testPackagePath, '..', 'test', filename));
-  var result = await Process.run(Platform.resolvedExecutable, [
-    'test',
-    // Force the expanded reporter because otherwise the test output will
-    // differ slightly when the tests run on GitHub (it uses a GitHub
-    // reporter).
-    '-r', 'expanded',
-    ...args,
-    testFilePath
-  ]);
+  var result = await Process.run(
+      Platform.resolvedExecutable, ['test', '-r', reporter, testFilePath]);
 
   var output = result.stdout.toString().trim();
   var error = result.stderr.toString().trim();

--- a/pkgs/test_reflective_loader/test/utils.dart
+++ b/pkgs/test_reflective_loader/test/utils.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:path/path.dart' as path;
+
+Future<({String stdout, String stderr})> runTestFile(String filename,
+    [List<String> args = const []]) async {
+  var testPackagePath = (await Isolate.resolvePackageUri(
+          Uri.parse('package:test_reflective_loader/')))!
+      .toFilePath();
+  var testFilePath = path.isAbsolute(filename)
+      ? filename
+      : path.normalize(path.join(testPackagePath, '..', 'test', filename));
+  var result = await Process.run(Platform.resolvedExecutable, [
+    'test',
+    // Force the expanded reporter because otherwise the test output will
+    // differ slightly when the tests run on GitHub (it uses a GitHub
+    // reporter).
+    '-r', 'expanded',
+    ...args,
+    testFilePath
+  ]);
+
+  var output = result.stdout.toString().trim();
+  var error = result.stderr.toString().trim();
+
+  return (stdout: output, stderr: error);
+}


### PR DESCRIPTION
This makes the calls to `setUpAll` and `tearDownAll` conditional based on whether there are corresponding methods, so that there aren't phantom nodes in the IDE for all test classes.

It also adds missing locations, so that they navigate to the correct location when clicked.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5967
Fixes https://github.com/Dart-Code/Dart-Code/issues/5950

While testing, I also noticed `package:test` is always adding a `tearDownAll` if there is a `setUpAll` - I've filed https://github.com/dart-lang/test/issues/2608 about that.
