### PR TITLE
Handle recursive self-referential collections

### DIFF
--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.4-wip
 
-* Fix a stack overflow in `deepHashCode` when handling self-referential lists.
+* Fix stack overflow when handling self-referential collections.
+  * Fix issue in `deepHashCode` when handling self-referential lists and maps.
+  * Prevent duplicate self-referential collections from being used as keys.
 
 ## 3.1.3
 

--- a/pkgs/yaml/lib/src/equality.dart
+++ b/pkgs/yaml/lib/src/equality.dart
@@ -13,7 +13,7 @@ import 'yaml_node.dart';
 
 /// Returns a [Map] that compares its keys based on [deepEquals].
 Map<K, V> deepEqualsMap<K, V>() =>
-    LinkedHashMap(equals: deepEquals, hashCode: deepHashCode);
+    LinkedHashMap(equals: _DeepEquals().equals, hashCode: _deepHasher);
 
 /// Returns whether two objects are structurally equivalent.
 ///
@@ -100,10 +100,18 @@ class _DeepEquals {
 /// This supports deep equality for maps and lists, including those with
 /// self-referential structures, and returns the same hash code for
 /// [YamlScalar]s and their values.
-int deepHashCode(Object? obj) {
+int deepHashCode(Object? obj) => _deepHasher(obj);
+
+int Function(Object?) get _deepHasher {
   var parents = <Object?>[];
 
   int deepHashCodeInner(Object? value) {
+    if (value is YamlMap && value.isSelfReferential) {
+      return identityHashCode(value);
+    }
+    if (value is YamlList && value.isSelfReferential) {
+      return identityHashCode(value);
+    }
     if (parents.any((parent) => identical(parent, value))) return -1;
 
     parents.add(value);
@@ -125,5 +133,5 @@ int deepHashCode(Object? obj) {
     }
   }
 
-  return deepHashCodeInner(obj);
+  return deepHashCodeInner;
 }

--- a/pkgs/yaml/lib/src/equality.dart
+++ b/pkgs/yaml/lib/src/equality.dart
@@ -103,7 +103,7 @@ class _DeepEquals {
 int deepHashCode(Object? obj) => _deepHasher(obj);
 
 int Function(Object?) get _deepHasher {
-  var parents = <Object?>[];
+  final parents = Set<Object?>.identity();
 
   int deepHashCodeInner(Object? value) {
     if (value is YamlMap && value.isSelfReferential) {
@@ -112,7 +112,7 @@ int Function(Object?) get _deepHasher {
     if (value is YamlList && value.isSelfReferential) {
       return identityHashCode(value);
     }
-    if (parents.any((parent) => identical(parent, value))) return -1;
+    if (parents.contains(value)) return -1;
 
     parents.add(value);
     try {
@@ -129,7 +129,7 @@ int Function(Object?) get _deepHasher {
         return value.hashCode;
       }
     } finally {
-      parents.removeLast();
+      parents.remove(value);
     }
   }
 

--- a/pkgs/yaml/lib/src/loader.dart
+++ b/pkgs/yaml/lib/src/loader.dart
@@ -29,6 +29,9 @@ class Loader {
   /// Aliases by the alias name.
   final _aliases = <String, YamlNode>{};
 
+  /// Anchors that are currently being resolved.
+  final _activeAnchors = <String>{};
+
   /// The span of the entire stream emitted so far.
   FileSpan get span => _span;
   FileSpan _span;
@@ -103,7 +106,16 @@ class Loader {
   /// Composes a node corresponding to an alias.
   YamlNode _loadAlias(AliasEvent event) {
     var alias = _aliases[event.name];
-    if (alias != null) return alias;
+    if (alias != null) {
+      if (_activeAnchors.contains(event.name)) {
+        if (alias is YamlMap) {
+          alias.isSelfReferential = true;
+        } else if (alias is YamlList) {
+          alias.isSelfReferential = true;
+        }
+      }
+      return alias;
+    }
 
     throw YamlException('Undefined alias.', event.span);
   }
@@ -135,10 +147,15 @@ class Loader {
     var node = YamlList.internal(children, firstEvent.span, firstEvent.style);
     _registerAnchor(firstEvent.anchor, node);
 
+    if (firstEvent.anchor case final anchor?) _activeAnchors.add(anchor);
     var event = _parser.parse();
-    while (event.type != EventType.sequenceEnd) {
-      children.add(_loadNode(event));
-      event = _parser.parse();
+    try {
+      while (event.type != EventType.sequenceEnd) {
+        children.add(_loadNode(event));
+        event = _parser.parse();
+      }
+    } finally {
+      if (firstEvent.anchor case final anchor?) _activeAnchors.remove(anchor);
     }
 
     setSpan(node, firstEvent.span.expand(event.span));
@@ -157,16 +174,21 @@ class Loader {
     var node = YamlMap.internal(children, firstEvent.span, firstEvent.style);
     _registerAnchor(firstEvent.anchor, node);
 
+    if (firstEvent.anchor case final anchor?) _activeAnchors.add(anchor);
     var event = _parser.parse();
-    while (event.type != EventType.mappingEnd) {
-      var key = _loadNode(event);
-      var value = _loadNode(_parser.parse());
-      if (children.containsKey(key)) {
-        throw YamlException('Duplicate mapping key.', key.span);
-      }
+    try {
+      while (event.type != EventType.mappingEnd) {
+        var key = _loadNode(event);
+        var value = _loadNode(_parser.parse());
+        if (children.containsKey(key)) {
+          throw YamlException('Duplicate mapping key.', key.span);
+        }
 
-      children[key] = value;
-      event = _parser.parse();
+        children[key] = value;
+        event = _parser.parse();
+      }
+    } finally {
+      if (firstEvent.anchor case final anchor?) _activeAnchors.remove(anchor);
     }
 
     setSpan(node, firstEvent.span.expand(event.span));

--- a/pkgs/yaml/lib/src/yaml_node.dart
+++ b/pkgs/yaml/lib/src/yaml_node.dart
@@ -54,6 +54,9 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
   /// `dynamic` `map.nodes["foo"]` will still work.
   final Map<dynamic, YamlNode> nodes;
 
+  /// Whether this map is self-referential.
+  bool isSelfReferential = false;
+
   /// The style used for the map in the original document.
   final CollectionStyle style;
 
@@ -98,6 +101,9 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
 /// A read-only [List] parsed from YAML.
 class YamlList extends YamlNode with collection.ListMixin {
   final List<YamlNode> nodes;
+
+  /// Whether this list is self-referential.
+  bool isSelfReferential = false;
 
   /// The style used for the list in the original document.
   final CollectionStyle style;

--- a/pkgs/yaml/lib/src/yaml_node_wrapper.dart
+++ b/pkgs/yaml/lib/src/yaml_node_wrapper.dart
@@ -30,6 +30,9 @@ class YamlMapWrapper extends MapBase
   final Map<dynamic, YamlNode> nodes;
 
   @override
+  bool isSelfReferential = false;
+
+  @override
   Map get value => this;
 
   @override
@@ -104,6 +107,9 @@ class YamlListWrapper extends ListBase implements YamlList {
 
   @override
   final List<YamlNode> nodes;
+
+  @override
+  bool isSelfReferential = false;
 
   @override
   List get value => this;

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -1137,6 +1137,60 @@ void main() {
       expect(map[key], 'value');
     });
 
+    test('self-referential map does not cause stack overflow in deepHashcode',
+        () {
+      var doc = loadYaml('&map { *map : *map }');
+      expect(doc, isNotNull);
+      expect(doc, isA<YamlMap>());
+      expect(doc.nodes.keys.first, same(doc));
+      expect(doc.nodes.values.first, same(doc));
+    });
+
+    test(
+      'Throws when duplicate aliases are used as a map key',
+      () {
+        expectYamlFails('&map { *map : hello, *map : there }');
+        expectYamlFails('&list [ { *list : this, *list : next } ]');
+      },
+    );
+
+    test(
+        'self-referential maps with structural equality as keys do not '
+        'throw duplicate key error (deviation from spec)', () {
+      // In a strict YAML parser, this should fail because *map1 and *map2 are
+      // structurally equivalent, resulting in duplicate keys in shouldBeError.
+      // However, because we use identityHashCode for self-referential maps,
+      // they have different hash codes and are not detected as duplicates.
+
+      var map1 = deepEqualsMap();
+      map1[map1] = 'hello';
+
+      var map2 = deepEqualsMap();
+      map2[map2] = 'hello';
+
+      var shouldBeError = deepEqualsMap();
+      shouldBeError[map1] = 'foo';
+      shouldBeError[map2] = 'bar';
+
+      var expected = {
+        'map1': map1,
+        'map2': map2,
+        'shouldBeError': shouldBeError
+      };
+
+      expectYamlLoads(expected, '''
+        map1: &map1 { *map1 : hello }
+        map2: &map2 { *map2 : hello }
+        shouldBeError:
+          ? *map1
+          : foo
+          ? *map2
+          : bar
+      ''');
+    },
+        skip: 'Deviation from spec: duplicate keys not detected for '
+            'structurally equivalent self-referential maps.');
+
     test('[Example 7.1]', () {
       expectYamlLoads({
         'First occurrence': 'Foo',


### PR DESCRIPTION
Closes #2373

Fixes a stack overflow.

The YAML spec requires that map keys use deep equality. When trying to
insert a Map as it's own key, it would try to read the "new keys"
hashCode, which in this case was the `deepHashCode` call, which then
tries to define it's hash code on the new inserted key.

Add an `isSelfReferential` field on `YamlMap` and `YamlList` to track
which collections may introduce a recursive cycle. Use a non-structural
hash code for self-referential collections. This is technically unsafe,
but it's very unlikely that the deviation from the spec will be
observed. Add a skipped test demonstrating the problem where
structurally identical separately defined self-recursive collections may
be used as keys in the same map, despite the YAML spec indicating they
should be considered identical keys.
