### PR TITLE
Support diverting Stdin temporarily

### DIFF
--- a/pkgs/io/CHANGELOG.md
+++ b/pkgs/io/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.1.0-wip
 
 * Add a `deepCopyLinks` argument to `copyPath` and `copyPathSync`.
+* Add a `SharedStdinSubscription` with support for diverting stdin temporarily
+  to a new substream.
 
 ## 1.0.5
 

--- a/pkgs/io/lib/src/shared_stdin.dart
+++ b/pkgs/io/lib/src/shared_stdin.dart
@@ -63,7 +63,7 @@ class SharedStdIn extends Stream<List<int>> {
           sync: true);
 
   @override
-  SharedStdinSubscription listen(
+  SharedStdInSubscription listen(
     void Function(List<int> event)? onData, {
     Function? onError,
     void Function()? onDone,
@@ -79,7 +79,7 @@ class SharedStdIn extends Stream<List<int>> {
           'Subscriber already listening. The existing subscriber must cancel '
           'before another may be added.');
     }
-    return SharedStdinSubscription._(
+    return SharedStdInSubscription._(
       controller.stream.listen(onData,
           onError: onError, onDone: onDone, cancelOnError: cancelOnError),
       onData,
@@ -100,7 +100,7 @@ class SharedStdIn extends Stream<List<int>> {
 }
 
 /// A subscription to [sharedStdIn] that can be temporarily diverted.
-class SharedStdinSubscription implements StreamSubscription<List<int>> {
+class SharedStdInSubscription implements StreamSubscription<List<int>> {
   final StreamSubscription<List<int>> _subscription;
   void Function(List<int>)? _onData;
   void Function()? _onDone;
@@ -108,7 +108,7 @@ class SharedStdinSubscription implements StreamSubscription<List<int>> {
 
   StreamController<List<int>>? _diverted;
 
-  SharedStdinSubscription._(
+  SharedStdInSubscription._(
       this._subscription, this._onData, this._onDone, this._onError);
 
   /// Temporarily diverts events from this stream into a new stream.

--- a/pkgs/io/lib/src/shared_stdin.dart
+++ b/pkgs/io/lib/src/shared_stdin.dart
@@ -79,11 +79,12 @@ class SharedStdIn extends Stream<List<int>> {
           'Subscriber already listening. The existing subscriber must cancel '
           'before another may be added.');
     }
-    return controller.stream._listen(
+    return SharedStdinSubscription._(
+      controller.stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError),
       onData,
       onDone,
       onError,
-      cancelOnError,
     );
   }
 
@@ -182,15 +183,4 @@ class SharedStdinSubscription implements StreamSubscription<List<int>> {
   void resume() {
     _subscription.resume();
   }
-}
-
-extension on Stream<List<int>> {
-  SharedStdinSubscription _listen(void Function(List<int>)? onData,
-          void Function()? onDone, Function? onError, bool? cancelOnError) =>
-      SharedStdinSubscription._(
-          listen(onData,
-              onError: onError, onDone: onDone, cancelOnError: cancelOnError),
-          onData,
-          onDone,
-          onError);
 }

--- a/pkgs/io/lib/src/shared_stdin.dart
+++ b/pkgs/io/lib/src/shared_stdin.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:async/async.dart';
 import 'package:meta/meta.dart';
 
 /// A shared singleton instance of `dart:io`'s [stdin] stream.
@@ -99,12 +98,16 @@ class SharedStdIn extends Stream<List<int>> {
   }
 }
 
-class SharedStdinSubscription extends DelegatingStreamSubscription<List<int>> {
-  final void Function(List<int>)? _onData;
-  final void Function()? _onDone;
-  final Function? _onError;
+class SharedStdinSubscription implements StreamSubscription<List<int>> {
+  final StreamSubscription<List<int>> _subscription;
+  void Function(List<int>)? _onData;
+  void Function()? _onDone;
+  Function? _onError;
+
+  StreamController<List<int>>? _diverted;
+
   SharedStdinSubscription._(
-      super.sourceSubscription, this._onData, this._onDone, this._onError);
+      this._subscription, this._onData, this._onDone, this._onError);
 
   /// Temporarily diverts events from this stream into a new stream.
   ///
@@ -117,23 +120,66 @@ class SharedStdinSubscription extends DelegatingStreamSubscription<List<int>> {
   /// returned stream has a listener both the substream and this stream's
   /// [onDone] callback is invoked.
   Stream<List<int>> divert() {
-    final controller = StreamController<List<int>>(
+    final diverted = _diverted = StreamController<List<int>>(
       onCancel: () {
-        super.onData(_onData);
-        super.onError(_onError);
-        super.onDone(_onDone);
+        _subscription.onData(_onData);
+        _subscription.onError(_onError);
+        _subscription.onDone(_onDone);
+        _diverted = null;
       },
+      onPause: _subscription.pause,
+      onResume: _subscription.resume,
       sync: true,
     );
 
-    super.onData(controller.add);
-    super.onError(controller.addError);
-    super.onDone(() {
-      controller.close();
+    _subscription.onData(diverted.add);
+    _subscription.onError(diverted.addError);
+    _subscription.onDone(() {
+      diverted.close();
       _onDone?.call();
     });
 
-    return controller.stream;
+    return diverted.stream;
+  }
+
+  @override
+  Future<E> asFuture<E>([E? futureValue]) =>
+      _subscription.asFuture(futureValue);
+
+  @override
+  Future<void> cancel() async {
+    await [_diverted?.close(), _subscription.cancel()].nonNulls.wait;
+  }
+
+  @override
+  bool get isPaused => _subscription.isPaused;
+
+  @override
+  void onData(void Function(List<int> data)? handleData) {
+    _onData = handleData;
+    if (_diverted == null) _subscription.onData(handleData);
+  }
+
+  @override
+  void onDone(void Function()? handleDone) {
+    _onDone = handleDone;
+    if (_diverted == null) _subscription.onDone(handleDone);
+  }
+
+  @override
+  void onError(Function? handleError) {
+    _onError = handleError;
+    if (_diverted == null) _subscription.onError(handleError);
+  }
+
+  @override
+  void pause([Future<void>? resumeSignal]) {
+    _subscription.pause(resumeSignal);
+  }
+
+  @override
+  void resume() {
+    _subscription.resume();
   }
 }
 

--- a/pkgs/io/lib/src/shared_stdin.dart
+++ b/pkgs/io/lib/src/shared_stdin.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:async/async.dart';
 import 'package:meta/meta.dart';
 
 /// A shared singleton instance of `dart:io`'s [stdin] stream.
@@ -63,7 +64,7 @@ class SharedStdIn extends Stream<List<int>> {
           sync: true);
 
   @override
-  StreamSubscription<List<int>> listen(
+  SharedStdinSubscription listen(
     void Function(List<int> event)? onData, {
     Function? onError,
     void Function()? onDone,
@@ -79,11 +80,11 @@ class SharedStdIn extends Stream<List<int>> {
           'Subscriber already listening. The existing subscriber must cancel '
           'before another may be added.');
     }
-    return controller.stream.listen(
+    return controller.stream._listen(
       onData,
-      onDone: onDone,
-      onError: onError,
-      cancelOnError: cancelOnError,
+      onDone,
+      onError,
+      cancelOnError,
     );
   }
 
@@ -96,4 +97,53 @@ class SharedStdIn extends Stream<List<int>> {
     await _current?.close();
     _sub = null;
   }
+}
+
+class SharedStdinSubscription extends DelegatingStreamSubscription<List<int>> {
+  final void Function(List<int>)? _onData;
+  final void Function()? _onDone;
+  final Function? _onError;
+  SharedStdinSubscription._(
+      super.sourceSubscription, this._onData, this._onDone, this._onError);
+
+  /// Temporarily diverts events from this stream into a new stream.
+  ///
+  /// Buffers events until the returned stream has a listener. After a listener
+  /// on the returned stream cancels, subsequent events will be delievered to
+  /// the original [onData] callback of this subscription.
+  ///
+  /// While the returned stream has a listener all events an errors are passed
+  /// only to the substream listener's callbacks. If this stream ends while the
+  /// returned stream has a listener both the substream and this stream's
+  /// [onDone] callback is invoked.
+  Stream<List<int>> divert() {
+    final controller = StreamController<List<int>>(
+      onCancel: () {
+        super.onData(_onData);
+        super.onError(_onError);
+        super.onDone(_onDone);
+      },
+      sync: true,
+    );
+
+    super.onData(controller.add);
+    super.onError(controller.addError);
+    super.onDone(() {
+      controller.close();
+      _onDone?.call();
+    });
+
+    return controller.stream;
+  }
+}
+
+extension on Stream<List<int>> {
+  SharedStdinSubscription _listen(void Function(List<int>)? onData,
+          void Function()? onDone, Function? onError, bool? cancelOnError) =>
+      SharedStdinSubscription._(
+          listen(onData,
+              onError: onError, onDone: onDone, cancelOnError: cancelOnError),
+          onData,
+          onDone,
+          onError);
 }

--- a/pkgs/io/lib/src/shared_stdin.dart
+++ b/pkgs/io/lib/src/shared_stdin.dart
@@ -98,6 +98,7 @@ class SharedStdIn extends Stream<List<int>> {
   }
 }
 
+/// A subscription to [sharedStdIn] that can be temporarily diverted.
 class SharedStdinSubscription implements StreamSubscription<List<int>> {
   final StreamSubscription<List<int>> _subscription;
   void Function(List<int>)? _onData;
@@ -112,10 +113,10 @@ class SharedStdinSubscription implements StreamSubscription<List<int>> {
   /// Temporarily diverts events from this stream into a new stream.
   ///
   /// Buffers events until the returned stream has a listener. After a listener
-  /// on the returned stream cancels, subsequent events will be delievered to
+  /// on the returned stream cancels, subsequent events will be delivered to
   /// the original [onData] callback of this subscription.
   ///
-  /// While the returned stream has a listener all events an errors are passed
+  /// While the returned stream has a listener all events and errors are passed
   /// only to the substream listener's callbacks. If this stream ends while the
   /// returned stream has a listener both the substream and this stream's
   /// [onDone] callback is invoked.

--- a/pkgs/io/pubspec.yaml
+++ b/pkgs/io/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  async: ^2.13.0
   meta: ^1.3.0
   path: ^1.8.0
   string_scanner: ^1.1.0

--- a/pkgs/io/pubspec.yaml
+++ b/pkgs/io/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
+  async: ^2.13.0
   meta: ^1.3.0
   path: ^1.8.0
   string_scanner: ^1.1.0

--- a/pkgs/io/test/shared_stdin_test.dart
+++ b/pkgs/io/test/shared_stdin_test.dart
@@ -77,4 +77,36 @@ void main() {
     expect(sharedStdIn.nextLine(), completion('Hello World'));
     fakeStdIn.add('Hello World\n');
   });
+
+  test('should temporarily divert events', () async {
+    final logs = <List<int>>[];
+    final sub = sharedStdIn.listen(logs.add);
+    fakeStdIn.add('a');
+    await pumpEventQueue(times: 0);
+    expect(logs, ['a'.codeUnits]);
+
+    final diverted = sub.divert();
+    fakeStdIn.add('b');
+    await pumpEventQueue(times: 0);
+    expect(logs, ['a'.codeUnits]);
+
+    final divertedLogs = <List<int>>[];
+    final divertedSub = diverted.listen(divertedLogs.add);
+    await pumpEventQueue(times: 0);
+    expect(divertedLogs, ['b'.codeUnits]);
+
+    fakeStdIn.add('c');
+    await pumpEventQueue(times: 0);
+    expect(divertedLogs, ['b'.codeUnits, 'c'.codeUnits]);
+    expect(logs, ['a'.codeUnits]);
+
+    final cancelDone = divertedSub.cancel();
+    fakeStdIn.add('d');
+    await cancelDone;
+    fakeStdIn.add('e');
+    await pumpEventQueue(times: 0);
+    expect(logs, ['a'.codeUnits, 'd'.codeUnits, 'e'.codeUnits]);
+
+    await sub.cancel();
+  });
 }

--- a/pkgs/io/test/shared_stdin_test.dart
+++ b/pkgs/io/test/shared_stdin_test.dart
@@ -109,4 +109,93 @@ void main() {
 
     await sub.cancel();
   });
+
+  test('should allow changing onData while diverted', () async {
+    final logs = <List<int>>[];
+    final sub = sharedStdIn.listen(logs.add);
+    final diverted = sub.divert();
+
+    final newLogs = <List<int>>[];
+    sub.onData(newLogs.add);
+
+    final divertedLogs = <List<int>>[];
+    final divertedSub = diverted.listen(divertedLogs.add);
+
+    fakeStdIn.add('a');
+    await pumpEventQueue(times: 0);
+    expect(divertedLogs, ['a'.codeUnits]);
+    expect(logs, isEmpty);
+    expect(newLogs, isEmpty);
+
+    await divertedSub.cancel();
+    fakeStdIn.add('b');
+    await pumpEventQueue(times: 0);
+    expect(divertedLogs, ['a'.codeUnits]);
+    expect(logs, isEmpty);
+    expect(newLogs, ['b'.codeUnits]);
+
+    await sub.cancel();
+  });
+
+  test('should allow changing onDone while diverted', () async {
+    var doneCalled = false;
+    final sub = sharedStdIn.listen((_) {}, onDone: () {
+      doneCalled = true;
+    });
+    final diverted = sub.divert();
+
+    var newDoneCalled = false;
+    sub.onDone(() {
+      newDoneCalled = true;
+    });
+
+    final divertedSub = diverted.listen((_) {});
+
+    await divertedSub.cancel();
+
+    await sharedStdIn.terminate();
+    await pumpEventQueue(times: 0);
+
+    expect(doneCalled, isFalse);
+    expect(newDoneCalled, isTrue);
+    await sub.cancel();
+  });
+
+  test('should call both onDone if stream closes while diverted', () async {
+    var doneCalled = false;
+    final sub = sharedStdIn.listen((_) {}, onDone: () {
+      doneCalled = true;
+    });
+    final diverted = sub.divert();
+
+    var divertedDoneCalled = false;
+    final divertedSub = diverted.listen((_) {}, onDone: () {
+      divertedDoneCalled = true;
+    });
+
+    await sharedStdIn.terminate();
+    await pumpEventQueue(times: 0);
+
+    expect(doneCalled, isTrue);
+    expect(divertedDoneCalled, isTrue);
+    await divertedSub.cancel();
+    await sub.cancel();
+  });
+
+  test('should handle pausing and resuming while diverted', () async {
+    final sub = sharedStdIn.listen((_) {});
+    final diverted = sub.divert();
+    final divertedSub = diverted.listen((_) {});
+
+    expect(sub.isPaused, isFalse);
+
+    divertedSub.pause();
+    expect(sub.isPaused, isTrue);
+
+    divertedSub.resume();
+    expect(sub.isPaused, isFalse);
+
+    await divertedSub.cancel();
+    await sub.cancel();
+  });
 }

--- a/pkgs/io/test/shared_stdin_test.dart
+++ b/pkgs/io/test/shared_stdin_test.dart
@@ -198,4 +198,31 @@ void main() {
     await divertedSub.cancel();
     await sub.cancel();
   });
+
+  test('should restore custom onData handler set before divert', () async {
+    final logs = <List<int>>[];
+    final sub = sharedStdIn.listen(logs.add);
+
+    final customLogs = <List<int>>[];
+    sub.onData(customLogs.add);
+
+    final diverted = sub.divert();
+    final divertedLogs = <List<int>>[];
+    final divertedSub = diverted.listen(divertedLogs.add);
+
+    fakeStdIn.add('a');
+    await pumpEventQueue(times: 0);
+    expect(divertedLogs, ['a'.codeUnits]);
+    expect(logs, isEmpty);
+    expect(customLogs, isEmpty);
+
+    await divertedSub.cancel();
+    fakeStdIn.add('b');
+    await pumpEventQueue(times: 0);
+    expect(divertedLogs, ['a'.codeUnits]);
+    expect(logs, isEmpty);
+    expect(customLogs, ['b'.codeUnits]);
+
+    await sub.cancel();
+  });
 }


### PR DESCRIPTION
Add a `SharedStdinSubscription` which stores it's callbacks and has a
`divert` method to create a new stream receiving events from stdin in
place of the original listener.
