### PR TITLE
allow package_config version 3.x.x in coverage

### DIFF
--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.1
+
+- Allow package_config `3.x.x`.
+
 ## 1.15.0
 
 - Expose `filterIgnored` function, which filters the coverage data according to
@@ -30,7 +34,7 @@
   format_coverage.
 - Fix a bug where we attempt to resume an isolate after the VM service has been
   shut down.
-  
+
 ## 1.12.0
 
 - Introduced support for specifying coverage flags through a YAML file.

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage
-version: 1.15.0
+version: 1.15.1
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage
@@ -13,7 +13,7 @@ dependencies:
   glob: ^2.1.2
   logging: ^1.0.0
   meta: ^1.0.2
-  package_config: ^2.0.0
+  package_config: '>=2.0.0 <4.0.0'
   path: ^1.8.0
   source_maps: ^0.10.10
   stack_trace: ^1.10.0


### PR DESCRIPTION
For this one I went ahead and also prepped it to publish, but lmk if we want to wait for some reason.

Note that this version is already in google3 and the SDK so we know it is compatible.