### PR TITLE
publish cli_util version 0.5.1

### DIFF
--- a/pkgs/cli_util/CHANGELOG.md
+++ b/pkgs/cli_util/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.1-wip
+## 0.5.1
 
 - Add `showMultiSelectDialog` and `showSingleSelectDialog` to new
   `cli_components` library, as well as an example.

--- a/pkgs/cli_util/pubspec.yaml
+++ b/pkgs/cli_util/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.5.1-wip
+version: 0.5.1
 description: A library to help in building Dart command-line apps.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/cli_util
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acli_util


### PR DESCRIPTION
~Looks like this hasn't quite landed in google3 yet but it did pass the smoke test. We can wait for the next Dart roll if we want before landing it though.~

The core changes have landed in google3, minus https://github.com/dart-lang/tools/pull/2399, but those files are not used at all by google3.