### PR TITLE
Allow single quotes in "raw" string literals

### DIFF
--- a/pkgs/code_builder/CHANGELOG.md
+++ b/pkgs/code_builder/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 5.0.0-wip
+## 4.12.0-wip
 
-* **BREAKING** `literalString` fully escapes content and cannot generate strings
-  with interpolated Dart variables. Removed `raw` argument.
+* Allow single quotes in strings passed to `literalString(raw:true)`. This
+  argument no longer guarantees a raw string is used, but results will have the
+  same behavior.
 * Correct type annotations on nullable and generic variables created with
   `declareVar`, `declareFinal`, and `declareConst`.
 

--- a/pkgs/code_builder/CHANGELOG.md
+++ b/pkgs/code_builder/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 4.11.2-wip
+## 5.0.0-wip
 
+* **BREAKING** `literalString` fully escapes content and cannot generate strings
+  with interpolated Dart variables. Removed `raw` argument.
 * Correct type annotations on nullable and generic variables created with
   `declareVar`, `declareFinal`, and `declareConst`.
 

--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -57,23 +57,23 @@ String _escapeString(String value) {
   var canBeRaw = true;
 
   value = value.replaceAllMapped(_escapeRegExp, (match) {
-    final value = match[0]!;
-    if (value == "'") {
+    final char = match[0]!;
+    if (char == "'") {
       hasSingleQuote = true;
-      return value;
-    } else if (value == '"') {
+      return char;
+    } else if (char == '"') {
       hasDoubleQuote = true;
-      return value;
-    } else if (value == r'$') {
+      return char;
+    } else if (char == r'$') {
       hasDollar = true;
-      return value;
-    } else if (value == r'\') {
+      return char;
+    } else if (char == r'\') {
       hasBackslash = true;
       return r'\\';
     }
 
     canBeRaw = false;
-    return _escapeMap[value] ?? _hexLiteral(value);
+    return _escapeMap[char] ?? _hexLiteral(char);
   });
 
   if (canBeRaw && (hasDollar || hasBackslash)) {
@@ -90,6 +90,15 @@ String _escapeString(String value) {
   return "'$value'";
 }
 
+/// Given single-character string, return the hex-escaped equivalent.
+String _hexLiteral(String input) {
+  final value = input.runes.single
+      .toRadixString(16)
+      .toUpperCase()
+      .padLeft(2, '0');
+  return '\\x$value';
+}
+
 final _dollarQuoteRegexp = RegExp(r"(?=[$'])");
 
 /// A map from whitespace characters & `\` to their escape sequences.
@@ -104,20 +113,12 @@ const _escapeMap = {
   r'\': r'\\', // backslash
 };
 
-/// Given single-character string, return the hex-escaped equivalent.
-String _hexLiteral(String input) {
-  final value = input.runes.single
-      .toRadixString(16)
-      .toUpperCase()
-      .padLeft(2, '0');
-  return '\\x$value';
-}
-
 /// A [RegExp] that matches whitespace characters that must be escaped and
 /// single-quote, double-quote, and `$`
 final _escapeRegExp = RegExp('[\$\'"\\x00-\\x07\\x0E-\\x1F$_escapeMapRegexp]');
 
-final _escapeMapRegexp = _escapeMap.keys.map(_hexLiteral).join();
+// _escapeMap.keys.map(_hexLiteral).join();
+const _escapeMapRegexp = r'\x08\x09\x0A\x0B\x0C\x0D\x7F\x5C';
 
 /// Create a literal `...` operator for use when creating a Map literal.
 ///

--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -50,7 +50,7 @@ Expression literalNum(num value) => LiteralExpression._('$value');
 Expression literalString(String value, {bool raw = false}) {
   if (raw) return LiteralExpression._(_escapeString(value));
   final escaped = value.replaceAll('\'', '\\\'').replaceAll('\n', '\\n');
-  return LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
+  return LiteralExpression._("'$escaped'");
 }
 
 String _escapeString(String value) {

--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -41,12 +41,17 @@ Expression literalNum(num value) => LiteralExpression._('$value');
 
 /// Create a literal expression from a string [value].
 ///
-/// Returns an expression that will evaluate to a String  containing exactly the
-/// same content as [value]. The literal may use single or double quotes, and
-/// may be raw, depending on the content. All disallowed characters are
-/// automatically escaped.
-Expression literalString(String value) =>
-    LiteralExpression._(_escapeString(value));
+/// Returns an expression for a string formatted `'<value>'`.
+///
+/// If [raw] is `true` returns an expression that will evaluate to a String
+/// containing exactly the same content as [value]. The literal may use single
+/// or double quotes, and may not actually be markedraw, depending on the
+/// content. All disallowed characters are automatically escaped.
+Expression literalString(String value, {bool raw = false}) {
+  if (raw) return LiteralExpression._(_escapeString(value));
+  final escaped = value.replaceAll('\'', '\\\'').replaceAll('\n', '\\n');
+  return LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
+}
 
 String _escapeString(String value) {
   final original = value;

--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -41,18 +41,83 @@ Expression literalNum(num value) => LiteralExpression._('$value');
 
 /// Create a literal expression from a string [value].
 ///
-/// **NOTE**: The string is always formatted `'<value>'`.
-///
-/// If [raw] is `true`, creates a raw String formatted `r'<value>'` and the
-/// value may not contain a single quote.
-/// Escapes single quotes and newlines in the value.
-Expression literalString(String value, {bool raw = false}) {
-  if (raw && value.contains('\'')) {
-    throw ArgumentError('Cannot include a single quote in a raw string');
+/// Returns an expression that will evaluate to a String  containing exactly the
+/// same content as [value]. The literal may use single or double quotes, and
+/// may be raw, depending on the content. All disallowed characters are
+/// automatically escaped.
+Expression literalString(String value) =>
+    LiteralExpression._(_escapeString(value));
+
+String _escapeString(String value) {
+  final original = value;
+  var hasSingleQuote = false;
+  var hasDoubleQuote = false;
+  var hasDollar = false;
+  var hasBackslash = false;
+  var canBeRaw = true;
+
+  value = value.replaceAllMapped(_escapeRegExp, (match) {
+    final value = match[0]!;
+    if (value == "'") {
+      hasSingleQuote = true;
+      return value;
+    } else if (value == '"') {
+      hasDoubleQuote = true;
+      return value;
+    } else if (value == r'$') {
+      hasDollar = true;
+      return value;
+    } else if (value == r'\') {
+      hasBackslash = true;
+      return r'\\';
+    }
+
+    canBeRaw = false;
+    return _escapeMap[value] ?? _hexLiteral(value);
+  });
+
+  if (canBeRaw && (hasDollar || hasBackslash)) {
+    if (!hasSingleQuote) return "r'$original'";
+    if (!hasDoubleQuote) return 'r"$original"';
   }
-  final escaped = value.replaceAll('\'', '\\\'').replaceAll('\n', '\\n');
-  return LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
+
+  if (!hasDollar) {
+    if (!hasSingleQuote) return "'$value'";
+    if (!hasDoubleQuote) return '"$value"';
+  }
+
+  value = value.replaceAll(_dollarQuoteRegexp, r'\');
+  return "'$value'";
 }
+
+final _dollarQuoteRegexp = RegExp(r"(?=[$'])");
+
+/// A map from whitespace characters & `\` to their escape sequences.
+const _escapeMap = {
+  '\b': r'\b', // 08 - backspace
+  '\t': r'\t', // 09 - tab
+  '\n': r'\n', // 0A - new line
+  '\v': r'\v', // 0B - vertical tab
+  '\f': r'\f', // 0C - form feed
+  '\r': r'\r', // 0D - carriage return
+  '\x7F': r'\x7F', // delete
+  r'\': r'\\', // backslash
+};
+
+/// Given single-character string, return the hex-escaped equivalent.
+String _hexLiteral(String input) {
+  final value = input.runes.single
+      .toRadixString(16)
+      .toUpperCase()
+      .padLeft(2, '0');
+  return '\\x$value';
+}
+
+/// A [RegExp] that matches whitespace characters that must be escaped and
+/// single-quote, double-quote, and `$`
+final _escapeRegExp = RegExp('[\$\'"\\x00-\\x07\\x0E-\\x1F$_escapeMapRegexp]');
+
+final _escapeMapRegexp = _escapeMap.keys.map(_hexLiteral).join();
 
 /// Create a literal `...` operator for use when creating a Map literal.
 ///

--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -115,7 +115,6 @@ const _escapeMap = {
   '\f': r'\f', // 0C - form feed
   '\r': r'\r', // 0D - carriage return
   '\x7F': r'\x7F', // delete
-  r'\': r'\\', // backslash
 };
 
 /// A [RegExp] that matches whitespace characters that must be escaped and

--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -45,7 +45,7 @@ Expression literalNum(num value) => LiteralExpression._('$value');
 ///
 /// If [raw] is `true` returns an expression that will evaluate to a String
 /// containing exactly the same content as [value]. The literal may use single
-/// or double quotes, and may not actually be markedraw, depending on the
+/// or double quotes, and may not actually be marked raw, depending on the
 /// content. All disallowed characters are automatically escaped.
 Expression literalString(String value, {bool raw = false}) {
   if (raw) return LiteralExpression._(_escapeString(value));

--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -47,6 +47,9 @@ Expression literalNum(num value) => LiteralExpression._('$value');
 /// containing exactly the same content as [value]. The literal may use single
 /// or double quotes, and may not actually be marked raw, depending on the
 /// content. All disallowed characters are automatically escaped.
+///
+/// Passing `raw: true` is recommended and will become the only option in a
+/// future release.
 Expression literalString(String value, {bool raw = false}) {
   if (raw) return LiteralExpression._(_escapeString(value));
   final escaped = value.replaceAll('\'', '\\\'').replaceAll('\n', '\\n');

--- a/pkgs/code_builder/pubspec.yaml
+++ b/pkgs/code_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 5.0.0-wip
+version: 4.12.0-wip
 description: A fluent, builder-based library for generating valid Dart code.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/code_builder
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acode_builder

--- a/pkgs/code_builder/pubspec.yaml
+++ b/pkgs/code_builder/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
   meta: ^1.16.0
 
 dev_dependencies:
-  # build: ^4.0.0
-  # build_runner: ^2.7.2
-  # built_value_generator: ^8.11.2
+  build: ^4.0.0
+  build_runner: ^2.7.2
+  built_value_generator: ^8.11.2
   dart_flutter_team_lints: ^3.0.0
   dart_style: ^3.1.2
   source_gen: ^4.0.1

--- a/pkgs/code_builder/pubspec.yaml
+++ b/pkgs/code_builder/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
   meta: ^1.16.0
 
 dev_dependencies:
-  build: ^4.0.0
-  build_runner: ^2.7.2
-  built_value_generator: ^8.11.2
+  # build: ^4.0.0
+  # build_runner: ^2.7.2
+  # built_value_generator: ^8.11.2
   dart_flutter_team_lints: ^3.0.0
   dart_style: ^3.1.2
   source_gen: ^4.0.1

--- a/pkgs/code_builder/pubspec.yaml
+++ b/pkgs/code_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.11.2-wip
+version: 5.0.0-wip
 description: A fluent, builder-based library for generating valid Dart code.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/code_builder
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acode_builder

--- a/pkgs/code_builder/test/specs/code/expression_test.dart
+++ b/pkgs/code_builder/test/specs/code/expression_test.dart
@@ -61,24 +61,74 @@ void main() {
     });
   });
 
-  test('should emit a String', () {
-    expect(literalString(r'$monkey'), equalsDart(r"'$monkey'"));
-  });
+  group('literalString', () {
+    test('should emit a simple string', () {
+      expect(literalString('foo'), equalsDart(r"'foo'"));
+    });
 
-  test('should emit a raw String', () {
-    expect(literalString(r'$monkey', raw: true), equalsDart(r"r'$monkey'"));
-  });
+    test('should emit an empty string', () {
+      expect(literalString(''), equalsDart("''"));
+    });
 
-  test('should escape single quotes in a String', () {
-    expect(literalString(r"don't"), equalsDart(r"'don\'t'"));
-  });
+    test('should use double quotes for just a single quote', () {
+      expect(literalString("'"), equalsDart('"\'"'));
+    });
 
-  test('does not allow single quote in raw string', () {
-    expect(() => literalString(r"don't", raw: true), throwsArgumentError);
-  });
+    test('should use single quotes for just a double quote', () {
+      expect(literalString('"'), equalsDart("'\"'"));
+    });
 
-  test('should escape a newline in a string', () {
-    expect(literalString('some\nthing'), equalsDart(r"'some\nthing'"));
+    test('should use raw string for a single backslash', () {
+      expect(literalString('\\'), equalsDart("r'\\'"));
+    });
+
+    test('should emit unicode characters', () {
+      expect(literalString('😊'), equalsDart("'😊'"));
+    });
+
+    test('should escape a carriage return in a string', () {
+      expect(literalString('some\rthing'), equalsDart(r"'some\rthing'"));
+    });
+
+    test('should use raw string for backslashes', () {
+      expect(literalString(r'a\tb'), equalsDart("r'a\\tb'"));
+    });
+
+    test('should use double quotes if it contains single quotes', () {
+      expect(literalString("don't"), equalsDart('"don\'t"'));
+    });
+
+    test('should use single quotes if it contains double quotes', () {
+      expect(literalString('foo "bar"'), equalsDart('\'foo "bar"\''));
+    });
+
+    test('should escape single quotes if it contains both quotes', () {
+      expect(literalString('don\'t "bar"'), equalsDart('\'don\\\'t "bar"\''));
+    });
+
+    test('should use raw single quotes for dollar signs if possible', () {
+      expect(literalString(r'$foo'), equalsDart('r\'\$foo\''));
+    });
+
+    test('should use raw double quotes for dollar signs and single quotes '
+        'if possible', () {
+      expect(literalString(r"don't $foo"), equalsDart('r"don\'t \$foo"'));
+    });
+
+    test('should escape if it contains dollar, single, and double quotes', () {
+      expect(
+        literalString('don\'t "bar" \$foo'),
+        equalsDart('\'don\\\'t "bar" \\\$foo\''),
+      );
+    });
+
+    test('should escape control characters', () {
+      expect(literalString('foo\nbar'), equalsDart('\'foo\\nbar\''));
+    });
+
+    test('should escape control characters and dollar signs', () {
+      expect(literalString('foo\n\$bar'), equalsDart('\'foo\\n\\\$bar\''));
+    });
   });
 
   test('should emit a && expression', () {

--- a/pkgs/code_builder/test/specs/code/expression_test.dart
+++ b/pkgs/code_builder/test/specs/code/expression_test.dart
@@ -61,73 +61,106 @@ void main() {
     });
   });
 
-  group('literalString', () {
+  group('literalString legacy', () {
+    test('should emit a String', () {
+      expect(literalString(r'$monkey'), equalsDart(r"'$monkey'"));
+    });
+
+    test('should emit a raw String', () {
+      expect(literalString(r'$monkey', raw: true), equalsDart(r"r'$monkey'"));
+    });
+
+    test('should escape single quotes in a String', () {
+      expect(literalString(r"don't"), equalsDart(r"'don\'t'"));
+    });
+
+    test('should escape a newline in a string', () {
+      expect(literalString('some\nthing'), equalsDart(r"'some\nthing'"));
+    });
+  });
+
+  group('literalString raw', () {
     test('should emit a simple string', () {
-      expect(literalString('foo'), equalsDart(r"'foo'"));
+      expect(literalString(raw: true, 'foo'), equalsDart(r"'foo'"));
     });
 
     test('should emit an empty string', () {
-      expect(literalString(''), equalsDart("''"));
+      expect(literalString(raw: true, ''), equalsDart("''"));
     });
 
     test('should use double quotes for just a single quote', () {
-      expect(literalString("'"), equalsDart('"\'"'));
+      expect(literalString(raw: true, "'"), equalsDart('"\'"'));
     });
 
     test('should use single quotes for just a double quote', () {
-      expect(literalString('"'), equalsDart("'\"'"));
+      expect(literalString(raw: true, '"'), equalsDart("'\"'"));
     });
 
     test('should use raw string for a single backslash', () {
-      expect(literalString('\\'), equalsDart("r'\\'"));
+      expect(literalString(raw: true, '\\'), equalsDart("r'\\'"));
     });
 
     test('should emit unicode characters', () {
-      expect(literalString('😊'), equalsDart("'😊'"));
+      expect(literalString(raw: true, '😊'), equalsDart("'😊'"));
     });
 
     test('should escape a carriage return in a string', () {
-      expect(literalString('some\rthing'), equalsDart(r"'some\rthing'"));
+      expect(
+        literalString(raw: true, 'some\rthing'),
+        equalsDart(r"'some\rthing'"),
+      );
     });
 
     test('should use raw string for backslashes', () {
-      expect(literalString(r'a\tb'), equalsDart("r'a\\tb'"));
+      expect(literalString(raw: true, r'a\tb'), equalsDart("r'a\\tb'"));
     });
 
     test('should use double quotes if it contains single quotes', () {
-      expect(literalString("don't"), equalsDart('"don\'t"'));
+      expect(literalString(raw: true, "don't"), equalsDart('"don\'t"'));
     });
 
     test('should use single quotes if it contains double quotes', () {
-      expect(literalString('foo "bar"'), equalsDart('\'foo "bar"\''));
+      expect(
+        literalString(raw: true, 'foo "bar"'),
+        equalsDart('\'foo "bar"\''),
+      );
     });
 
     test('should escape single quotes if it contains both quotes', () {
-      expect(literalString('don\'t "bar"'), equalsDart('\'don\\\'t "bar"\''));
+      expect(
+        literalString(raw: true, 'don\'t "bar"'),
+        equalsDart('\'don\\\'t "bar"\''),
+      );
     });
 
     test('should use raw single quotes for dollar signs if possible', () {
-      expect(literalString(r'$foo'), equalsDart(r"r'$foo'"));
+      expect(literalString(raw: true, r'$foo'), equalsDart(r"r'$foo'"));
     });
 
     test('should use raw double quotes for dollar signs and single quotes '
         'if possible', () {
-      expect(literalString(r"don't $foo"), equalsDart('r"don\'t \$foo"'));
+      expect(
+        literalString(raw: true, r"don't $foo"),
+        equalsDart('r"don\'t \$foo"'),
+      );
     });
 
     test('should escape if it contains dollar, single, and double quotes', () {
       expect(
-        literalString('don\'t "bar" \$foo'),
+        literalString(raw: true, 'don\'t "bar" \$foo'),
         equalsDart('\'don\\\'t "bar" \\\$foo\''),
       );
     });
 
     test('should escape control characters', () {
-      expect(literalString('foo\nbar'), equalsDart('\'foo\\nbar\''));
+      expect(literalString(raw: true, 'foo\nbar'), equalsDart('\'foo\\nbar\''));
     });
 
     test('should escape control characters and dollar signs', () {
-      expect(literalString('foo\n\$bar'), equalsDart('\'foo\\n\\\$bar\''));
+      expect(
+        literalString(raw: true, 'foo\n\$bar'),
+        equalsDart('\'foo\\n\\\$bar\''),
+      );
     });
   });
 

--- a/pkgs/code_builder/test/specs/code/expression_test.dart
+++ b/pkgs/code_builder/test/specs/code/expression_test.dart
@@ -107,7 +107,7 @@ void main() {
     });
 
     test('should use raw single quotes for dollar signs if possible', () {
-      expect(literalString(r'$foo'), equalsDart('r\'\$foo\''));
+      expect(literalString(r'$foo'), equalsDart(r"r'$foo'"));
     });
 
     test('should use raw double quotes for dollar signs and single quotes '


### PR DESCRIPTION
Closes #2352
Closes #2350

The raw string behavior is more useful for codegen, but it disallows
single quotes in the content which is too limiting. Expand the behavior
to always create an allowed string literal with exactly the same content
as the argument and allow single quotes. The literal is no longer
guaranteed to be an actual raw string tagged with `r`, but there are no
behavior differences and this matches the intent for the argument.

A future breaking change will change the default behavior of the method
to match this new `raw: true` behavior. Changing the current behavior
with the argument allows for an incremental migration. There are not
dependencies on the existing behavior which guarantees the `r` prefix. A
subsequent breaking change will remove the argument altogether.
