### PR TITLE
Support forward slashes in executable paths on Windows

### DIFF
--- a/pkgs/process/CHANGELOG.md
+++ b/pkgs/process/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.0.6-wip
 
 * Add an example app.
+* Fix `getExecutablePath()` to support forward slashes on Windows.
 
 ## 5.0.5
 

--- a/pkgs/process/lib/src/interface/common.dart
+++ b/pkgs/process/lib/src/interface/common.dart
@@ -60,15 +60,22 @@ String? getExecutablePath(
     extensions = platform.environment['PATHEXT']!.split(pathSeparator);
   }
 
-  List<String> candidates = <String>[];
-  List<String> searchPath;
-  if (executable.contains(context.separator)) {
-    // Deal with commands that specify a relative or absolute path differently.
-    searchPath = <String>[workingDirectory];
-  } else {
-    searchPath = platform.environment['PATH']!.split(pathSeparator);
+  bool executableContainsSeparator = executable.contains(context.separator);
+
+  // On Windows both '/' and '\' are valid path separators. Normalize to '\'
+  // so that path operations are consistent.
+  if (platform.isWindows && executable.contains('/')) {
+    executableContainsSeparator = true;
+    executable = context.normalize(executable);
   }
-  candidates = _getCandidatePaths(executable, searchPath, extensions, context);
+
+  // Deal with commands that specify a relative or absolute path differently.
+  final List<String> searchPath = executableContainsSeparator
+      ? <String>[workingDirectory]
+      : platform.environment['PATH']!.split(pathSeparator);
+
+  final List<String> candidates =
+      _getCandidatePaths(executable, searchPath, extensions, context);
   final List<String> foundCandidates = <String>[];
   for (final String path in candidates) {
     final File candidate = fs.file(path);

--- a/pkgs/process/test/src/interface/common_test.dart
+++ b/pkgs/process/test/src/interface/common_test.dart
@@ -125,7 +125,7 @@ void main() {
       });
 
       test('in subdir of work dir', () {
-        String command = fs.path.join('.', 'foo', 'bla.exe');
+        String command = fs.path.join('foo', 'bla.exe');
         final String expectedPath = fs.path.join(workingDir.path, command);
         fs.file(expectedPath).createSync(recursive: true);
 
@@ -140,6 +140,45 @@ void main() {
         command = fs.path.withoutExtension(command);
         executablePath = getExecutablePath(
           command,
+          workingDir.path,
+          platform: platform,
+          fs: fs,
+        );
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('in subdir of work dir with forward slashes', () {
+        String command = fs.path.join('foo', 'bla.exe');
+        final String expectedPath = fs.path.join(workingDir.path, command);
+        fs.file(expectedPath).createSync(recursive: true);
+
+        String? executablePath = getExecutablePath(
+          'foo/bla.exe',
+          workingDir.path,
+          platform: platform,
+          fs: fs,
+        );
+        _expectSamePath(executablePath, expectedPath);
+
+        command = fs.path.withoutExtension(command);
+        executablePath = getExecutablePath(
+          command,
+          workingDir.path,
+          platform: platform,
+          fs: fs,
+        );
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('absolute path with forward slashes', () {
+        // Windows supports absolute paths with '/' separators.
+        final String expectedPath = fs.path.join(dir3.path, 'bla.exe');
+        fs.file(expectedPath).createSync();
+        final String commandWithForwardSlashes =
+            expectedPath.replaceAll('\\', '/');
+
+        final String? executablePath = getExecutablePath(
+          commandWithForwardSlashes,
           workingDir.path,
           platform: platform,
           fs: fs,

--- a/pkgs/process/test/src/interface/common_test.dart
+++ b/pkgs/process/test/src/interface/common_test.dart
@@ -160,9 +160,8 @@ void main() {
         );
         _expectSamePath(executablePath, expectedPath);
 
-        command = fs.path.withoutExtension(command);
         executablePath = getExecutablePath(
-          command,
+          'foo/bla',
           workingDir.path,
           platform: platform,
           fs: fs,


### PR DESCRIPTION
`getExecutablePath` did not work on Windows if the `executable` argument contained forward slashes.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
