### PR TITLE
Deprecate and remove uses of Expression.expression

### DIFF
--- a/pkgs/code_builder/CHANGELOG.md
+++ b/pkgs/code_builder/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Correct type annotations on nullable and generic variables created with
   `declareVar`, `declareFinal`, and `declareConst`.
+* Deprecate and remove uses of `Expression.expression`.
 
 ## 4.11.1
 

--- a/pkgs/code_builder/lib/src/specs/expression.dart
+++ b/pkgs/code_builder/lib/src/specs/expression.dart
@@ -53,90 +53,83 @@ abstract class Expression implements Spec {
   Code get statement => ToCodeExpression(this, true);
 
   /// Returns the result of `this` `&&` [other].
-  Expression and(Expression other) =>
-      BinaryExpression._(expression, other, '&&');
+  Expression and(Expression other) => BinaryExpression._(this, other, '&&');
 
   /// Returns the result of `this` `||` [other].
-  Expression or(Expression other) =>
-      BinaryExpression._(expression, other, '||');
+  Expression or(Expression other) => BinaryExpression._(this, other, '||');
 
   /// Returns the result of `!this`.
-  Expression negate() =>
-      BinaryExpression._(_empty, expression, '!', addSpace: false);
+  Expression negate() => BinaryExpression._(_empty, this, '!', addSpace: false);
 
   /// Returns the result of `this` `as` [other].
   Expression asA(Expression other) =>
-      ParenthesizedExpression._(BinaryExpression._(expression, other, 'as'));
+      ParenthesizedExpression._(BinaryExpression._(this, other, 'as'));
 
   /// Returns accessing the index operator (`[]`) on `this`.
   Expression index(Expression index) => BinaryExpression._(
-    expression,
+    this,
     CodeExpression(Block.of([const Code('['), index.code, const Code(']')])),
     '',
   );
 
   /// Returns the result of `this` `is` [other].
-  Expression isA(Expression other) =>
-      BinaryExpression._(expression, other, 'is');
+  Expression isA(Expression other) => BinaryExpression._(this, other, 'is');
 
   /// Returns the result of `this` `is!` [other].
-  Expression isNotA(Expression other) =>
-      BinaryExpression._(expression, other, 'is!');
+  Expression isNotA(Expression other) => BinaryExpression._(this, other, 'is!');
 
   /// Returns the result of `this` `==` [other].
-  Expression equalTo(Expression other) =>
-      BinaryExpression._(expression, other, '==');
+  Expression equalTo(Expression other) => BinaryExpression._(this, other, '==');
 
   /// Returns the result of `this` `!=` [other].
   Expression notEqualTo(Expression other) =>
-      BinaryExpression._(expression, other, '!=');
+      BinaryExpression._(this, other, '!=');
 
   /// Returns the result of `this` `>` [other].
   Expression greaterThan(Expression other) =>
-      BinaryExpression._(expression, other, '>');
+      BinaryExpression._(this, other, '>');
 
   /// Returns the result of `this` `<` [other].
-  Expression lessThan(Expression other) =>
-      BinaryExpression._(expression, other, '<');
+  Expression lessThan(Expression other) => BinaryExpression._(this, other, '<');
 
   /// Returns the result of `this` `>=` [other].
   Expression greaterOrEqualTo(Expression other) =>
-      BinaryExpression._(expression, other, '>=');
+      BinaryExpression._(this, other, '>=');
 
   /// Returns the result of `this` `<=` [other].
   Expression lessOrEqualTo(Expression other) =>
-      BinaryExpression._(expression, other, '<=');
+      BinaryExpression._(this, other, '<=');
 
   /// Returns the result of `this` `+` [other].
   Expression operatorAdd(Expression other) =>
-      BinaryExpression._(expression, other, '+');
+      BinaryExpression._(this, other, '+');
 
   /// Returns the result of `this` `-` [other].
   Expression operatorSubtract(Expression other) =>
-      BinaryExpression._(expression, other, '-');
+      BinaryExpression._(this, other, '-');
 
   @Deprecated('Use `operatorSubtract` instead')
   Expression operatorSubstract(Expression other) => operatorSubtract(other);
 
   /// Returns the result of `this` `/` [other].
   Expression operatorDivide(Expression other) =>
-      BinaryExpression._(expression, other, '/');
+      BinaryExpression._(this, other, '/');
 
   /// Returns the result of `this` `*` [other].
   Expression operatorMultiply(Expression other) =>
-      BinaryExpression._(expression, other, '*');
+      BinaryExpression._(this, other, '*');
 
   /// Returns the result of `this` `%` [other].
   Expression operatorEuclideanModulo(Expression other) =>
-      BinaryExpression._(expression, other, '%');
+      BinaryExpression._(this, other, '%');
 
   /// Returns the result of `this` `~/` [other].
   Expression operatorIntDivide(Expression other) =>
-      BinaryExpression._(expression, other, '~/');
+      BinaryExpression._(this, other, '~/');
 
   Expression conditional(Expression whenTrue, Expression whenFalse) =>
       BinaryExpression._(
-        expression,
+        this,
         BinaryExpression._(whenTrue, whenFalse, ':'),
         '?',
       );
@@ -146,51 +139,51 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `++this`.
   Expression operatorUnaryPrefixIncrement() =>
-      BinaryExpression._(_empty, expression, '++', addSpace: false);
+      BinaryExpression._(_empty, this, '++', addSpace: false);
 
   /// Return the result of `this++`.
   Expression operatorUnaryPostfixIncrement() =>
-      BinaryExpression._(expression, _empty, '++', addSpace: false);
+      BinaryExpression._(this, _empty, '++', addSpace: false);
 
   /// Returns the result of `-this`.
   Expression operatorUnaryMinus() =>
-      BinaryExpression._(_empty, expression, '-', addSpace: false);
+      BinaryExpression._(_empty, this, '-', addSpace: false);
 
   /// Returns the result of `--this`.
   Expression operatorUnaryPrefixDecrement() =>
-      BinaryExpression._(_empty, expression, '--', addSpace: false);
+      BinaryExpression._(_empty, this, '--', addSpace: false);
 
   /// Return the result of `this--`.
   Expression operatorUnaryPostfixDecrement() =>
-      BinaryExpression._(expression, _empty, '--', addSpace: false);
+      BinaryExpression._(this, _empty, '--', addSpace: false);
 
   /// Returns the result of `this` `&` [other].
   Expression operatorBitwiseAnd(Expression other) =>
-      BinaryExpression._(expression, other, '&');
+      BinaryExpression._(this, other, '&');
 
   /// Returns the result of `this` `|` [other].
   Expression operatorBitwiseOr(Expression other) =>
-      BinaryExpression._(expression, other, '|');
+      BinaryExpression._(this, other, '|');
 
   /// Returns the result of `this` `^` [other].
   Expression operatorBitwiseXor(Expression other) =>
-      BinaryExpression._(expression, other, '^');
+      BinaryExpression._(this, other, '^');
 
   /// Returns the result of `~this`.
   Expression operatorUnaryBitwiseComplement() =>
-      BinaryExpression._(_empty, expression, '~', addSpace: false);
+      BinaryExpression._(_empty, this, '~', addSpace: false);
 
   /// Returns the result of `this` `<<` [other].
   Expression operatorShiftLeft(Expression other) =>
-      BinaryExpression._(expression, other, '<<');
+      BinaryExpression._(this, other, '<<');
 
   /// Returns the result of `this` `>>` [other].
   Expression operatorShiftRight(Expression other) =>
-      BinaryExpression._(expression, other, '>>');
+      BinaryExpression._(this, other, '>>');
 
   /// Returns the result of `this` `>>>` [other].
   Expression operatorShiftRightUnsigned(Expression other) =>
-      BinaryExpression._(expression, other, '>>>');
+      BinaryExpression._(this, other, '>>>');
 
   /// Return `{this} = {other}`.
   Expression assign(Expression other) =>
@@ -350,8 +343,9 @@ abstract class Expression implements Spec {
   Expression get thrown =>
       BinaryExpression._(const LiteralExpression._('throw'), this, '');
 
-  /// May be overridden to support other types implementing [Expression].
+  /// Returns `this`.
   @visibleForOverriding
+  @Deprecated('Do not use.')
   Expression get expression => this;
 
   /// Returns this expression wrapped in parenthesis.

--- a/pkgs/code_builder/lib/src/specs/expression.dart
+++ b/pkgs/code_builder/lib/src/specs/expression.dart
@@ -345,7 +345,7 @@ abstract class Expression implements Spec {
 
   /// Returns `this`.
   @visibleForOverriding
-  @Deprecated('Do not use.')
+  @Deprecated('No longer needed. Use the expression directly.')
   Expression get expression => this;
 
   /// Returns this expression wrapped in parenthesis.

--- a/pkgs/code_builder/lib/src/specs/reference.dart
+++ b/pkgs/code_builder/lib/src/specs/reference.dart
@@ -7,7 +7,6 @@ import 'package:meta/meta.dart';
 
 import '../base.dart';
 import '../visitors.dart';
-import 'code.dart';
 import 'expression.dart';
 import 'type_reference.dart';
 
@@ -96,10 +95,6 @@ class Reference extends Expression implements Spec {
     typeArguments,
     name,
   );
-
-  @override
-  // TODO - annotate with @visibleForOverriding
-  Expression get expression => CodeExpression(Code.scope((a) => a(this)));
 
   @override
   String toString() =>

--- a/pkgs/code_builder/lib/src/specs/type_reference.dart
+++ b/pkgs/code_builder/lib/src/specs/type_reference.dart
@@ -9,7 +9,6 @@ import 'package:meta/meta.dart';
 import '../base.dart';
 import '../mixins/generics.dart';
 import '../visitors.dart';
-import 'code.dart';
 import 'expression.dart';
 import 'reference.dart';
 
@@ -48,10 +47,6 @@ abstract class TypeReference extends Expression
 
   @override
   TypeReference get type => this;
-
-  @override
-  // TODO - annotate with @visibleForOverriding
-  Expression get expression => CodeExpression(Code.scope((a) => a(this)));
 
   @override
   Expression newInstance(


### PR DESCRIPTION
Closes #2371

This API has no practical effect today. As best as I can tell the
intention was to handle differences in what type expressions are allowed
in difference corner's of Dart syntax, and it either never or no longer
serves that purpose correctly.
