### PR TITLE
fix(yaml): Fix stack overflow in self-referential maps

### DIFF
--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.4-wip
 
-* Fix a stack overflow in `deepHashCode` when handling self-referential lists.
+* Fix stack overflow when handling self-referential collections.
+  * Fix issue in `deepHashCode` when handling self-referential lists and maps.
+  * Prevent duplicate self-referential collections from being used as keys.
 
 ## 3.1.3
 

--- a/pkgs/yaml/lib/src/equality.dart
+++ b/pkgs/yaml/lib/src/equality.dart
@@ -29,6 +29,7 @@ class _DeepEquals {
 
   /// Returns whether [obj1] and [obj2] are structurally equivalent.
   bool equals(Object? obj1, Object? obj2) {
+    if (identical(obj1, obj2)) return true;
     if (obj1 is YamlScalar) obj1 = obj1.value;
     if (obj2 is YamlScalar) obj2 = obj2.value;
 

--- a/pkgs/yaml/lib/src/equality.dart
+++ b/pkgs/yaml/lib/src/equality.dart
@@ -110,8 +110,16 @@ int deepHashCode(Object? obj) {
     try {
       if (value is Map) {
         var equality = const UnorderedIterableEquality<Object?>();
-        return equality.hash(value.keys.map(deepHashCodeInner)) ^
-            equality.hash(value.values.map(deepHashCodeInner));
+
+        // Avoid calling keys in YamlMap which eagerly iterates recursive
+        // references.
+        final (keys, values) = switch (value) {
+          YamlMap(:final nodes) => (nodes.keys, nodes.values),
+          _ => (value.keys, value.values)
+        };
+
+        return equality.hash(keys.map(deepHashCodeInner)) ^
+            equality.hash(values.map(deepHashCodeInner));
       } else if (value is Iterable) {
         return const IterableEquality<Object?>()
             .hash(value.map(deepHashCodeInner));

--- a/pkgs/yaml/lib/src/loader.dart
+++ b/pkgs/yaml/lib/src/loader.dart
@@ -167,16 +167,14 @@ class Loader {
       if (identical(node, key)) {
         if (hasRecursive) {
           // Key span points to anchor. Use event.
-          throw YamlException('Duplicate recursive mapping key', event.span);
+          throw YamlException('Duplicate recursive mapping key.', event.span);
         }
 
         hasRecursive = true;
       } else if (children.containsKey(key)) {
-        final keySpan = key.span;
-
         throw YamlException(
           'Duplicate mapping key.',
-          keySpan.start.offset <= node.span.start.offset ? event.span : keySpan,
+          event.type == EventType.alias ? event.span : key.span,
         );
       }
 

--- a/pkgs/yaml/lib/src/loader.dart
+++ b/pkgs/yaml/lib/src/loader.dart
@@ -176,7 +176,7 @@ class Loader {
 
         throw YamlException(
           'Duplicate mapping key.',
-          keySpan.start.offset < node.span.start.offset ? event.span : keySpan,
+          keySpan.start.offset <= node.span.start.offset ? event.span : keySpan,
         );
       }
 

--- a/pkgs/yaml/lib/src/loader.dart
+++ b/pkgs/yaml/lib/src/loader.dart
@@ -153,16 +153,31 @@ class Loader {
       throw YamlException('Invalid tag for mapping.', firstEvent.span);
     }
 
-    var children = deepEqualsMap<dynamic, YamlNode>();
-    var node = YamlMap.internal(children, firstEvent.span, firstEvent.style);
+    final children = deepEqualsMap<dynamic, YamlNode>();
+    final node = YamlMap.internal(children, firstEvent.span, firstEvent.style);
     _registerAnchor(firstEvent.anchor, node);
 
     var event = _parser.parse();
+    var hasRecursive = false;
+
     while (event.type != EventType.mappingEnd) {
-      var key = _loadNode(event);
-      var value = _loadNode(_parser.parse());
-      if (children.containsKey(key)) {
-        throw YamlException('Duplicate mapping key.', key.span);
+      final key = _loadNode(event);
+      final value = _loadNode(_parser.parse());
+
+      if (identical(node, key)) {
+        if (hasRecursive) {
+          // Key span points to anchor. Use event.
+          throw YamlException('Duplicate recursive mapping key', event.span);
+        }
+
+        hasRecursive = true;
+      } else if (children.containsKey(key)) {
+        final keySpan = key.span;
+
+        throw YamlException(
+          'Duplicate mapping key.',
+          keySpan.start.offset < node.span.start.offset ? event.span : keySpan,
+        );
       }
 
       children[key] = value;

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -1137,6 +1137,23 @@ void main() {
       expect(map[key], 'value');
     });
 
+    test('self-referential map does not cause stack overflow in deepHashcode',
+        () {
+      var doc = loadYaml('&map { *map : *map }');
+      expect(doc, isNotNull);
+      expect(doc, isA<YamlMap>());
+      expect(doc.nodes.keys.first, same(doc));
+      expect(doc.nodes.values.first, same(doc));
+    });
+
+    test(
+      'Throws when duplicate aliases are used as a map key',
+      () {
+        expectYamlFails('&map { *map : hello, *map : there }');
+        expectYamlFails('&list [ { *list : this, *list : next } ]');
+      },
+    );
+
     test('[Example 7.1]', () {
       expectYamlLoads({
         'First occurrence': 'Foo',


### PR DESCRIPTION
Similar to #2365 but for maps:

- Prevents `deepHashCodeInner` from eagerly calling `keys` on map which results in a stack overflow. Should call `nodes.keys` and `nodes.values` which contains the actual nodes parsed.
- Ensures duplicate self-referential maps and lists do not appear twice as stated [here](https://yaml.org/spec/1.2.2/#3213-node-comparison:~:text=identical%2E-,Uniqueness,equal,-%2E)

```yaml
&list [ *list, &map { *map : *list , *list : *map }]
```

@natebosch @kevmoo

I must say it seems weird that `containsKey` fails to catch the self-reference for maps. I had to handle it at the map level.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
