### PR TITLE
Add parameter to track detected AI agent string

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 8.0.15
 - Added IDE and plugin information to `Event.serverSession`.
 - Discard any `Exception` or `Error` thrown while reading or writing analytics logs.
+- Added `agent` parameter to `Analytics` constructors to track the AI coding assistant/agent executing the tool.
 
 ## 8.0.14
 - Added HCPP related analytics to `Event.commandUsageValues`.

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -40,6 +40,10 @@ abstract class Analytics {
   /// any features that are enabled for a user. For example,
   /// "enable-linux-desktop,cli-animations" are two features that can be enabled
   /// for the flutter-tool.
+  ///
+  /// [agent] is an optional parameter to capture the name of any AI coding
+  /// assistant/agent executing the tool. Examples include "Claude Code",
+  /// "Cursor", or "Copilot".
   factory Analytics({
     required DashTool tool,
     required String dartVersion,
@@ -47,6 +51,7 @@ abstract class Analytics {
     String? flutterVersion,
     String? clientIde,
     String? enabledFeatures,
+    String? agent,
     bool enableAsserts = false,
   }) {
     // Create the instance of the file system so clients don't need
@@ -97,6 +102,7 @@ abstract class Analytics {
       enableAsserts: enableAsserts,
       clientIde: clientIde,
       enabledFeatures: enabledFeatures,
+      agent: agent,
       firstRun: firstRun,
     );
   }
@@ -117,6 +123,7 @@ abstract class Analytics {
     String? flutterVersion,
     String? clientIde,
     String? enabledFeatures,
+    String? agent,
     bool enableAsserts = true,
   }) {
     // Create the instance of the file system so clients don't need
@@ -176,6 +183,7 @@ abstract class Analytics {
       enableAsserts: enableAsserts,
       clientIde: clientIde,
       enabledFeatures: enabledFeatures,
+      agent: agent,
       firstRun: firstRun,
     );
   }
@@ -297,6 +305,7 @@ abstract class Analytics {
     String? flutterVersion,
     String? clientIde,
     String? enabledFeatures,
+    String? agent,
     SurveyHandler? surveyHandler,
     GAClient? gaClient,
     DevicePlatform platform = DevicePlatform.linux,
@@ -326,6 +335,7 @@ abstract class Analytics {
       gaClient: gaClient ?? const FakeGAClient(),
       clientIde: clientIde,
       enabledFeatures: enabledFeatures,
+      agent: agent,
       firstRun: firstRun,
       enableAsserts: enableAsserts,
     );
@@ -389,6 +399,7 @@ class AnalyticsImpl implements Analytics {
     required SurveyHandler surveyHandler,
     required bool enableAsserts,
     required bool firstRun,
+    String? agent,
   }) : _gaClient = gaClient,
        _surveyHandler = surveyHandler,
        _enableAsserts = enableAsserts,
@@ -412,6 +423,7 @@ class AnalyticsImpl implements Analytics {
          ),
          locale: io.Platform.localeName,
          clientIde: clientIde,
+         aiAgent: agent,
        ),
        _enabledFeatures = enabledFeatures,
        _configHandler = ConfigHandler(
@@ -772,6 +784,7 @@ class FakeAnalytics extends AnalyticsImpl {
     super.flutterVersion,
     super.clientIde,
     super.enabledFeatures,
+    super.agent,
     super.toolsMessageVersion = kToolsMessageVersion,
     super.gaClient = const FakeGAClient(),
     super.enableAsserts = true,

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -116,6 +116,10 @@ abstract class Analytics {
   ///
   /// [flutterChannel] and [flutterVersion] are nullable in case the client
   /// using this package is unable to resolve those values.
+  ///
+  /// [agent] is an optional parameter to capture the name of any AI coding
+  /// assistant/agent executing the tool. Examples include "Claude Code",
+  /// "Cursor", or "Copilot".
   factory Analytics.development({
     required DashTool tool,
     required String dartVersion,
@@ -423,7 +427,7 @@ class AnalyticsImpl implements Analytics {
          ),
          locale: io.Platform.localeName,
          clientIde: clientIde,
-         aiAgent: agent,
+         aiAgent: agent != null ? truncateStringToLength(agent, 36) : null,
        ),
        _enabledFeatures = enabledFeatures,
        _configHandler = ConfigHandler(

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -303,7 +303,7 @@ enum AiAgent {
   ///
   /// Returns `null` if no AI agent is detected.
   static String? detectAgentName(Map<String, String> environment) {
-    const String genericAiAgentLabel = 'Generic AI Agent';
+    const genericAiAgentLabel = 'Generic AI Agent';
 
     if (environment.containsKey('CLAUDECODE') ||
         environment.containsKey('CLAUDE_CODE') ||
@@ -315,7 +315,8 @@ enum AiAgent {
       return antigravity.label;
     }
 
-    if (environment.containsKey('GEMINI_AGENT') || environment.containsKey('GEMINI_CLI')) {
+    if (environment.containsKey('GEMINI_AGENT') ||
+        environment.containsKey('GEMINI_CLI')) {
       return gemini.label;
     }
 
@@ -325,7 +326,8 @@ enum AiAgent {
     }
 
     if (environment.keys.any(
-      (String key) => key.startsWith('COPILOT_') || key.startsWith('GITHUB_COPILOT'),
+      (String key) =>
+          key.startsWith('COPILOT_') || key.startsWith('GITHUB_COPILOT'),
     )) {
       return copilot.label;
     }
@@ -335,7 +337,8 @@ enum AiAgent {
       return aider.label;
     }
 
-    if (environment.containsKey('DEVIN') || environment.containsKey('DEVIN_WORKSPACE_ID')) {
+    if (environment.containsKey('DEVIN') ||
+        environment.containsKey('DEVIN_WORKSPACE_ID')) {
       return devin.label;
     }
 
@@ -353,7 +356,8 @@ enum AiAgent {
       return codex.label;
     }
 
-    if (environment.containsKey('OPENCODE') || environment.containsKey('OPENCODE_CLIENT')) {
+    if (environment.containsKey('OPENCODE') ||
+        environment.containsKey('OPENCODE_CLIENT')) {
       return openCode.label;
     }
 
@@ -365,7 +369,7 @@ enum AiAgent {
       return replit.label;
     }
 
-    String? agent = environment['AGENT'];
+    var agent = environment['AGENT'];
     if (agent != null && agent.isNotEmpty) {
       return agent == '1' ? genericAiAgentLabel : agent;
     }

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -276,3 +276,107 @@ enum DevicePlatform {
   final String label;
   const DevicePlatform(this.label);
 }
+
+/// Enumerate options for AI agents supported.
+enum AiAgent {
+  aider('Aider'),
+  amp('Amp'),
+  antigravity('Antigravity'),
+  augment('Augment'),
+  claudeCode('Claude Code'),
+  codex('Codex'),
+  copilot('Copilot'),
+  cursor('Cursor'),
+  devin('Devin'),
+  gemini('Gemini'),
+  openCode('OpenCode'),
+  pi('Pi'),
+  replit('Replit'),
+  genericAiAgent('Generic AI Agent');
+
+  final String label;
+
+  const AiAgent(this.label);
+
+  /// Returns the name of the AI agent executing the tool, if any,
+  /// by parsing the environment variables.
+  ///
+  /// Returns `null` if no AI agent is detected.
+  static String? detectAgentName(Map<String, String> environment) {
+    const String genericAiAgentLabel = 'Generic AI Agent';
+
+    if (environment.containsKey('CLAUDECODE') ||
+        environment.containsKey('CLAUDE_CODE') ||
+        environment.containsKey('CLAUDE_CODE_IS_COWORK')) {
+      return claudeCode.label;
+    }
+
+    if (environment.containsKey('ANTIGRAVITY_AGENT')) {
+      return antigravity.label;
+    }
+
+    if (environment.containsKey('GEMINI_AGENT') || environment.containsKey('GEMINI_CLI')) {
+      return gemini.label;
+    }
+
+    if (environment['TERM_PROGRAM'] == 'cursor' ||
+        environment.keys.any((String key) => key.startsWith('CURSOR_'))) {
+      return cursor.label;
+    }
+
+    if (environment.keys.any(
+      (String key) => key.startsWith('COPILOT_') || key.startsWith('GITHUB_COPILOT'),
+    )) {
+      return copilot.label;
+    }
+
+    if (environment.containsKey('AIDER') ||
+        environment.keys.any((String key) => key.startsWith('AIDER_'))) {
+      return aider.label;
+    }
+
+    if (environment.containsKey('DEVIN') || environment.containsKey('DEVIN_WORKSPACE_ID')) {
+      return devin.label;
+    }
+
+    if (environment.containsKey('AMP_CURRENT_THREAD_ID')) {
+      return amp.label;
+    }
+
+    if (environment.containsKey('AUGMENT_AGENT')) {
+      return augment.label;
+    }
+
+    if (environment.containsKey('CODEX_CI') ||
+        environment.containsKey('CODEX_SANDBOX') ||
+        environment.containsKey('CODEX_THREAD_ID')) {
+      return codex.label;
+    }
+
+    if (environment.containsKey('OPENCODE') || environment.containsKey('OPENCODE_CLIENT')) {
+      return openCode.label;
+    }
+
+    if (environment.containsKey('PI_CODING_AGENT')) {
+      return pi.label;
+    }
+
+    if (environment.containsKey('REPL_ID')) {
+      return replit.label;
+    }
+
+    String? agent = environment['AGENT'];
+    if (agent != null && agent.isNotEmpty) {
+      return agent == '1' ? genericAiAgentLabel : agent;
+    }
+    agent = environment['AI_AGENT'];
+    if (agent != null && agent.isNotEmpty) {
+      return agent == '1' ? genericAiAgentLabel : agent;
+    }
+    if (environment.containsKey('SWE_AGENT')) {
+      return genericAiAgentLabel;
+    }
+
+    return null;
+  }
+}

--- a/pkgs/unified_analytics/lib/src/user_property.dart
+++ b/pkgs/unified_analytics/lib/src/user_property.dart
@@ -21,6 +21,7 @@ class UserProperty {
   final String hostOsVersion;
   final String locale;
   final String? clientIde;
+  final String? aiAgent;
 
   final File sessionFile;
 
@@ -42,6 +43,7 @@ class UserProperty {
     required this.hostOsVersion,
     required this.locale,
     required this.clientIde,
+    required this.aiAgent,
     required this.sessionFile,
   });
 
@@ -159,5 +161,6 @@ class UserProperty {
     'host_os_version': hostOsVersion,
     'locale': locale,
     'client_ide': clientIde,
+    'ai_agent': aiAgent,
   };
 }

--- a/pkgs/unified_analytics/lib/unified_analytics.dart
+++ b/pkgs/unified_analytics/lib/unified_analytics.dart
@@ -4,7 +4,7 @@
 
 export 'src/analytics.dart' show Analytics, FakeAnalytics, NoOpAnalytics;
 export 'src/config_handler.dart' show ToolInfo;
-export 'src/enums.dart' show DashEnvVar, DashTool, AiAgent;
+export 'src/enums.dart' show AiAgent, DashEnvVar, DashTool;
 export 'src/event.dart' show CustomMetrics, Event;
 export 'src/log_handler.dart' show LogFileStats;
 export 'src/survey_handler.dart' show Survey, SurveyButton, SurveyHandler;

--- a/pkgs/unified_analytics/lib/unified_analytics.dart
+++ b/pkgs/unified_analytics/lib/unified_analytics.dart
@@ -4,7 +4,7 @@
 
 export 'src/analytics.dart' show Analytics, FakeAnalytics, NoOpAnalytics;
 export 'src/config_handler.dart' show ToolInfo;
-export 'src/enums.dart' show DashEnvVar, DashTool;
+export 'src/enums.dart' show DashEnvVar, DashTool, AiAgent;
 export 'src/event.dart' show CustomMetrics, Event;
 export 'src/log_handler.dart' show LogFileStats;
 export 'src/survey_handler.dart' show Survey, SurveyButton, SurveyHandler;

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -885,31 +885,94 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
   test('AiAgent.detectAgentName detects AI agents based on environment', () {
     expect(AiAgent.detectAgentName(<String, String>{}), isNull);
 
-    expect(AiAgent.detectAgentName(<String, String>{'CLAUDECODE': '1'}), 'Claude Code');
-    expect(AiAgent.detectAgentName(<String, String>{'CLAUDE_CODE': '1'}), 'Claude Code');
-    expect(AiAgent.detectAgentName(<String, String>{'CLAUDE_CODE_IS_COWORK': '1'}), 'Claude Code');
-    expect(AiAgent.detectAgentName(<String, String>{'ANTIGRAVITY_AGENT': '1'}), 'Antigravity');
-    expect(AiAgent.detectAgentName(<String, String>{'GEMINI_AGENT': '1'}), 'Gemini');
-    expect(AiAgent.detectAgentName(<String, String>{'GEMINI_CLI': '1'}), 'Gemini');
-    expect(AiAgent.detectAgentName(<String, String>{'TERM_PROGRAM': 'cursor'}), 'Cursor');
-    expect(AiAgent.detectAgentName(<String, String>{'CURSOR_APP_VERSION': '1'}), 'Cursor');
-    expect(AiAgent.detectAgentName(<String, String>{'COPILOT_CLI': '1'}), 'Copilot');
-    expect(AiAgent.detectAgentName(<String, String>{'GITHUB_COPILOT': '1'}), 'Copilot');
+    expect(
+      AiAgent.detectAgentName(<String, String>{'CLAUDECODE': '1'}),
+      'Claude Code',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'CLAUDE_CODE': '1'}),
+      'Claude Code',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'CLAUDE_CODE_IS_COWORK': '1'}),
+      'Claude Code',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'ANTIGRAVITY_AGENT': '1'}),
+      'Antigravity',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'GEMINI_AGENT': '1'}),
+      'Gemini',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'GEMINI_CLI': '1'}),
+      'Gemini',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'TERM_PROGRAM': 'cursor'}),
+      'Cursor',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'CURSOR_APP_VERSION': '1'}),
+      'Cursor',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'COPILOT_CLI': '1'}),
+      'Copilot',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'GITHUB_COPILOT': '1'}),
+      'Copilot',
+    );
     expect(AiAgent.detectAgentName(<String, String>{'AIDER': '1'}), 'Aider');
-    expect(AiAgent.detectAgentName(<String, String>{'AIDER_COMMAND': '1'}), 'Aider');
+    expect(
+      AiAgent.detectAgentName(<String, String>{'AIDER_COMMAND': '1'}),
+      'Aider',
+    );
     expect(AiAgent.detectAgentName(<String, String>{'DEVIN': '1'}), 'Devin');
-    expect(AiAgent.detectAgentName(<String, String>{'DEVIN_WORKSPACE_ID': '1'}), 'Devin');
-    expect(AiAgent.detectAgentName(<String, String>{'AMP_CURRENT_THREAD_ID': '1'}), 'Amp');
-    expect(AiAgent.detectAgentName(<String, String>{'AUGMENT_AGENT': '1'}), 'Augment');
+    expect(
+      AiAgent.detectAgentName(<String, String>{'DEVIN_WORKSPACE_ID': '1'}),
+      'Devin',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'AMP_CURRENT_THREAD_ID': '1'}),
+      'Amp',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'AUGMENT_AGENT': '1'}),
+      'Augment',
+    );
     expect(AiAgent.detectAgentName(<String, String>{'CODEX_CI': '1'}), 'Codex');
-    expect(AiAgent.detectAgentName(<String, String>{'OPENCODE': '1'}), 'OpenCode');
-    expect(AiAgent.detectAgentName(<String, String>{'PI_CODING_AGENT': '1'}), 'Pi');
+    expect(
+      AiAgent.detectAgentName(<String, String>{'OPENCODE': '1'}),
+      'OpenCode',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'PI_CODING_AGENT': '1'}),
+      'Pi',
+    );
     expect(AiAgent.detectAgentName(<String, String>{'REPL_ID': '1'}), 'Replit');
-    expect(AiAgent.detectAgentName(<String, String>{'SWE_AGENT': '1'}), 'Generic AI Agent');
-    expect(AiAgent.detectAgentName(<String, String>{'AI_AGENT': '1'}), 'Generic AI Agent');
-    expect(AiAgent.detectAgentName(<String, String>{'AGENT': '1'}), 'Generic AI Agent');
-    expect(AiAgent.detectAgentName(<String, String>{'AGENT': 'MyCustomAgent'}), 'MyCustomAgent');
-    expect(AiAgent.detectAgentName(<String, String>{'AI_AGENT': 'MyCustomAgent'}), 'MyCustomAgent');
+    expect(
+      AiAgent.detectAgentName(<String, String>{'SWE_AGENT': '1'}),
+      'Generic AI Agent',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'AI_AGENT': '1'}),
+      'Generic AI Agent',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'AGENT': '1'}),
+      'Generic AI Agent',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'AGENT': 'MyCustomAgent'}),
+      'MyCustomAgent',
+    );
+    expect(
+      AiAgent.detectAgentName(<String, String>{'AI_AGENT': 'MyCustomAgent'}),
+      'MyCustomAgent',
+    );
   });
 
   test('The minimum session duration should be at least 30 minutes', () {
@@ -1231,11 +1294,9 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
         1,
         reason: 'There should only be one session after the initial send event',
       );
-      expect(
-        firstQuery.flutterChannelCount,
-        {'flutterChannel': 1},
-        reason: 'There should only be one flutter channel logged',
-      );
+      expect(firstQuery.flutterChannelCount, {
+        'flutterChannel': 1,
+      }, reason: 'There should only be one flutter channel logged');
       expect(firstQuery.toolCount, {
         'flutter-tool': 1,
       }, reason: 'There should only be one tool logged');
@@ -1292,11 +1353,10 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // Query the log file stats to verify that there are two tools
     final query = analytics.logFileStats()!;
 
-    expect(
-      query.toolCount,
-      {'flutter-tool': 1, 'dart-tool': 1},
-      reason: 'There should have been two tools in the persisted logs',
-    );
+    expect(query.toolCount, {
+      'flutter-tool': 1,
+      'dart-tool': 1,
+    }, reason: 'There should have been two tools in the persisted logs');
   });
 
   test('Check that log data missing some keys results in null for stats', () {
@@ -1417,11 +1477,9 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // Query the log file stats to verify that there are two tools
     final query = analytics.logFileStats()!;
 
-    expect(
-      query.toolCount,
-      {'dart-tool': 1},
-      reason: 'There should have only been on tool that sent events',
-    );
+    expect(query.toolCount, {
+      'dart-tool': 1,
+    }, reason: 'There should have only been on tool that sent events');
     expect(
       query.flutterChannelCount.isEmpty,
       true,
@@ -1446,11 +1504,9 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       query.sessionCount,
       reason: 'The session should have remained the same',
     );
-    expect(
-      query2.flutterChannelCount,
-      {'flutterChannel': 1},
-      reason: 'The first instance has flutter information initialized',
-    );
+    expect(query2.flutterChannelCount, {
+      'flutterChannel': 1,
+    }, reason: 'The first instance has flutter information initialized');
   });
 
   group('Testing against Google Analytics limitations:', () {

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -882,6 +882,36 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     },
   );
 
+  test('AiAgent.detectAgentName detects AI agents based on environment', () {
+    expect(AiAgent.detectAgentName(<String, String>{}), isNull);
+
+    expect(AiAgent.detectAgentName(<String, String>{'CLAUDECODE': '1'}), 'Claude Code');
+    expect(AiAgent.detectAgentName(<String, String>{'CLAUDE_CODE': '1'}), 'Claude Code');
+    expect(AiAgent.detectAgentName(<String, String>{'CLAUDE_CODE_IS_COWORK': '1'}), 'Claude Code');
+    expect(AiAgent.detectAgentName(<String, String>{'ANTIGRAVITY_AGENT': '1'}), 'Antigravity');
+    expect(AiAgent.detectAgentName(<String, String>{'GEMINI_AGENT': '1'}), 'Gemini');
+    expect(AiAgent.detectAgentName(<String, String>{'GEMINI_CLI': '1'}), 'Gemini');
+    expect(AiAgent.detectAgentName(<String, String>{'TERM_PROGRAM': 'cursor'}), 'Cursor');
+    expect(AiAgent.detectAgentName(<String, String>{'CURSOR_APP_VERSION': '1'}), 'Cursor');
+    expect(AiAgent.detectAgentName(<String, String>{'COPILOT_CLI': '1'}), 'Copilot');
+    expect(AiAgent.detectAgentName(<String, String>{'GITHUB_COPILOT': '1'}), 'Copilot');
+    expect(AiAgent.detectAgentName(<String, String>{'AIDER': '1'}), 'Aider');
+    expect(AiAgent.detectAgentName(<String, String>{'AIDER_COMMAND': '1'}), 'Aider');
+    expect(AiAgent.detectAgentName(<String, String>{'DEVIN': '1'}), 'Devin');
+    expect(AiAgent.detectAgentName(<String, String>{'DEVIN_WORKSPACE_ID': '1'}), 'Devin');
+    expect(AiAgent.detectAgentName(<String, String>{'AMP_CURRENT_THREAD_ID': '1'}), 'Amp');
+    expect(AiAgent.detectAgentName(<String, String>{'AUGMENT_AGENT': '1'}), 'Augment');
+    expect(AiAgent.detectAgentName(<String, String>{'CODEX_CI': '1'}), 'Codex');
+    expect(AiAgent.detectAgentName(<String, String>{'OPENCODE': '1'}), 'OpenCode');
+    expect(AiAgent.detectAgentName(<String, String>{'PI_CODING_AGENT': '1'}), 'Pi');
+    expect(AiAgent.detectAgentName(<String, String>{'REPL_ID': '1'}), 'Replit');
+    expect(AiAgent.detectAgentName(<String, String>{'SWE_AGENT': '1'}), 'Generic AI Agent');
+    expect(AiAgent.detectAgentName(<String, String>{'AI_AGENT': '1'}), 'Generic AI Agent');
+    expect(AiAgent.detectAgentName(<String, String>{'AGENT': '1'}), 'Generic AI Agent');
+    expect(AiAgent.detectAgentName(<String, String>{'AGENT': 'MyCustomAgent'}), 'MyCustomAgent');
+    expect(AiAgent.detectAgentName(<String, String>{'AI_AGENT': 'MyCustomAgent'}), 'MyCustomAgent');
+  });
+
   test('The minimum session duration should be at least 30 minutes', () {
     expect(
       kSessionDurationMinutes < 30,

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -1294,9 +1294,11 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
         1,
         reason: 'There should only be one session after the initial send event',
       );
-      expect(firstQuery.flutterChannelCount, {
-        'flutterChannel': 1,
-      }, reason: 'There should only be one flutter channel logged');
+      expect(
+        firstQuery.flutterChannelCount,
+        {'flutterChannel': 1},
+        reason: 'There should only be one flutter channel logged',
+      );
       expect(firstQuery.toolCount, {
         'flutter-tool': 1,
       }, reason: 'There should only be one tool logged');
@@ -1353,10 +1355,11 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // Query the log file stats to verify that there are two tools
     final query = analytics.logFileStats()!;
 
-    expect(query.toolCount, {
-      'flutter-tool': 1,
-      'dart-tool': 1,
-    }, reason: 'There should have been two tools in the persisted logs');
+    expect(
+      query.toolCount,
+      {'flutter-tool': 1, 'dart-tool': 1},
+      reason: 'There should have been two tools in the persisted logs',
+    );
   });
 
   test('Check that log data missing some keys results in null for stats', () {
@@ -1477,9 +1480,11 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     // Query the log file stats to verify that there are two tools
     final query = analytics.logFileStats()!;
 
-    expect(query.toolCount, {
-      'dart-tool': 1,
-    }, reason: 'There should have only been on tool that sent events');
+    expect(
+      query.toolCount,
+      {'dart-tool': 1},
+      reason: 'There should have only been on tool that sent events',
+    );
     expect(
       query.flutterChannelCount.isEmpty,
       true,
@@ -1504,9 +1509,11 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       query.sessionCount,
       reason: 'The session should have remained the same',
     );
-    expect(query2.flutterChannelCount, {
-      'flutterChannel': 1,
-    }, reason: 'The first instance has flutter information initialized');
+    expect(
+      query2.flutterChannelCount,
+      {'flutterChannel': 1},
+      reason: 'The first instance has flutter information initialized',
+    );
   });
 
   group('Testing against Google Analytics limitations:', () {

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -853,6 +853,35 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     },
   );
 
+  test(
+    'The UserProperty class truncates the ai_agent value to a maximum of 36 characters',
+    () {
+      final longAgentAnalytics = Analytics.fake(
+        tool: initialTool,
+        homeDirectory: home,
+        flutterChannel: flutterChannel,
+        toolsMessageVersion: toolsMessageVersion,
+        toolsMessage: toolsMessage,
+        flutterVersion: flutterVersion,
+        dartVersion: dartVersion,
+        fs: fs,
+        platform: platform,
+        clientIde: 'CursorIDE',
+        agent:
+            'ThisIsAnExtremelyLongAgentNameThatExceedsThe36CharacterLimitOfGA4',
+      );
+
+      final String expectedAgent = 'ThisIsAnExtremelyLongAgentNameThatEx';
+      expect(expectedAgent.length, 36);
+      expect(
+        longAgentAnalytics.userPropertyMap['ai_agent']?['value'],
+        expectedAgent,
+        reason:
+            'The ai_agent user property should be truncated to 36 characters',
+      );
+    },
+  );
+
   test('The minimum session duration should be at least 30 minutes', () {
     expect(
       kSessionDurationMinutes < 30,

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -807,6 +807,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       'host_os_version',
       'locale',
       'client_ide',
+      'ai_agent',
     ];
     expect(
       analytics.userPropertyMap.keys.length,
@@ -821,6 +822,36 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       );
     }
   });
+
+  test(
+    'The UserProperty class correctly sets and exposes the ai_agent value',
+    () {
+      final secondAnalytics = Analytics.fake(
+        tool: initialTool,
+        homeDirectory: home,
+        flutterChannel: flutterChannel,
+        toolsMessageVersion: toolsMessageVersion,
+        toolsMessage: toolsMessage,
+        flutterVersion: flutterVersion,
+        dartVersion: dartVersion,
+        fs: fs,
+        platform: platform,
+        clientIde: 'CursorIDE',
+        agent: 'Cursor',
+      );
+
+      expect(
+        secondAnalytics.userPropertyMap['ai_agent']?['value'],
+        'Cursor',
+        reason: 'The ai_agent user property should be set to Cursor',
+      );
+      expect(
+        secondAnalytics.userPropertyMap['client_ide']?['value'],
+        'CursorIDE',
+        reason: 'The client_ide user property should be set to CursorIDE',
+      );
+    },
+  );
 
   test('The minimum session duration should be at least 30 minutes', () {
     expect(

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -871,7 +871,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
             'ThisIsAnExtremelyLongAgentNameThatExceedsThe36CharacterLimitOfGA4',
       );
 
-      final String expectedAgent = 'ThisIsAnExtremelyLongAgentNameThatEx';
+      final expectedAgent = 'ThisIsAnExtremelyLongAgentNameThatEx';
       expect(expectedAgent.length, 36);
       expect(
         longAgentAnalytics.userPropertyMap['ai_agent']?['value'],


### PR DESCRIPTION
Add an optional parameter to include a string describing a detected AI agent. 

`AiAgent.detectAgentName` will take a platform environment and return a string, to be passed back into the usage event.

Environment logic gathered from:
- https://code.claude.com/docs/en/env-vars
- https://www.npmjs.com/package/@vercel/detect-agent
- https://github.com/vercel/vercel/issues/15336
- https://github.com/ergebnis/agent-detector

Part of https://github.com/flutter/flutter/issues/187623

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
