### PR TITLE
fix(yaml): Fix stack overflow in deepHashCode for self-referential lists

### DIFF
--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.4-wip
+
+* Fix a stack overflow in `deepHashCode` when handling self-referential lists.
+
 ## 3.1.3
 
 * Require Dart 3.4

--- a/pkgs/yaml/lib/src/equality.dart
+++ b/pkgs/yaml/lib/src/equality.dart
@@ -113,7 +113,8 @@ int deepHashCode(Object? obj) {
         return equality.hash(value.keys.map(deepHashCodeInner)) ^
             equality.hash(value.values.map(deepHashCodeInner));
       } else if (value is Iterable) {
-        return const IterableEquality<Object?>().hash(value.map(deepHashCode));
+        return const IterableEquality<Object?>()
+            .hash(value.map(deepHashCodeInner));
       } else if (value is YamlScalar) {
         return (value.value as Object?).hashCode;
       } else {

--- a/pkgs/yaml/pubspec.yaml
+++ b/pkgs/yaml/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml
-version: 3.1.3
+version: 3.1.4-wip
 description: A parser for YAML, a human-friendly data serialization standard
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/yaml
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Ayaml

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -1118,6 +1118,21 @@ void main() {
       expect(anchorList, same(aliasList));
     });
 
+    test('self-referential list does not cause stack overflow in deepHashCode',
+        () {
+      var doc = loadYaml(cleanUpLiteral('''
+        ? &anchor [*anchor]
+        : value'''));
+      expect(doc, isNotNull);
+      var key = doc.keys.first;
+      expect(key, isA<YamlList>());
+      expect(key[0], same(key));
+
+      var map = deepEqualsMap();
+      map[key] = 'value';
+      expect(map[key], 'value');
+    });
+
     test('[Example 7.1]', () {
       expectYamlLoads({
         'First occurrence': 'Foo',


### PR DESCRIPTION
Replaces #2362

Replace a nested call to `deepHashCode` with `deepHashCodeInner` to fix
a stack overflow with self referential iterables.
