### PR TITLE
Mark AnsiCode and AnsiCodeType final

### DIFF
--- a/pkgs/io/CHANGELOG.md
+++ b/pkgs/io/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 1.1.0-wip
 
 * Add a `deepCopyLinks` argument to `copyPath` and `copyPathSync`.
+* **Potentially Breaking** `AnsiCode` and `AnsiCodeType` marked final. These
+  never intended to support subclasses and were already closed for extension
+  with private generative constructors. Mark them `final` to explicitly indicate
+  they should not be used as interfaces either and retain room for more API
+  changes.
 
 ## 1.0.5
 

--- a/pkgs/io/CHANGELOG.md
+++ b/pkgs/io/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 * Add a `deepCopyLinks` argument to `copyPath` and `copyPathSync`.
 * **Potentially Breaking** `AnsiCode` and `AnsiCodeType` marked final. These
-  never intended to support subclasses and were already closed for extension
-  with private generative constructors. Mark them `final` to explicitly indicate
-  they should not be used as interfaces either and retain room for more API
-  changes.
+  were never intended to support subclasses and were already closed for
+  extension with private generative constructors. They are now marked `final`
+  and statically restricted from use as an interface.
 
 ## 1.0.5
 

--- a/pkgs/io/lib/src/ansi_code.dart
+++ b/pkgs/io/lib/src/ansi_code.dart
@@ -34,7 +34,7 @@ T overrideAnsiOutput<T>(bool enableAnsiOutput, T Function() body) =>
     runZoned(body, zoneValues: <Object, Object>{AnsiCode: enableAnsiOutput});
 
 /// The type of code represented by [AnsiCode].
-class AnsiCodeType {
+final class AnsiCodeType {
   final String _name;
 
   /// A foreground color.
@@ -58,7 +58,7 @@ class AnsiCodeType {
 /// Standard ANSI escape code for customizing terminal text output.
 ///
 /// [Source](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
-class AnsiCode {
+final class AnsiCode {
   /// The numeric value associated with this code.
   final int code;
 


### PR DESCRIPTION
As discussed in #2297

Eagerly mark these as final to disallow `implements` before landing
changes to the API.

An internal test run confirmed no google3 use cases rely on the
capability.
