### PR TITLE
feat(pool): support async allowRelease callbacks and prevent slot leaks on error

### DIFF
--- a/pkgs/pool/lib/pool.dart
+++ b/pkgs/pool/lib/pool.dart
@@ -27,7 +27,7 @@ class Pool {
   /// allocated.
   ///
   /// See [PoolResource.allowRelease].
-  final _onReleaseCallbacks = Queue<void Function()>();
+  final _onReleaseCallbacks = Queue<FutureOr<void> Function()>();
 
   /// Completers that will be completed once `onRelease` callbacks are done
   /// running.
@@ -275,7 +275,7 @@ class Pool {
 
   /// If there are any pending requests, this will fire the oldest one after
   /// running [onRelease].
-  void _onResourceReleaseAllowed(void Function() onRelease) {
+  void _onResourceReleaseAllowed(FutureOr<void> Function() onRelease) {
     _resetTimer();
 
     if (_requestedResources.isNotEmpty) {
@@ -297,15 +297,17 @@ class Pool {
   ///
   /// Futures returned by [_runOnRelease] always complete in the order they were
   /// created, even if earlier [onRelease] callbacks take longer to run.
-  Future<PoolResource> _runOnRelease(void Function() onRelease) {
-    Future.sync(onRelease).then((value) {
-      _onReleaseCompleters.removeFirst().complete(PoolResource._(this));
-    }).catchError((Object error, StackTrace stackTrace) {
-      _onReleaseCompleters.removeFirst().completeError(error, stackTrace);
-    });
-
+  Future<PoolResource> _runOnRelease(FutureOr<void> Function() onRelease) {
     var completer = Completer<PoolResource>.sync();
     _onReleaseCompleters.add(completer);
+
+    Future.sync(onRelease).then((value) {
+      _onReleaseCompleters.removeFirst().complete(PoolResource._(this));
+    }).onError((Object error, StackTrace stackTrace) {
+      _onReleaseCompleters.removeFirst().completeError(error, stackTrace);
+      _onResourceReleased();
+    });
+
     return completer.future;
   }
 

--- a/pkgs/pool/test/pool_test.dart
+++ b/pkgs/pool/test/pool_test.dart
@@ -277,6 +277,44 @@ void main() {
 
       await pool.request();
     });
+
+    test('request() throws if allowRelease callback throws', () async {
+      var pool = Pool(1);
+      var resource = await pool.request();
+
+      var requestFuture = pool.request();
+
+      var completer = Completer<void>();
+      resource.allowRelease(() => completer.future);
+
+      await Future<void>.delayed(Duration.zero);
+      completer.completeError('oh no!');
+
+      await expectLater(requestFuture, throwsA('oh no!'));
+    });
+
+    test('request() does not leak resources when allowRelease throws',
+        () async {
+      var pool = Pool(1);
+      var resource = await pool.request();
+
+      var requestFuture = pool.request();
+
+      var completer = Completer<void>();
+      resource.allowRelease(() => completer.future);
+
+      await Future<void>.delayed(Duration.zero);
+      completer.completeError('oh no!');
+
+      await expectLater(requestFuture, throwsA('oh no!'));
+
+      // Without the fix, this will hang because the slot is leaked.
+      var nextRequest = pool.request().timeout(
+          const Duration(milliseconds: 100),
+          onTimeout: () => throw TimeoutException('Leaked!'));
+
+      await expectLater(nextRequest, completes);
+    });
   });
 
   test("done doesn't complete without close", () async {


### PR DESCRIPTION
Updates allowRelease to accept FutureOr<void> Function() and prevents resource slot leaks when allowRelease callback throws or completes with an error.