### PR TITLE
[code_builder] Fix incomplete string escaping in literalString()

### DIFF
--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -45,12 +45,18 @@ Expression literalNum(num value) => LiteralExpression._('$value');
 ///
 /// If [raw] is `true`, creates a raw String formatted `r'<value>'` and the
 /// value may not contain a single quote.
-/// Escapes single quotes and newlines in the value.
+/// Escapes single quotes, dollar signs, backslashes, newlines, and carriage
+/// returns in the value.
 Expression literalString(String value, {bool raw = false}) {
   if (raw && value.contains('\'')) {
     throw ArgumentError('Cannot include a single quote in a raw string');
   }
-  final escaped = value.replaceAll('\'', '\\\'').replaceAll('\n', '\\n');
+  final escaped = value
+      .replaceAll('\\', '\\\\')
+      .replaceAll('\'', '\\\'')
+      .replaceAll('\$', '\\\$')
+      .replaceAll('\n', '\\n')
+      .replaceAll('\r', '\\r');
   return LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
 }
 

--- a/pkgs/code_builder/test/specs/code/expression_test.dart
+++ b/pkgs/code_builder/test/specs/code/expression_test.dart
@@ -62,7 +62,7 @@ void main() {
   });
 
   test('should emit a String', () {
-    expect(literalString(r'$monkey'), equalsDart(r"'$monkey'"));
+    expect(literalString(r'$monkey'), equalsDart(r"'\$monkey'"));
   });
 
   test('should emit a raw String', () {
@@ -79,6 +79,25 @@ void main() {
 
   test('should escape a newline in a string', () {
     expect(literalString('some\nthing'), equalsDart(r"'some\nthing'"));
+  });
+
+  test('should escape a dollar sign in a string', () {
+    expect(literalString(r'${dangerous}'), equalsDart(r"'\${dangerous}'"));
+  });
+
+  test('should escape backslashes in a string', () {
+    expect(literalString(r'back\slash'), equalsDart(r"'back\\slash'"));
+  });
+
+  test('should escape a carriage return in a string', () {
+    expect(literalString('some\rthing'), equalsDart(r"'some\rthing'"));
+  });
+
+  test('should escape combined special characters', () {
+    expect(
+      literalString('it\'s \$100\nfor\\each'),
+      equalsDart(r"'it\'s \$100\nfor\\each'"),
+    );
   });
 
   test('should emit a && expression', () {


### PR DESCRIPTION
## Summary

`literalString()` does not escape `$`, `\`, or `\r` characters when generating non-raw Dart string literals. This causes `$` in input strings to be emitted as Dart string interpolation expressions rather than literal dollar-sign characters.

### Example

```dart
literalString(r'$monkey')
// Before fix: '$monkey'   ← Dart interprets as interpolation of `monkey`
// After fix:  '\$monkey'  ← Correct: literal dollar sign
```

A string like `'${Process.runSync("id",[]).stdout}'` would execute arbitrary code when the generated source is compiled and run.

### The problem

The escape chain in `literalString()` (line 53 of `literal.dart`) only handles:
- `'` → `\'` (single quote)  
- `\n` → `\n` (newline)

Missing escapes:
- `$` → `\$` (dollar sign — enables string interpolation injection)
- `\` → `\\` (backslash — enables escape sequence manipulation)
- `\r` → `\r` (carriage return)

### The fix

Escape `\` first (to avoid double-escaping), then `'`, `$`, `\n`, and `\r`. Order matters.

### Impact

`code_builder` is a foundational Dart code generation package used by `json_serializable`, `built_value`, `freezed`, and many protobuf/gRPC generators. Any generator passing user-controlled strings through `literalString()` produces code vulnerable to string interpolation injection.

### Tests

- Updated the existing `'should emit a String'` test expectation from `'$monkey'` → `'\$monkey'`
- Added new tests for dollar sign, backslash, carriage return, and combined special characters

### Checklist
- [x] Updated `literal.dart` escape chain
- [x] Updated existing test expectations  
- [x] Added new test cases for all newly-escaped characters