### PR TITLE
fix(api_summary): actionably handle CLI argument errors and add JSON parsing utilities

### DIFF
--- a/pkgs/api_summary/bin/api_summary.dart
+++ b/pkgs/api_summary/bin/api_summary.dart
@@ -39,6 +39,13 @@ Future<void> main(List<String> arguments) async {
     stderr.writeln(parser.usage);
     exitCode = 64;
     return;
+    // ignore: avoid_catching_errors
+  } on ArgumentError catch (e) {
+    stderr.writeln('Error: ${e.message}');
+    stderr.writeln('\nUsage: api_summary [options]');
+    stderr.writeln(parser.usage);
+    exitCode = 64;
+    return;
   }
 }
 

--- a/pkgs/api_summary/lib/src/json_utils.dart
+++ b/pkgs/api_summary/lib/src/json_utils.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Parses a JSON list of objects using [fromJson].
+List<T> parseList<T>(
+  Map<String, dynamic> json,
+  String key,
+  T Function(Map<String, dynamic>) fromJson,
+) =>
+    (json[key] as List<dynamic>?)
+        ?.map((e) => fromJson(e as Map<String, dynamic>))
+        .toList() ??
+    [];
+
+/// Parses a JSON list of strings.
+List<String> parseStringList(Map<String, dynamic> json, String key) =>
+    (json[key] as List<dynamic>?)?.map((e) => e as String).toList() ?? [];

--- a/pkgs/api_summary/test/app_test.dart
+++ b/pkgs/api_summary/test/app_test.dart
@@ -39,4 +39,17 @@ void main() {
       expect(actualOutput, equals(expectedOutput));
     },
   );
+
+  test('exits with code 64 on invalid arguments', () async {
+    final packageDir = p.current;
+    final result = await Process.run(Platform.resolvedExecutable, [
+      if (Platform.packageConfig != null)
+        '--packages=${Platform.packageConfig}',
+      p.join(packageDir, 'bin', 'api_summary.dart'),
+      '--invalid-option',
+    ], workingDirectory: packageDir);
+
+    expect(result.exitCode, equals(64));
+    expect(result.stderr, contains('Usage: api_summary'));
+  });
 }


### PR DESCRIPTION
Part 1 of 5 in stacked PR split of #2420.

- Catch ArgumentError in main() and exit gracefully with usage exit code 64.
- Introduce json_utils.dart parsing helpers.
- Add CLI argument error test coverage in app_test.dart.