### PR TITLE
[yaml] Better recovering for list entry without `- ` prefix

### DIFF
--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.1.4-wip
 
+* Improve recovery for list entries without `-` prefix. When recovering, provide
+  a more helpful error message suggesting the missing prefix.
 * Fix parsing of plain scalars starting with indicator characters (`?`, `:`, and `-`).
 * Throw a `FormatException` when parsing self-referential collections instead of
   a `StackOverflow`. Yaml definitions with collections nested within themselves

--- a/pkgs/yaml/lib/src/parser.dart
+++ b/pkgs/yaml/lib/src/parser.dart
@@ -379,6 +379,16 @@ class Parser {
       return Event(EventType.sequenceEnd, token.span);
     }
 
+    // The scanner may insert a `key` token (its own recovery for a required
+    // simple key without `:`) when a scalar appears at the current indent level
+    // inside a block sequence. Consume it and treat the scalar as a sequence
+    // entry; the scanner already reported the appropriate error.
+    if (token.type == TokenType.key) {
+      _scanner.scan();
+      _states.add(_State.BLOCK_SEQUENCE_ENTRY);
+      return _parseNode(block: true);
+    }
+
     throw YamlException("While parsing a block collection, expected '-'.",
         token.span.start.pointSpan());
   }

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -138,6 +138,12 @@ class Scanner {
   /// The YAML spec specifies that the initial indentation level is -1 spaces.
   final _indents = <int>[-1];
 
+  /// The token type pushed at each indent level in [_indents].
+  ///
+  /// Always the same length as [_indents]. The base level (`-1`) has no
+  /// associated token, so its entry is `null`.
+  final _indentTypes = <TokenType?>[null];
+
   /// Whether a simple key is allowed in this context.
   ///
   /// A simple key refers to any mapping key that doesn't have an explicit "?".
@@ -482,7 +488,14 @@ class Scanner {
       if (key.line == _scanner.line) continue;
 
       if (key.required) {
-        _reportError(YamlException("Expected ':'.", _scanner.emptySpan));
+        final keyIndentIdx = _indents.lastIndexOf(key.column);
+        final inBlockSequence = keyIndentIdx >= 0 &&
+            _indentTypes[keyIndentIdx] == TokenType.blockSequenceStart;
+        final message = StringBuffer("Expected ':'.");
+        if (inBlockSequence) {
+          message.write(" If this is a list entry, it must start with '- '.");
+        }
+        _reportError(YamlException(message.toString(), _scanner.emptySpan));
         _tokens.insert(key.tokenNumber - _tokensParsed,
             Token(TokenType.key, key.location.pointSpan() as FileSpan));
       }
@@ -551,6 +564,7 @@ class Scanner {
     // Push the current indentation level to the stack and set the new
     // indentation level.
     _indents.add(column);
+    _indentTypes.add(type);
 
     // Create a token and insert it into the queue.
     var token = Token(type, location.pointSpan() as FileSpan);
@@ -571,6 +585,7 @@ class Scanner {
     while (_indent > column) {
       _tokens.add(Token(TokenType.blockEnd, _scanner.emptySpan));
       _indents.removeLast();
+      _indentTypes.removeLast();
     }
   }
 

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -133,16 +133,14 @@ class Scanner {
   /// before it.
   var _tokenAvailable = false;
 
-  /// The stack of indent levels for the current nested block contexts.
+  /// The stack of indent levels and their associated token types for the
+  /// current nested block contexts.
   ///
   /// The YAML spec specifies that the initial indentation level is -1 spaces.
-  final _indents = <int>[-1];
-
-  /// The token type pushed at each indent level in [_indents].
-  ///
-  /// Always the same length as [_indents]. The base level (`-1`) has no
-  /// associated token, so its entry is `null`.
-  final _indentTypes = <TokenType?>[null];
+  /// The base level (`-1`) has no associated token, so its entry is `null`.
+  final _indentLevels = <({int column, TokenType? type})>[
+    (column: -1, type: null),
+  ];
 
   /// Whether a simple key is allowed in this context.
   ///
@@ -160,7 +158,7 @@ class Scanner {
   final _simpleKeys = <_SimpleKey?>[null];
 
   /// The current indentation level.
-  int get _indent => _indents.last;
+  int get _indent => _indentLevels.last.column;
 
   /// Whether the scanner's currently positioned in a block-level structure (as
   /// opposed to flow-level).
@@ -488,9 +486,10 @@ class Scanner {
       if (key.line == _scanner.line) continue;
 
       if (key.required) {
-        final keyIndentIdx = _indents.lastIndexOf(key.column);
+        final keyIndentIdx = _indentLevels
+            .lastIndexWhere((indent) => indent.column == key.column);
         final inBlockSequence = keyIndentIdx >= 0 &&
-            _indentTypes[keyIndentIdx] == TokenType.blockSequenceStart;
+            _indentLevels[keyIndentIdx].type == TokenType.blockSequenceStart;
         final message = StringBuffer("Expected ':'.");
         if (inBlockSequence) {
           message.write(" If this is a list entry, it must start with '- '.");
@@ -563,8 +562,7 @@ class Scanner {
 
     // Push the current indentation level to the stack and set the new
     // indentation level.
-    _indents.add(column);
-    _indentTypes.add(type);
+    _indentLevels.add((column: column, type: type));
 
     // Create a token and insert it into the queue.
     var token = Token(type, location.pointSpan() as FileSpan);
@@ -575,8 +573,8 @@ class Scanner {
     }
   }
 
-  /// Pops indentation levels from [_indents] until the current level becomes
-  /// less than or equal to [column].
+  /// Pops indentation levels from [_indentLevels] until the current level
+  /// becomes less than or equal to [column].
   ///
   /// For each indentation level, appends a [TokenType.blockEnd] token.
   void _unrollIndent(int column) {
@@ -584,13 +582,12 @@ class Scanner {
 
     while (_indent > column) {
       _tokens.add(Token(TokenType.blockEnd, _scanner.emptySpan));
-      _indents.removeLast();
-      _indentTypes.removeLast();
+      _indentLevels.removeLast();
     }
   }
 
-  /// Pops indentation levels from [_indents] until the current level resets to
-  /// -1.
+  /// Pops indentation levels from [_indentLevels] until the current level
+  /// resets to -1.
   ///
   /// For each indentation level, appends a [TokenType.blockEnd] token.
   void _resetIndent() => _unrollIndent(-1);

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -159,9 +159,11 @@ void main() {
             }
           }));
       expect(collector.errors.length, equals(1));
-      expectErrorAtLineCol(collector.errors[0],
+      expectErrorAtLineCol(
+          collector.errors[0],
           "Expected ':'. If this is a list entry, it must start with '- '.",
-          4, 4);
+          4,
+          4);
     });
   });
 

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -143,6 +143,26 @@ void main() {
             }
           }));
     });
+    test('from list elements with missing "- " prefix', () {
+      final yaml = cleanUpLiteral(r'''
+        linter:
+          rules:
+            - annotate_overrides
+            alway
+            ''');
+      var result = loadYaml(yaml, recover: true, errorListener: collector);
+      expect(
+          result,
+          deepEquals({
+            'linter': {
+              'rules': ['annotate_overrides', 'alway'],
+            }
+          }));
+      expect(collector.errors.length, equals(1));
+      expectErrorAtLineCol(collector.errors[0],
+          "Expected ':'. If this is a list entry, it must start with '- '.",
+          4, 4);
+    });
   });
 
   test('includes source span information', () {


### PR DESCRIPTION
This is a suggestion to fix:

- https://github.com/dart-lang/tools/issues/2426

Where we recover from a list item without the `- ` prefix and give it a more coherent error message.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
