### PR TITLE
[api_summary] Include mixins in textual API summaries

### DIFF
--- a/pkgs/api_summary/lib/src/api_description.dart
+++ b/pkgs/api_summary/lib/src/api_description.dart
@@ -260,6 +260,7 @@ class ApiDescription {
           case InterfaceElement(
             :final typeParameters,
             :final supertype,
+            :final mixins,
             :final interfaces,
           ):
             final instanceDescription = <Object?>[
@@ -283,6 +284,11 @@ class ApiDescription {
                 ' extends ',
                 ..._describeType(supertype),
               ]);
+            }
+            if (mixins.isNotEmpty) {
+              instanceDescription.addAll(
+                mixins.map(_describeType).separatedBy(prefix: ' with '),
+              );
             }
             if (element is MixinElement &&
                 element.superclassConstraints.isNotEmpty) {

--- a/pkgs/api_summary/test/api_description_test.dart
+++ b/pkgs/api_summary/test/api_description_test.dart
@@ -36,6 +36,28 @@ class Foo {}
     super.setUp();
   }
 
+  Future<void> test_class_mixins() async {
+    final summary = await _build({
+      '$testPackageLibPath/file.dart': '''
+mixin M1 {}
+mixin M2 {}
+class C1 extends Object with M1 {}
+class C2 extends Object with M2 implements M1 {}
+''',
+    });
+    expect(summary, '''
+package:test/file.dart:
+  C1 (class extends Object with M1):
+    new (constructor: C1 Function())
+  C2 (class extends Object with M2 implements M1):
+    new (constructor: C2 Function())
+  M1 (mixin on Object)
+  M2 (mixin on Object)
+dart:core:
+  Object (referenced)
+''');
+  }
+
   Future<void> test_class_modifiers() async {
     final summary = await _build({
       '$testPackageLibPath/file.dart': '''


### PR DESCRIPTION
Fixes an issue where with mixin clauses were omitted when generating textual API summaries for class and interface declarations.

Ports over https://github.com/dart-lang/sdk/commit/1e8a9d5d45a82d43b06926430f2e0420eed43880
