### PR TITLE
[benchmark_harness] add support for detailed measurement with CV%

### DIFF
--- a/pkgs/benchmark_harness/CHANGELOG.md
+++ b/pkgs/benchmark_harness/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2.5.0
+
+- Added an opt-in detailed measurement path for benchmarks where one
+  `run()` is at or above the timer noise floor (~100 µs).
+  - `BenchmarkBase.measureDetailed({minimumMillis})` returns a new
+    `DetailedMeasurement` that retains every per-call elapsed time and
+    exposes `meanMicros`, `medianMicros`, `minMicros`, `stddevMicros`,
+    and `coefficientOfVariation`.
+  - `BenchmarkBase.reportDetailed({minimumMillis})` prints the mean,
+    median, coefficient of variation, sample count, and minimum to
+    stdout via a new top-level `printDetailedMeasurement(name,
+    measurement)` helper.
+  - The detailed path bypasses any `exercise` override and times each
+    `run()` call individually, so the reported mean is per `run()`, not
+    per batch of 10.
+- Existing APIs (`measure`, `report`, `Measurement`, `PrintEmitter`,
+  `PrintEmitterV2`, `ScoreEmitter`, `ScoreEmitterV2`) are unchanged.
+
 ## 2.4.0
 
 - Added a `bench` command.

--- a/pkgs/benchmark_harness/README.md
+++ b/pkgs/benchmark_harness/README.md
@@ -146,8 +146,8 @@ JsonParse: avg=4.812 ms · median=4.785 ms · CV=2.13% · samples=415 · min=4.7
 is bypassed), so the printed mean is *per `run()` call*, not per 10
 calls. The default time budget is 2 seconds; pass
 `reportDetailed(minimumMillis: 10000)` to collect more samples on slow
-benchmarks. CV computed from very few samples carries large uncertainty
-— aim for at least a few dozen.
+benchmarks. CV computed from very few samples carries large uncertainty,
+so aim for at least a few dozen.
 
 For custom rendering (JSON, CSV, etc.), call `measureDetailed()` and
 format the returned `DetailedMeasurement` (which exposes `samples`,

--- a/pkgs/benchmark_harness/README.md
+++ b/pkgs/benchmark_harness/README.md
@@ -115,6 +115,45 @@ This is the average amount of time it takes to run `run()` 10 times for
 `BenchmarkBase` and once for `AsyncBenchmarkBase`.
 > `us` is an abbreviation for microseconds.
 
+## Detailed measurement (CV%)
+
+For benchmarks where one `run()` is comfortably above the timer noise
+floor (≥ ~100 µs, typically ms-scale), `BenchmarkBase` exposes
+`reportDetailed()` which times each `run()` call individually and emits a
+median, coefficient of variation, sample count, and minimum sample
+alongside the mean. Use it to gauge how stable a measurement is.
+
+```dart
+class JsonParse extends BenchmarkBase {
+  const JsonParse() : super('JsonParse');
+
+  @override
+  void run() {
+    // ~5 ms of work
+  }
+}
+
+void main() {
+  const JsonParse().reportDetailed();
+}
+```
+
+```console
+JsonParse: avg=4.812 ms · median=4.785 ms · CV=2.13% · samples=415 · min=4.703 ms
+```
+
+`reportDetailed` always calls `run()` directly (any `exercise` override
+is bypassed), so the printed mean is *per `run()` call*, not per 10
+calls. The default time budget is 2 seconds; pass
+`reportDetailed(minimumMillis: 10000)` to collect more samples on slow
+benchmarks. CV computed from very few samples carries large uncertainty
+— aim for at least a few dozen.
+
+For custom rendering (JSON, CSV, etc.), call `measureDetailed()` and
+format the returned `DetailedMeasurement` (which exposes `samples`,
+`meanMicros`, `medianMicros`, `minMicros`, `stddevMicros`,
+`coefficientOfVariation`) yourself.
+
 ## `bench` command
 
 A convenience command available in `package:benchmark_harness`.

--- a/pkgs/benchmark_harness/example/cv_example.dart
+++ b/pkgs/benchmark_harness/example/cv_example.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+/// A benchmark whose `run()` takes ~5 ms, well above the timer noise floor.
+/// Demonstrates [BenchmarkBase.reportDetailed] surfacing CV% and the
+/// number of samples that fed it.
+class SlowSineSum extends BenchmarkBase {
+  const SlowSineSum() : super('SlowSineSum');
+
+  @override
+  void run() {
+    var x = 0.0;
+    for (var i = 0; i < 200000; i++) {
+      x += math.sin(i.toDouble());
+    }
+    if (x.isNaN) print('unreachable');
+  }
+}
+
+void main() {
+  // Baseline (per-exercise).
+  const SlowSineSum().report();
+  // Per-run, with detailed statistics.
+  const SlowSineSum().reportDetailed();
+}

--- a/pkgs/benchmark_harness/lib/benchmark_harness.dart
+++ b/pkgs/benchmark_harness/lib/benchmark_harness.dart
@@ -4,4 +4,12 @@
 
 export 'src/async_benchmark_base.dart';
 export 'src/benchmark_base.dart' show BenchmarkBase;
-export 'src/score_emitter.dart';
+export 'src/measurement.dart'
+    show DetailedMeasurement, Measurement, measureRunsDirect;
+export 'src/score_emitter.dart'
+    show
+        PrintEmitter,
+        PrintEmitterV2,
+        ScoreEmitter,
+        ScoreEmitterV2,
+        printDetailedMeasurement;

--- a/pkgs/benchmark_harness/lib/src/benchmark_base.dart
+++ b/pkgs/benchmark_harness/lib/src/benchmark_base.dart
@@ -98,9 +98,7 @@ class BenchmarkBase {
   /// See [measureDetailed] for guidance on selecting [minimumMillis].
   /// The budget should be chosen so enough samples are collected for the
   /// CV to be trustworthy; CV computed from few samples is not reliable.
-  void reportDetailed({
-    int minimumMillis = minimumMeasureDurationMillis,
-  }) {
+  void reportDetailed({int minimumMillis = minimumMeasureDurationMillis}) {
     printDetailedMeasurement(
       name,
       measureDetailed(minimumMillis: minimumMillis),

--- a/pkgs/benchmark_harness/lib/src/benchmark_base.dart
+++ b/pkgs/benchmark_harness/lib/src/benchmark_base.dart
@@ -56,7 +56,54 @@ class BenchmarkBase {
     return result.score;
   }
 
+  /// Measures the benchmark by timing each [run] call individually for
+  /// at least [minimumMillis] milliseconds.
+  ///
+  /// Bypasses any [exercise] override (always calls [run] directly). The
+  /// reported score is per-[run], so it will be ~10x smaller than [measure]
+  /// with the default [exercise]. Recommended for benchmarks where one
+  /// [run] takes at least about a hundred microseconds; for faster
+  /// benchmarks the per-call stopwatch overhead distorts results.
+  ///
+  /// **Choosing [minimumMillis]:** sample count is approximately
+  /// `minimumMillis / per-run-time`. The CV estimator's own error scales
+  /// roughly as `1 / sqrt(2 * (n - 1))`, so a CV computed from only a
+  /// handful of samples carries large uncertainty and is not a reliable
+  /// indicator of stability. Aim for at least a few dozen samples for a
+  /// trustworthy CV. The default of [minimumMeasureDurationMillis] is
+  /// appropriate for benchmarks where one [run] takes a few tens of
+  /// milliseconds or less; for slower benchmarks pick a larger budget so
+  /// enough samples are collected (e.g., a 200 ms `run` needs ~6 s for
+  /// 30 samples; a 1 s `run` needs ~30 s).
+  DetailedMeasurement measureDetailed({
+    int minimumMillis = minimumMeasureDurationMillis,
+  }) {
+    setup();
+    // Warmup for at least 100ms. Discard result.
+    measureForImpl(warmup, 100);
+    final result = measureRunsDirect(run, minimumMillis);
+    teardown();
+    return result;
+  }
+
   void report() {
     emitter.emit(name, measure());
+  }
+
+  /// Like [report], but prints the per-[run] mean alongside CV%, sample
+  /// count, and min via [printDetailedMeasurement]. Ignores [emitter];
+  /// callers wanting a custom rendering should use [measureDetailed]
+  /// directly and format the returned [DetailedMeasurement] themselves.
+  ///
+  /// See [measureDetailed] for guidance on selecting [minimumMillis] —
+  /// the budget should be chosen so enough samples are collected for the
+  /// CV to be trustworthy; CV computed from few samples is not reliable.
+  void reportDetailed({
+    int minimumMillis = minimumMeasureDurationMillis,
+  }) {
+    printDetailedMeasurement(
+      name,
+      measureDetailed(minimumMillis: minimumMillis),
+    );
   }
 }

--- a/pkgs/benchmark_harness/lib/src/benchmark_base.dart
+++ b/pkgs/benchmark_harness/lib/src/benchmark_base.dart
@@ -95,8 +95,8 @@ class BenchmarkBase {
   /// callers wanting a custom rendering should use [measureDetailed]
   /// directly and format the returned [DetailedMeasurement] themselves.
   ///
-  /// See [measureDetailed] for guidance on selecting [minimumMillis] —
-  /// the budget should be chosen so enough samples are collected for the
+  /// See [measureDetailed] for guidance on selecting [minimumMillis].
+  /// The budget should be chosen so enough samples are collected for the
   /// CV to be trustworthy; CV computed from few samples is not reliable.
   void reportDetailed({
     int minimumMillis = minimumMeasureDurationMillis,

--- a/pkgs/benchmark_harness/lib/src/measurement.dart
+++ b/pkgs/benchmark_harness/lib/src/measurement.dart
@@ -56,10 +56,7 @@ Measurement measureForImpl(void Function() f, int minimumMillis) {
 /// Intended for benchmarks where one [run] call clears the timer noise
 /// floor (a hundred microseconds or more). Below that, stopwatch
 /// overhead and timer quantization distort both score and CV.
-DetailedMeasurement measureRunsDirect(
-  void Function() run,
-  int minimumMillis,
-) {
+DetailedMeasurement measureRunsDirect(void Function() run, int minimumMillis) {
   final minimumMicros = minimumMillis * 1000;
   final samples = <int>[];
   final watch = Stopwatch()..start();

--- a/pkgs/benchmark_harness/lib/src/measurement.dart
+++ b/pkgs/benchmark_harness/lib/src/measurement.dart
@@ -36,6 +36,44 @@ Measurement measureForImpl(void Function() f, int minimumMillis) {
   }
 }
 
+/// Measures [run] by timing each call individually until total elapsed
+/// time reaches [minimumMillis] milliseconds.
+///
+/// The returned [DetailedMeasurement] carries one timing per call. The
+/// score is the per-[run] mean (in microseconds), so it will be smaller
+/// than [measureForImpl] applied to a default `exercise` (which batches
+/// 10 runs per iteration).
+///
+/// Sample count is determined entirely by the time budget. The loop
+/// never extends past [minimumMillis] to chase a sample-count target.
+/// A CV% computed from only a handful of samples is not statistically
+/// reliable, so callers should pick [minimumMillis] so that
+/// `minimumMillis / expected per-run time` produces enough samples
+/// (a few dozen as a rule of thumb).
+///
+/// Intended for benchmarks where one [run] call clears the timer noise
+/// floor (a hundred microseconds or more). Below that, stopwatch
+/// overhead and timer quantization distort both score and CV.
+DetailedMeasurement measureRunsDirect(
+  void Function() run,
+  int minimumMillis,
+) {
+  final minimumMicros = minimumMillis * 1000;
+  final samples = <int>[];
+  final watch = Stopwatch()..start();
+  var lastUs = 0;
+  // Loop until the time budget is met AND there are at least 2 samples,
+  // since sample stddev (n-1) is undefined for a single sample. This
+  // matters when one [run] takes longer than [minimumMillis].
+  while (lastUs < minimumMicros || samples.length < 2) {
+    run();
+    final now = watch.elapsedMicroseconds;
+    samples.add(now - lastUs);
+    lastUs = now;
+  }
+  return DetailedMeasurement(samples);
+}
+
 class Measurement {
   Measurement(this.elapsedMicros, this.iterations, this.totalIterations);
 
@@ -54,6 +92,63 @@ class Measurement {
 
   @override
   String toString() => '$elapsedMicros in $iterations iterations';
+}
+
+/// A measurement that retains the per-call elapsed time of every call
+/// to the benchmark function, enabling derived statistics.
+class DetailedMeasurement {
+  DetailedMeasurement(this.samples) : assert(samples.length >= 2);
+
+  /// Per-call elapsed time in microseconds, one entry per call.
+  final List<int> samples;
+
+  /// Smallest sample in microseconds. The fastest observed call.
+  int get minMicros {
+    var lo = samples[0];
+    for (final v in samples) {
+      if (v < lo) lo = v;
+    }
+    return lo;
+  }
+
+  /// Median of [samples] in microseconds. For an even sample count,
+  /// this is the average of the two middle values.
+  ///
+  /// More robust than [meanMicros] when the distribution has a tail
+  /// (e.g., occasional GC pauses) — the typical-case run time.
+  double get medianMicros {
+    final sorted = List<int>.from(samples)..sort();
+    final n = sorted.length;
+    if (n.isOdd) return sorted[n ~/ 2].toDouble();
+    return (sorted[n ~/ 2 - 1] + sorted[n ~/ 2]) / 2;
+  }
+
+  /// Mean of [samples] in microseconds.
+  double get meanMicros {
+    var sum = 0;
+    for (final v in samples) {
+      sum += v;
+    }
+    return sum / samples.length;
+  }
+
+  /// Sample standard deviation (n-1) of [samples] in microseconds.
+  double get stddevMicros {
+    final m = meanMicros;
+    var sq = 0.0;
+    for (final v in samples) {
+      final d = v - m;
+      sq += d * d;
+    }
+    return math.sqrt(sq / (samples.length - 1));
+  }
+
+  /// Coefficient of variation (stddev / mean), expressed as a percentage.
+  /// Always computable from at least two samples. Callers should decide
+  /// whether the value is meaningful: it is unreliable when the per-call
+  /// mean is near the timer noise floor or when very few samples were
+  /// collected.
+  double get coefficientOfVariation => stddevMicros / meanMicros * 100;
 }
 
 int _roundDownToMillisecond(int micros) => (micros ~/ 1000) * 1000;

--- a/pkgs/benchmark_harness/lib/src/measurement.dart
+++ b/pkgs/benchmark_harness/lib/src/measurement.dart
@@ -44,8 +44,10 @@ Measurement measureForImpl(void Function() f, int minimumMillis) {
 /// than [measureForImpl] applied to a default `exercise` (which batches
 /// 10 runs per iteration).
 ///
-/// Sample count is determined entirely by the time budget. The loop
-/// never extends past [minimumMillis] to chase a sample-count target.
+/// Sample count is determined by the time budget. In the rare case
+/// where a single [run] call exceeds [minimumMillis], the loop continues
+/// until at least 2 samples are collected, the minimum required for
+/// [DetailedMeasurement.stddevMicros] to be defined.
 /// A CV% computed from only a handful of samples is not statistically
 /// reliable, so callers should pick [minimumMillis] so that
 /// `minimumMillis / expected per-run time` produces enough samples
@@ -115,7 +117,7 @@ class DetailedMeasurement {
   /// this is the average of the two middle values.
   ///
   /// More robust than [meanMicros] when the distribution has a tail
-  /// (e.g., occasional GC pauses) — the typical-case run time.
+  /// (e.g., occasional GC pauses), giving the typical-case run time.
   double get medianMicros {
     final sorted = List<int>.from(samples)..sort();
     final n = sorted.length;

--- a/pkgs/benchmark_harness/lib/src/score_emitter.dart
+++ b/pkgs/benchmark_harness/lib/src/score_emitter.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'measurement.dart';
+
 abstract class ScoreEmitter {
   void emit(String testName, double value);
 }
@@ -43,4 +45,26 @@ class PrintEmitterV2 implements ScoreEmitterV2 {
   }) {
     print(['$testName($metric):', value, if (unit.isNotEmpty) unit].join(' '));
   }
+}
+
+/// Prints [measurement] to stdout in a human-readable format with
+/// average, coefficient of variation, sample count, and minimum sample.
+/// Used by `BenchmarkBase.reportDetailed`; exposed publicly so callers
+/// writing custom rendering paths can reuse the same format or compose
+/// their own.
+void printDetailedMeasurement(
+  String testName,
+  DetailedMeasurement measurement,
+) {
+  final avgMs = (measurement.meanMicros / 1000).toStringAsFixed(3);
+  final medianMs = (measurement.medianMicros / 1000).toStringAsFixed(3);
+  final minMs = (measurement.minMicros / 1000).toStringAsFixed(3);
+  final cv = measurement.coefficientOfVariation.toStringAsFixed(2);
+  print(
+    '$testName: avg=$avgMs ms'
+    ' · median=$medianMs ms'
+    ' · CV=$cv%'
+    ' · samples=${measurement.samples.length}'
+    ' · min=$minMs ms',
+  );
 }

--- a/pkgs/benchmark_harness/pubspec.yaml
+++ b/pkgs/benchmark_harness/pubspec.yaml
@@ -1,5 +1,5 @@
 name: benchmark_harness
-version: 2.4.0
+version: 2.5.0
 description: The official Dart project benchmark harness.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/benchmark_harness
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Abenchmark_harness

--- a/pkgs/benchmark_harness/test/detailed_measurement_test.dart
+++ b/pkgs/benchmark_harness/test/detailed_measurement_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DetailedMeasurement', () {
+    test('mean is the arithmetic mean of samples', () {
+      final m = _withSamples([100, 200, 300, 400, 500]);
+      expect(m.meanMicros, 300);
+    });
+
+    test('min is the smallest sample', () {
+      final m = _withSamples([300, 100, 200, 400]);
+      expect(m.minMicros, 100);
+    });
+
+    test('median picks the middle value for odd counts', () {
+      final m = _withSamples([300, 100, 200, 400, 50]);
+      expect(m.medianMicros, 200);
+    });
+
+    test('median averages the two middle values for even counts', () {
+      final m = _withSamples([10, 30, 20, 40]);
+      expect(m.medianMicros, 25);
+    });
+
+    test('stddev uses Bessel correction (n-1)', () {
+      // Hand-computed: samples [2,4,4,4,5,5,7,9] have mean 5,
+      // sum of squared deviations = 32, variance = 32/7, stddev ~= 2.138.
+      final m = _withSamples([2, 4, 4, 4, 5, 5, 7, 9]);
+      expect(m.stddevMicros, closeTo(2.138, 0.01));
+    });
+
+    test('coefficient of variation is stddev/mean*100', () {
+      final m = _withSamples(
+        List.generate(50, (i) => 1000 + (i % 5) * 10),
+      );
+      final expected = m.stddevMicros / m.meanMicros * 100;
+      expect(m.coefficientOfVariation, closeTo(expected, 1e-9));
+    });
+
+    test('coefficientOfVariation computes from any 2+ samples', () {
+      // Math is honest regardless of how many samples there are; gating
+      // is a display-level concern handled by callers.
+      final m = _withSamples([10, 20, 30]);
+      expect(m.coefficientOfVariation, isNonNegative);
+    });
+  });
+
+  group('measureRunsDirect', () {
+    test('records one sample per call and stops at the time budget', () {
+      var calls = 0;
+      final stopwatch = Stopwatch()..start();
+      final m = measureRunsDirect(() => calls++, 50);
+      stopwatch.stop();
+      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(50));
+      expect(m.samples, isNotEmpty);
+      expect(m.samples.length, calls);
+    });
+
+    test('produces a non-empty samples list', () {
+      final m = measureRunsDirect(() {}, 20);
+      expect(m.samples, isNotEmpty);
+    });
+
+    test('returns at least 2 samples even when run > minimumMillis', () {
+      // Each call sleep-busy-waits ~30 ms; budget is 10 ms. Without the
+      // 2-sample floor this would return 1 sample and the stddev would
+      // be undefined.
+      final m = measureRunsDirect(
+        () {
+          final sw = Stopwatch()..start();
+          while (sw.elapsedMilliseconds < 30) {}
+        },
+        10,
+      );
+      expect(m.samples.length, greaterThanOrEqualTo(2));
+    });
+  });
+}
+
+DetailedMeasurement _withSamples(List<int> samples) =>
+    DetailedMeasurement(samples);

--- a/pkgs/benchmark_harness/test/detailed_measurement_test.dart
+++ b/pkgs/benchmark_harness/test/detailed_measurement_test.dart
@@ -35,9 +35,7 @@ void main() {
     });
 
     test('coefficient of variation is stddev/mean*100', () {
-      final m = _withSamples(
-        List.generate(50, (i) => 1000 + (i % 5) * 10),
-      );
+      final m = _withSamples(List.generate(50, (i) => 1000 + (i % 5) * 10));
       final expected = m.stddevMicros / m.meanMicros * 100;
       expect(m.coefficientOfVariation, closeTo(expected, 1e-9));
     });
@@ -70,13 +68,10 @@ void main() {
       // Each call sleep-busy-waits ~30 ms; budget is 10 ms. Without the
       // 2-sample floor this would return 1 sample and the stddev would
       // be undefined.
-      final m = measureRunsDirect(
-        () {
-          final sw = Stopwatch()..start();
-          while (sw.elapsedMilliseconds < 30) {}
-        },
-        10,
-      );
+      final m = measureRunsDirect(() {
+        final sw = Stopwatch()..start();
+        while (sw.elapsedMilliseconds < 30) {}
+      }, 10);
       expect(m.samples.length, greaterThanOrEqualTo(2));
     });
   });


### PR DESCRIPTION
## Summary

Adds an opt-in detailed measurement path to `BenchmarkBase` for benchmarks where one `run()` is comfortably above the timer noise floor (~100 µs, typically ms-scale). Surfaces a coefficient of variation alongside the mean, median, and min so users can gauge stability of their measurements.

This moves the metrics I wrote about [here](https://modulovalue.com/blog/statistical-methods-for-reliable-benchmarks/) from [benchmark_harness_plus](https://pub.dev/packages/benchmark_harness_plus) into the OG benchmark harness!

- `BenchmarkBase.measureDetailed`: returns a new `DetailedMeasurement` with per-call samples, mean, median, min, stddev, and CV.
- `BenchmarkBase.reportDetailed`: prints `name: avg=... ms · median=... ms · CV=...% · samples=N · min=... ms` via the new top-level `printDetailedMeasurement(name, m)` helper.
- The detailed path bypasses `exercise` and times each `run()` directly, so the printed mean is per-`run()`, not per batch of 10.

Existing APIs are unchanged.

## Output example

```console
SlowSineSum(RunTime): 6181.43 us.
SlowSineSum: avg=0.619 ms · median=0.617 ms · CV=1.20% · samples=3231 · min=0.601 ms
```

## What's not included (deliberately)

- `AsyncBenchmarkBase` parity. Left as a follow-up to keep this PR focused on the sync path.
- Magnitude-aware unit formatting. Output is always `ms` for now.

The existing benchmark methodology (i.e. the exercise part and not tracking sample results) is not compatible with a CV% measurement since taking the CV% of averages skews the result, so this does not use the exercise path (which is suboptimal but backward compatible) and runs iterations only without exercises. Should we perhaps have a new BenchmarkBase, a DetailedBenchmarkBase? Open to API feedback.

/cc @kevmoo what do you think?

/cc @munificent FYI added min from your feedback on benchmark harness plus!

/cc @mraleph the primary motivation here is to add support for more meaningful metrics in https://github.com/dart-lang/sdk/tree/main/benchmarks do you see any blindspots?