### PR TITLE
[mime] Fix hanging part streams on source stream error or completion

### DIFF
--- a/pkgs/mime/lib/src/bound_multipart_stream.dart
+++ b/pkgs/mime/lib/src/bound_multipart_stream.dart
@@ -13,6 +13,8 @@ const _separators = {
   40, 41, 60, 62, 64, 44, 59, 58, 92, 34, 47, 91, 93, 63, 61, 123, 125, 32, 9 //
 };
 
+const _exceptionBadEnding = MimeMultipartException('Bad multipart ending');
+
 bool _isTokenChar(int byte) =>
     byte > 31 && byte < 128 && !_separators.contains(byte);
 
@@ -125,12 +127,27 @@ class BoundMultipartStream {
           _index = 0;
           _parse();
         }, onDone: () {
+          if (_multipartController case final controller?) {
+            _multipartController = null;
+            if (_state != _doneCode) {
+              controller.addError(_exceptionBadEnding);
+            }
+            controller.close();
+          }
           if (_state != _doneCode) {
-            _controller
-                .addError(const MimeMultipartException('Bad multipart ending'));
+            _controller.addError(_exceptionBadEnding);
           }
           _controller.close();
-        }, onError: _controller.addError);
+        }, onError: (Object error, StackTrace stackTrace) {
+          if (_multipartController case final controller?) {
+            _multipartController = null;
+            controller.addError(error, stackTrace);
+            controller.close();
+            _tryPropagateControllerState();
+          }
+          _state = _failCode;
+          _controller.addError(error, stackTrace);
+        });
       };
   }
 

--- a/pkgs/mime/test/mime_multipart_transformer_test.dart
+++ b/pkgs/mime/test/mime_multipart_transformer_test.dart
@@ -463,7 +463,73 @@ Body2\r
   _testParse(message, 'xxx', null, [null, null], true);
 }
 
+void _testErrorAndCloseDuringParsing() {
+  test('error in source stream during parsing does not hang', () async {
+    final controller = StreamController<List<int>>();
+    final transformer = MimeMultipartTransformer('xxx');
+    final stream = controller.stream.transform(transformer);
+
+    controller.add('--xxx\r\n'.codeUnits);
+    controller.add('Header: value\r\n\r\npart data'.codeUnits);
+
+    final partCompleter = Completer<void>();
+    final mainCompleter = Completer<void>();
+
+    stream.listen((part) {
+      scheduleMicrotask(() {
+        controller.addError(Exception('source error'));
+      });
+      part.listen((data) {}, onError: (Object error) {
+        expect(error, isA<Exception>());
+        partCompleter.complete();
+      });
+    }, onError: (Object error) {
+      expect(error, isA<Exception>());
+      mainCompleter.complete();
+    });
+
+    await Future.wait([partCompleter.future, mainCompleter.future]).timeout(
+      const Duration(seconds: 3),
+      onTimeout: () => fail(
+        'Test hung: streams were not notified of source stream error',
+      ),
+    );
+  });
+
+  test('premature done in source stream during parsing does not hang',
+      () async {
+    final controller = StreamController<List<int>>();
+    final transformer = MimeMultipartTransformer('xxx');
+    final stream = controller.stream.transform(transformer);
+
+    controller.add('--xxx\r\n'.codeUnits);
+    controller.add('Header: value\r\n\r\npart data'.codeUnits);
+
+    final partCompleter = Completer<void>();
+    final mainCompleter = Completer<void>();
+
+    stream.listen((part) {
+      scheduleMicrotask(controller.close);
+      part.listen((data) {}, onError: (Object error) {
+        expect(error, isA<MimeMultipartException>());
+        partCompleter.complete();
+      });
+    }, onError: (Object error) {
+      expect(error, isA<MimeMultipartException>());
+      mainCompleter.complete();
+    });
+
+    await Future.wait([partCompleter.future, mainCompleter.future]).timeout(
+      const Duration(seconds: 3),
+      onTimeout: () => fail(
+        'Test hung: part stream was not closed or notified of premature onDone',
+      ),
+    );
+  });
+}
+
 void main() {
   _testParseValid();
   _testParseInvalid();
+  _testErrorAndCloseDuringParsing();
 }


### PR DESCRIPTION
Fixes #2428

Propagate source stream errors and premature close events (`MimeMultipartException`) to the active part stream (`_multipartController`) and close it. This prevents listeners of the active part from hanging indefinitely.

Adds corresponding tests in `mime_multipart_transformer_test.dart`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
