### PR TITLE
Prefer raw strings when possible

### DIFF
--- a/pkgs/code_builder/lib/src/specs/expression/literal.dart
+++ b/pkgs/code_builder/lib/src/specs/expression/literal.dart
@@ -51,12 +51,12 @@ Expression literalNum(num value) => LiteralExpression._('$value');
 /// Passing `raw: true` is recommended and will become the only option in a
 /// future release.
 Expression literalString(String value, {bool raw = false}) {
-  if (raw) return LiteralExpression._(_escapeString(value));
+  if (raw) return LiteralExpression._(_escapeString(value, preferRaw: raw));
   final escaped = value.replaceAll('\'', '\\\'').replaceAll('\n', '\\n');
   return LiteralExpression._("'$escaped'");
 }
 
-String _escapeString(String value) {
+String _escapeString(String value, {bool preferRaw = false}) {
   final original = value;
   var hasSingleQuote = false;
   var hasDoubleQuote = false;
@@ -83,6 +83,10 @@ String _escapeString(String value) {
     canBeRaw = false;
     return _escapeMap[char] ?? _hexLiteral(char);
   });
+
+  if (preferRaw && canBeRaw && !hasSingleQuote) {
+    return "r'$original'";
+  }
 
   if (canBeRaw && (hasDollar || hasBackslash)) {
     if (!hasSingleQuote) return "r'$original'";

--- a/pkgs/code_builder/test/specs/code/expression_test.dart
+++ b/pkgs/code_builder/test/specs/code/expression_test.dart
@@ -81,11 +81,11 @@ void main() {
 
   group('literalString raw', () {
     test('should emit a simple string', () {
-      expect(literalString(raw: true, 'foo'), equalsDart(r"'foo'"));
+      expect(literalString(raw: true, 'foo'), equalsDart(r"r'foo'"));
     });
 
     test('should emit an empty string', () {
-      expect(literalString(raw: true, ''), equalsDart("''"));
+      expect(literalString(raw: true, ''), equalsDart(r"r''"));
     });
 
     test('should use double quotes for just a single quote', () {
@@ -93,7 +93,7 @@ void main() {
     });
 
     test('should use single quotes for just a double quote', () {
-      expect(literalString(raw: true, '"'), equalsDart("'\"'"));
+      expect(literalString(raw: true, '"'), equalsDart("r'\"'"));
     });
 
     test('should use raw string for a single backslash', () {
@@ -101,7 +101,7 @@ void main() {
     });
 
     test('should emit unicode characters', () {
-      expect(literalString(raw: true, '😊'), equalsDart("'😊'"));
+      expect(literalString(raw: true, '😊'), equalsDart(r"r'😊'"));
     });
 
     test('should escape a carriage return in a string', () {
@@ -122,7 +122,7 @@ void main() {
     test('should use single quotes if it contains double quotes', () {
       expect(
         literalString(raw: true, 'foo "bar"'),
-        equalsDart('\'foo "bar"\''),
+        equalsDart("r'foo \"bar\"'"),
       );
     });
 


### PR DESCRIPTION
In #2357 we added more complex escaping to allow creating safe string
literals even when they may include single quote characters. The new
implementation didn't prefer raw strings by default so use existing uses
changed behavior and some tests which hardcode expected generated output
a non-behavior impacting diff appears.

Prefer to use actual prefixed raw strings when there are no single
quotes. Existing callers passing strings allowed by the old
implementation will not be impacted by the change. In the next steps of
the migration calling sites will only see a behavior difference as they
change their arguments. In the end all tests will be migrated to the
code path which doesn't prefer raw prefixed strings, but the incremental
changes will only impact tests when library code is changing.
