### PR TITLE
refactor(api_summary): introduce structured API declaration and type models

### DIFF
--- a/pkgs/api_summary/lib/src/api_declaration.dart
+++ b/pkgs/api_summary/lib/src/api_declaration.dart
@@ -1,0 +1,455 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'api_type.dart';
+import 'json_utils.dart';
+
+/// The exposure status of an API declaration within the summarized package.
+enum ApiDeclarationStatus {
+  /// The declaration is part of the public API of the package.
+  public,
+
+  /// The declaration is from an external package or SDK library referenced
+  /// by the public API.
+  referenced,
+
+  /// The declaration is internal (non-public) but reachable through public
+  /// API signatures.
+  nonPublic,
+}
+
+/// The specific kind of executable member declaration.
+enum ApiExecutableKind { getter, setter, method, constructor, function }
+
+/// Modifiers that define the inheritance, implementation, or instantiation
+/// capabilities of a class or mixin.
+enum ApiClassModifier {
+  isSealed('sealed'),
+  isAbstract('abstract'),
+  isBase('base'),
+  isMixin('mixin'),
+  isInterface('interface'),
+  isFinal('final');
+
+  final String jsonName;
+  const ApiClassModifier(this.jsonName);
+
+  static ApiClassModifier parse(String value) =>
+      values.firstWhere((e) => e.jsonName == value);
+}
+
+/// A canonical summary of the public API of a package.
+///
+/// This serves as the root model object containing the [name] of the package
+/// and the collection of [libraries] that make up its public API surface.
+final class ApiSummary {
+  final String name;
+
+  final List<ApiLibrary> libraries;
+
+  ApiSummary({required this.name, required this.libraries});
+
+  factory ApiSummary.fromJson(Map<String, dynamic> json) => ApiSummary(
+    name: json['name'] as String,
+    libraries: parseList(json, 'libraries', ApiLibrary.fromJson),
+  );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'libraries': libraries.map((e) => e.toJson()).toList(),
+  };
+
+  @override
+  String toString() =>
+      'ApiSummary(name: $name, libraries: ${libraries.length})';
+}
+
+/// A summary of the declarations exposed by a single library within a package.
+final class ApiLibrary {
+  final String uri;
+  final bool isPublicEntryPoint;
+  final List<ApiClass> classes;
+  final List<ApiClass> enums;
+  final List<ApiClass> mixins;
+  final List<ApiExtension> extensions;
+  final List<ApiExtensionType> extensionTypes;
+  final List<ApiExecutable> functions;
+  final List<ApiTypeAlias> typeAliases;
+
+  ApiLibrary({
+    required this.uri,
+    required this.isPublicEntryPoint,
+    required this.classes,
+    required this.enums,
+    required this.mixins,
+    required this.extensions,
+    required this.extensionTypes,
+    required this.functions,
+    required this.typeAliases,
+  });
+
+  factory ApiLibrary.fromJson(Map<String, dynamic> json) => ApiLibrary(
+    uri: json['uri'] as String,
+    isPublicEntryPoint: json['isPublicEntryPoint'] as bool,
+    classes: parseList(json, 'classes', ApiClass.fromJson),
+    enums: parseList(json, 'enums', ApiClass.fromJson),
+    mixins: parseList(json, 'mixins', ApiClass.fromJson),
+    extensions: parseList(json, 'extensions', ApiExtension.fromJson),
+    extensionTypes: parseList(
+      json,
+      'extensionTypes',
+      ApiExtensionType.fromJson,
+    ),
+    functions: parseList(json, 'functions', ApiExecutable.fromJson),
+    typeAliases: parseList(json, 'typeAliases', ApiTypeAlias.fromJson),
+  );
+
+  Map<String, dynamic> toJson() => {
+    'uri': uri,
+    'isPublicEntryPoint': isPublicEntryPoint,
+    if (classes.isNotEmpty) 'classes': classes.map((e) => e.toJson()).toList(),
+    if (enums.isNotEmpty) 'enums': enums.map((e) => e.toJson()).toList(),
+    if (mixins.isNotEmpty) 'mixins': mixins.map((e) => e.toJson()).toList(),
+    if (extensions.isNotEmpty)
+      'extensions': extensions.map((e) => e.toJson()).toList(),
+    if (extensionTypes.isNotEmpty)
+      'extensionTypes': extensionTypes.map((e) => e.toJson()).toList(),
+    if (functions.isNotEmpty)
+      'functions': functions.map((e) => e.toJson()).toList(),
+    if (typeAliases.isNotEmpty)
+      'typeAliases': typeAliases.map((e) => e.toJson()).toList(),
+  };
+}
+
+/// The base class for all API declarations (classes, extensions, methods,
+/// aliases) modeled in a package summary.
+sealed class ApiDeclaration {
+  final String name;
+  final String? locationUri;
+  final ApiDeclarationStatus status;
+  final bool isDeprecated;
+  final bool isExperimental;
+  final bool isVisibleForTesting;
+
+  const ApiDeclaration({
+    required this.name,
+    this.locationUri,
+    this.status = ApiDeclarationStatus.public,
+    this.isDeprecated = false,
+    this.isExperimental = false,
+    this.isVisibleForTesting = false,
+  });
+}
+
+/// A summary of a Dart class, mixin, or enum declaration.
+///
+/// Models class modifiers, constructors, methods, type parameters, hierarchy
+/// relationships, deprecation status, and other element metadata.
+final class ApiClass extends ApiDeclaration {
+  final Map<String, ApiType?> typeParameters;
+  final ApiType? supertype;
+  final List<ApiType> interfaces;
+  final List<ApiType> mixins;
+  final List<ApiType> superclassConstraints;
+  final List<ApiClassModifier> modifiers;
+  final List<String> immediateSubtypes;
+  final List<ApiExecutable> constructors;
+  final List<ApiExecutable> methods;
+
+  ApiClass({
+    required super.name,
+    super.locationUri,
+    super.status,
+    required this.typeParameters,
+    this.supertype,
+    required this.interfaces,
+    required this.mixins,
+    this.superclassConstraints = const [],
+    required this.modifiers,
+    required this.immediateSubtypes,
+    required this.constructors,
+    required this.methods,
+    super.isDeprecated,
+    super.isExperimental,
+    super.isVisibleForTesting,
+  });
+
+  factory ApiClass.fromJson(Map<String, dynamic> json) => ApiClass(
+    name: json['name'] as String,
+    locationUri: json['locationUri'] as String?,
+    status: _parseStatus(json),
+    typeParameters: parseTypeParameters(json, 'typeParameters'),
+    supertype: json['supertype'] != null
+        ? ApiType.fromJson(json['supertype'] as Map<String, dynamic>)
+        : null,
+    interfaces: parseList(json, 'interfaces', ApiType.fromJson),
+    mixins: parseList(json, 'mixins', ApiType.fromJson),
+    superclassConstraints: parseList(
+      json,
+      'superclassConstraints',
+      ApiType.fromJson,
+    ),
+    modifiers: parseStringList(
+      json,
+      'modifiers',
+    ).map(ApiClassModifier.parse).toList(),
+    immediateSubtypes: parseStringList(json, 'immediateSubtypes'),
+    constructors: parseList(json, 'constructors', ApiExecutable.fromJson),
+    methods: parseList(json, 'methods', ApiExecutable.fromJson),
+    isDeprecated: json['isDeprecated'] as bool? ?? false,
+    isExperimental: json['isExperimental'] as bool? ?? false,
+    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    if (locationUri != null) 'locationUri': locationUri,
+    if (status != ApiDeclarationStatus.public) 'status': status.name,
+    if (typeParameters.isNotEmpty)
+      'typeParameters': {
+        for (final entry in typeParameters.entries)
+          entry.key: entry.value?.toJson(),
+      },
+    if (supertype != null) 'supertype': supertype!.toJson(),
+    if (interfaces.isNotEmpty)
+      'interfaces': interfaces.map((e) => e.toJson()).toList(),
+    if (mixins.isNotEmpty) 'mixins': mixins.map((e) => e.toJson()).toList(),
+    if (superclassConstraints.isNotEmpty)
+      'superclassConstraints': superclassConstraints
+          .map((e) => e.toJson())
+          .toList(),
+    if (modifiers.isNotEmpty)
+      'modifiers': modifiers.map((e) => e.jsonName).toList(),
+    if (immediateSubtypes.isNotEmpty) 'immediateSubtypes': immediateSubtypes,
+    if (constructors.isNotEmpty)
+      'constructors': constructors.map((e) => e.toJson()).toList(),
+    if (methods.isNotEmpty) 'methods': methods.map((e) => e.toJson()).toList(),
+    if (isDeprecated) 'isDeprecated': isDeprecated,
+    if (isExperimental) 'isExperimental': isExperimental,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
+  };
+}
+
+/// A summary of a Dart extension declaration.
+///
+/// Models type parameters, the extended type, and extension methods.
+final class ApiExtension extends ApiDeclaration {
+  final Map<String, ApiType?> typeParameters;
+  final ApiType extendedType;
+  final List<ApiExecutable> methods;
+
+  ApiExtension({
+    required super.name,
+    super.locationUri,
+    super.status,
+    required this.typeParameters,
+    required this.extendedType,
+    required this.methods,
+    super.isDeprecated,
+    super.isExperimental,
+    super.isVisibleForTesting,
+  });
+
+  factory ApiExtension.fromJson(Map<String, dynamic> json) => ApiExtension(
+    name: json['name'] as String,
+    locationUri: json['locationUri'] as String?,
+    status: _parseStatus(json),
+    typeParameters: parseTypeParameters(json, 'typeParameters'),
+    extendedType: ApiType.fromJson(
+      json['extendedType'] as Map<String, dynamic>,
+    ),
+    methods: parseList(json, 'methods', ApiExecutable.fromJson),
+    isDeprecated: json['isDeprecated'] as bool? ?? false,
+    isExperimental: json['isExperimental'] as bool? ?? false,
+    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    if (locationUri != null) 'locationUri': locationUri,
+    if (status != ApiDeclarationStatus.public) 'status': status.name,
+    if (typeParameters.isNotEmpty)
+      'typeParameters': {
+        for (final entry in typeParameters.entries)
+          entry.key: entry.value?.toJson(),
+      },
+    'extendedType': extendedType.toJson(),
+    if (methods.isNotEmpty) 'methods': methods.map((e) => e.toJson()).toList(),
+    if (isDeprecated) 'isDeprecated': isDeprecated,
+    if (isExperimental) 'isExperimental': isExperimental,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
+  };
+}
+
+/// A summary of a Dart extension type declaration.
+///
+/// Models the representation type, implemented interfaces, and defined constructors/methods.
+final class ApiExtensionType extends ApiDeclaration {
+  final Map<String, ApiType?> typeParameters;
+  final ApiType representationType;
+  final List<ApiType> interfaces;
+  final List<ApiExecutable> constructors;
+  final List<ApiExecutable> methods;
+
+  ApiExtensionType({
+    required super.name,
+    super.locationUri,
+    super.status,
+    required this.typeParameters,
+    required this.representationType,
+    required this.interfaces,
+    required this.constructors,
+    required this.methods,
+    super.isDeprecated,
+    super.isExperimental,
+    super.isVisibleForTesting,
+  });
+
+  factory ApiExtensionType.fromJson(Map<String, dynamic> json) =>
+      ApiExtensionType(
+        name: json['name'] as String,
+        locationUri: json['locationUri'] as String?,
+        status: _parseStatus(json),
+        typeParameters: parseTypeParameters(json, 'typeParameters'),
+        representationType: ApiType.fromJson(
+          json['representationType'] as Map<String, dynamic>,
+        ),
+        interfaces: parseList(json, 'interfaces', ApiType.fromJson),
+        constructors: parseList(json, 'constructors', ApiExecutable.fromJson),
+        methods: parseList(json, 'methods', ApiExecutable.fromJson),
+        isDeprecated: json['isDeprecated'] as bool? ?? false,
+        isExperimental: json['isExperimental'] as bool? ?? false,
+        isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    if (locationUri != null) 'locationUri': locationUri,
+    if (status != ApiDeclarationStatus.public) 'status': status.name,
+    if (typeParameters.isNotEmpty)
+      'typeParameters': {
+        for (final entry in typeParameters.entries)
+          entry.key: entry.value?.toJson(),
+      },
+    'representationType': representationType.toJson(),
+    if (interfaces.isNotEmpty)
+      'interfaces': interfaces.map((e) => e.toJson()).toList(),
+    if (constructors.isNotEmpty)
+      'constructors': constructors.map((e) => e.toJson()).toList(),
+    if (methods.isNotEmpty) 'methods': methods.map((e) => e.toJson()).toList(),
+    if (isDeprecated) 'isDeprecated': isDeprecated,
+    if (isExperimental) 'isExperimental': isExperimental,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
+  };
+}
+
+/// A summary of an executable member (function, method, constructor, getter,
+/// or setter).
+///
+/// Models signature details such as parameters, return type, type parameters,
+/// and modifiers.
+final class ApiExecutable extends ApiDeclaration {
+  final ApiExecutableKind kind;
+  final Map<String, ApiType?> typeParameters;
+  final ApiType returnType;
+  final List<ApiParameter> parameters;
+  final bool isStatic;
+
+  ApiExecutable({
+    required super.name,
+    super.locationUri,
+    super.status,
+    required this.kind,
+    required this.typeParameters,
+    required this.returnType,
+    required this.parameters,
+    required this.isStatic,
+    super.isDeprecated,
+    super.isExperimental,
+    super.isVisibleForTesting,
+  });
+
+  factory ApiExecutable.fromJson(Map<String, dynamic> json) => ApiExecutable(
+    name: json['name'] as String,
+    locationUri: json['locationUri'] as String?,
+    status: _parseStatus(json),
+    kind: ApiExecutableKind.values.byName(
+      json['kind'] as String? ?? 'function',
+    ),
+    typeParameters: parseTypeParameters(json, 'typeParameters'),
+    returnType: ApiType.fromJson(json['returnType'] as Map<String, dynamic>),
+    parameters: parseList(json, 'parameters', ApiParameter.fromJson),
+    isStatic: json['isStatic'] as bool? ?? false,
+    isDeprecated: json['isDeprecated'] as bool? ?? false,
+    isExperimental: json['isExperimental'] as bool? ?? false,
+    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    if (locationUri != null) 'locationUri': locationUri,
+    if (status != ApiDeclarationStatus.public) 'status': status.name,
+    'kind': kind.name,
+    if (typeParameters.isNotEmpty)
+      'typeParameters': {
+        for (final entry in typeParameters.entries)
+          entry.key: entry.value?.toJson(),
+      },
+    'returnType': returnType.toJson(),
+    if (parameters.isNotEmpty)
+      'parameters': parameters.map((e) => e.toJson()).toList(),
+    if (isStatic) 'isStatic': isStatic,
+    if (isDeprecated) 'isDeprecated': isDeprecated,
+    if (isExperimental) 'isExperimental': isExperimental,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
+  };
+}
+
+/// A summary of a Dart typedef type alias declaration.
+///
+/// Models type parameters and the aliased target type.
+final class ApiTypeAlias extends ApiDeclaration {
+  final Map<String, ApiType?> typeParameters;
+  final ApiType aliasedType;
+
+  ApiTypeAlias({
+    required super.name,
+    super.locationUri,
+    super.status,
+    required this.typeParameters,
+    required this.aliasedType,
+    super.isDeprecated,
+    super.isExperimental,
+    super.isVisibleForTesting,
+  });
+
+  factory ApiTypeAlias.fromJson(Map<String, dynamic> json) => ApiTypeAlias(
+    name: json['name'] as String,
+    locationUri: json['locationUri'] as String?,
+    status: _parseStatus(json),
+    typeParameters: parseTypeParameters(json, 'typeParameters'),
+    aliasedType: ApiType.fromJson(json['aliasedType'] as Map<String, dynamic>),
+    isDeprecated: json['isDeprecated'] as bool? ?? false,
+    isExperimental: json['isExperimental'] as bool? ?? false,
+    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    if (locationUri != null) 'locationUri': locationUri,
+    if (status != ApiDeclarationStatus.public) 'status': status.name,
+    if (typeParameters.isNotEmpty)
+      'typeParameters': {
+        for (final entry in typeParameters.entries)
+          entry.key: entry.value?.toJson(),
+      },
+    'aliasedType': aliasedType.toJson(),
+    if (isDeprecated) 'isDeprecated': isDeprecated,
+    if (isExperimental) 'isExperimental': isExperimental,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
+  };
+}
+
+ApiDeclarationStatus _parseStatus(Map<String, dynamic> json) =>
+    ApiDeclarationStatus.values.byName(json['status'] as String? ?? 'public');

--- a/pkgs/api_summary/lib/src/api_type.dart
+++ b/pkgs/api_summary/lib/src/api_type.dart
@@ -1,0 +1,230 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'json_utils.dart';
+
+enum _Kind {
+  isDynamic('dynamic', ApiDynamicType.fromJson),
+  isVoid('void', ApiVoidType.fromJson),
+  typeParameter('typeParameter', ApiTypeParameterType.fromJson),
+  interface('interface', ApiInterfaceType.fromJson),
+  record('record', ApiRecordType.fromJson),
+  function('function', ApiFunctionType.fromJson);
+
+  final String jsonName;
+  final ApiType Function(Map<String, dynamic>) fromJson;
+  const _Kind(this.jsonName, this.fromJson);
+
+  static _Kind parse(String value) => values.firstWhere(
+    (e) => e.jsonName == value,
+    orElse: () => throw ArgumentError('Unknown ApiType kind: $value'),
+  );
+}
+
+/// The base class for all types represented in an API summary.
+///
+/// This sealed hierarchy models the various Dart types (dynamic, void,
+/// function, interface, record, and type parameter) encountered in package
+/// public APIs.
+sealed class ApiType {
+  Map<String, dynamic> toJson();
+  factory ApiType.fromJson(Map<String, dynamic> json) =>
+      _Kind.parse(json['kind'] as String).fromJson(json);
+}
+
+/// Represents the `dynamic` type in Dart.
+final class ApiDynamicType implements ApiType {
+  const ApiDynamicType();
+  factory ApiDynamicType.fromJson(Map<String, dynamic> _) =>
+      const ApiDynamicType();
+  @override
+  Map<String, dynamic> toJson() => {'kind': _Kind.isDynamic.jsonName};
+}
+
+/// Represents the `void` type in Dart.
+final class ApiVoidType implements ApiType {
+  const ApiVoidType();
+  factory ApiVoidType.fromJson(Map<String, dynamic> _) => const ApiVoidType();
+  @override
+  Map<String, dynamic> toJson() => {'kind': _Kind.isVoid.jsonName};
+}
+
+/// Represents a type parameter type (e.g. `T`) in Dart.
+final class ApiTypeParameterType implements ApiType {
+  final String name;
+  final bool isNullable;
+
+  ApiTypeParameterType({required this.name, required this.isNullable});
+
+  factory ApiTypeParameterType.fromJson(Map<String, dynamic> json) =>
+      ApiTypeParameterType(
+        name: json['name'] as String,
+        isNullable: json['isNullable'] as bool? ?? false,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': _Kind.typeParameter.jsonName,
+    'name': name,
+    if (isNullable) 'isNullable': true,
+  };
+}
+
+/// Represents an interface type (a class, mixin, or enum type) in Dart.
+///
+/// Models name, defining library URI, and type arguments.
+final class ApiInterfaceType implements ApiType {
+  final String name;
+  final String? libraryUri;
+  final List<ApiType> typeArguments;
+  final bool isNullable;
+
+  ApiInterfaceType({
+    required this.name,
+    this.libraryUri,
+    required this.typeArguments,
+    required this.isNullable,
+  });
+
+  factory ApiInterfaceType.fromJson(Map<String, dynamic> json) =>
+      ApiInterfaceType(
+        name: json['name'] as String,
+        libraryUri: json['libraryUri'] as String?,
+        typeArguments: parseList(json, 'typeArguments', ApiType.fromJson),
+        isNullable: json['isNullable'] as bool? ?? false,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': _Kind.interface.jsonName,
+    'name': name,
+    if (libraryUri != null) 'libraryUri': libraryUri,
+    if (typeArguments.isNotEmpty)
+      'typeArguments': typeArguments.map((e) => e.toJson()).toList(),
+    if (isNullable) 'isNullable': true,
+  };
+}
+
+/// Represents a named field within a record type (e.g. `foo` in `({int foo})`).
+final class ApiRecordNamedField {
+  final String name;
+  final ApiType type;
+
+  ApiRecordNamedField({required this.name, required this.type});
+
+  factory ApiRecordNamedField.fromJson(Map<String, dynamic> json) =>
+      ApiRecordNamedField(
+        name: json['name'] as String,
+        type: ApiType.fromJson(json['type'] as Map<String, dynamic>),
+      );
+
+  Map<String, dynamic> toJson() => {'name': name, 'type': type.toJson()};
+}
+
+/// Represents a record type in Dart (e.g. `(int, {String foo})`).
+final class ApiRecordType implements ApiType {
+  final List<ApiType> positionalFields;
+  final List<ApiRecordNamedField> namedFields;
+  final bool isNullable;
+
+  ApiRecordType({
+    required this.positionalFields,
+    required this.namedFields,
+    required this.isNullable,
+  });
+
+  factory ApiRecordType.fromJson(Map<String, dynamic> json) => ApiRecordType(
+    positionalFields: parseList(json, 'positionalFields', ApiType.fromJson),
+    namedFields: parseList(json, 'namedFields', ApiRecordNamedField.fromJson),
+    isNullable: json['isNullable'] as bool? ?? false,
+  );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': _Kind.record.jsonName,
+    if (positionalFields.isNotEmpty)
+      'positionalFields': positionalFields.map((e) => e.toJson()).toList(),
+    if (namedFields.isNotEmpty)
+      'namedFields': namedFields.map((e) => e.toJson()).toList(),
+    if (isNullable) 'isNullable': true,
+  };
+}
+
+/// Represents a function type in Dart (e.g. `void Function(int)`).
+final class ApiFunctionType implements ApiType {
+  final ApiType returnType;
+  final Map<String, ApiType?> typeParameters;
+  final List<ApiParameter> parameters;
+  final bool isNullable;
+
+  ApiFunctionType({
+    required this.returnType,
+    required this.typeParameters,
+    required this.parameters,
+    required this.isNullable,
+  });
+
+  factory ApiFunctionType.fromJson(Map<String, dynamic> json) =>
+      ApiFunctionType(
+        returnType: ApiType.fromJson(
+          json['returnType'] as Map<String, dynamic>,
+        ),
+        typeParameters: parseTypeParameters(json, 'typeParameters'),
+        parameters: parseList(json, 'parameters', ApiParameter.fromJson),
+        isNullable: json['isNullable'] as bool? ?? false,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': _Kind.function.jsonName,
+    'returnType': returnType.toJson(),
+    if (typeParameters.isNotEmpty)
+      'typeParameters': {
+        for (final entry in typeParameters.entries)
+          entry.key: entry.value?.toJson(),
+      },
+    if (parameters.isNotEmpty)
+      'parameters': parameters.map((e) => e.toJson()).toList(),
+    if (isNullable) 'isNullable': true,
+  };
+}
+
+/// Represents a parameter in a function or method signature.
+///
+/// Models parameter name, type, and optional/required/named status.
+final class ApiParameter {
+  final String name;
+  final ApiType type;
+  final bool isRequired;
+  final bool isNamed;
+  final bool isOptionalPositional;
+  final bool isDeprecated;
+
+  ApiParameter({
+    required this.name,
+    required this.type,
+    required this.isRequired,
+    required this.isNamed,
+    required this.isOptionalPositional,
+    required this.isDeprecated,
+  });
+
+  factory ApiParameter.fromJson(Map<String, dynamic> json) => ApiParameter(
+    name: json['name'] as String,
+    type: ApiType.fromJson(json['type'] as Map<String, dynamic>),
+    isRequired: json['isRequired'] as bool? ?? false,
+    isNamed: json['isNamed'] as bool? ?? false,
+    isOptionalPositional: json['isOptionalPositional'] as bool? ?? false,
+    isDeprecated: json['isDeprecated'] as bool? ?? false,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'type': type.toJson(),
+    if (isRequired) 'isRequired': isRequired,
+    if (isNamed) 'isNamed': isNamed,
+    if (isOptionalPositional) 'isOptionalPositional': isOptionalPositional,
+    if (isDeprecated) 'isDeprecated': isDeprecated,
+  };
+}

--- a/pkgs/api_summary/lib/src/json_utils.dart
+++ b/pkgs/api_summary/lib/src/json_utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'api_type.dart';
+
 /// Parses a JSON list of objects using [fromJson].
 List<T> parseList<T>(
   Map<String, dynamic> json,
@@ -16,3 +18,18 @@ List<T> parseList<T>(
 /// Parses a JSON list of strings.
 List<String> parseStringList(Map<String, dynamic> json, String key) =>
     (json[key] as List<dynamic>?)?.map((e) => e as String).toList() ?? [];
+
+/// Parses a JSON map representing type parameters and their bounds.
+Map<String, ApiType?> parseTypeParameters(
+  Map<String, dynamic> json,
+  String key,
+) {
+  final map = json[key];
+  if (map is! Map) return {};
+  return {
+    for (final entry in map.entries)
+      entry.key as String: entry.value == null
+          ? null
+          : ApiType.fromJson(entry.value as Map<String, dynamic>),
+  };
+}


### PR DESCRIPTION
Part 2 of 5 in stacked PR split of #2420.

- Introduce structured data model representations (ApiDeclaration, ApiType, ApiSummary).
- Implement serialization logic (toJson / fromJson) for API entities.