### PR TITLE
Integrate `yaml-test-suite` for specification compliance testing

### DIFF
--- a/pkgs/yaml/test/yaml_test_suite.dart
+++ b/pkgs/yaml/test/yaml_test_suite.dart
@@ -1,0 +1,207 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:collection/collection.dart';
+import 'package:string_scanner/string_scanner.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+/// Represents a single test case from the yaml-test-suite.
+typedef YamlTestCase = ({
+  /// The unique identifier of the test case, typically the filename and an
+  /// index (e.g., '229Q-0').
+  String id,
+
+  /// The URI of the test file this case was loaded from.
+  Uri file,
+
+  /// A short descriptive phrase for the test. Uses the [id] as a fallback if
+  /// not provided.
+  String name,
+
+  /// The origin of the test, such as a link to the YAML spec or the author.
+  String? from,
+
+  /// A set of tags categorizing the test.
+  Set<String> tags,
+
+  /// The actual YAML string payload that the parser is meant to process.
+  String yaml,
+
+  /// A boolean indicating if the yaml input is invalid and the parser must
+  /// throw an error.
+  bool fail,
+
+  /// A boolean indicating if the test suite descriptor included a 'json' field.
+  bool hasJson,
+
+  /// The expected parsed result in JSON format.
+  /// If there are no json docs, the list is empty.
+  List<({String source, Object? json})> json,
+
+  /// A low-level event stream representation.
+  String? tree,
+
+  /// The expected output string if a YAML dumper were to reconstruct the YAML.
+  String? dump,
+
+  /// The expected output string if a YAML emitter were to reconstruct the YAML.
+  String? emit,
+});
+
+/// Loads all test cases from the yaml-test-suite descriptors.
+Iterable<YamlTestCase> loadYamlTestSuite() sync* {
+  final libUri = Isolate.resolvePackageUriSync(Uri.parse('package:yaml/'))!;
+  final srcUri = libUri.resolve('../third_party/yaml-test-suite/src');
+  final srcDir = Directory.fromUri(srcUri);
+
+  final files = srcDir
+      .listSync()
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.yaml'))
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+
+  if (files.isEmpty) {
+    throw AssertionError('yaml-test-suite files not found');
+  }
+
+  for (final file in files) {
+    final content = file.readAsStringSync();
+    // Load the yaml test descriptor
+    final yamlList = loadYaml(content) as YamlList;
+
+    final fileId = file.uri.pathSegments.last.replaceAll('.yaml', '');
+
+    for (var i = 0; i < yamlList.length; i++) {
+      final item = yamlList[i] as YamlMap;
+      final id = '$fileId-$i';
+
+      // Parse tags into a Set<String>
+      final tagsStr = item['tags'] as String?;
+      final tags = tagsStr != null && tagsStr.trim().isNotEmpty
+          ? tagsStr.trim().split(RegExp(r'\s+')).toSet()
+          : const <String>{};
+
+      yield (
+        id: id,
+        file: file.uri,
+        name:
+            item['name'] as String? ?? id, // Fallback to id if name is missing
+        from: item['from'] as String?,
+        tags: tags,
+        yaml: _replaceSpecialCharacters(item['yaml'] as String? ?? ''),
+        fail: item['fail'] as bool? ?? false,
+        hasJson: item['json'] != null,
+        json: (() {
+          final j = item['json'] as String?;
+          if (j == null) return <({String source, Object? json})>[];
+          return splitMultiJson(j)
+              .map((s) => (source: s, json: jsonDecode(s)))
+              .toList();
+        })(),
+        tree: item['tree'] as String?,
+        dump: item['dump'] as String?,
+        emit: item['emit'] as String?,
+      );
+    }
+  }
+}
+
+/// Replaces special characters used by yaml-test-suite to visualize invisible
+/// characters.
+/// See: https://github.com/yaml/yaml-test-suite/blob/main/ReadMe.md#special-characters
+String _replaceSpecialCharacters(String input) => input
+    .replaceAll('␣', ' ')
+    .replaceAll(RegExp(r'—*»'), '\t')
+    .replaceAll('↵', '')
+    .replaceAll('←', '\r')
+    .replaceAll('⇔', '\uFEFF')
+    .replaceFirst(RegExp(r'∎\n?$'), '');
+
+extension YamlTestCaseExtension on YamlTestCase {
+  void runTest() {
+    if (this.fail) {
+      try {
+        loadYamlStream(this.yaml);
+      } on YamlException {
+        return;
+      }
+      throw TestFailure('Expected parsing to fail');
+    }
+
+    final docs = loadYamlStream(this.yaml);
+
+    if (this.hasJson) {
+      final actualDocs = docs.map(_toJson).toList();
+      final expectedDocs = this.json.map((e) => e.json).toList();
+
+      if (!const DeepCollectionEquality().equals(actualDocs, expectedDocs)) {
+        const encoder = JsonEncoder.withIndent('  ');
+        final actualJson = encoder.convert(actualDocs);
+        final expectedStr = encoder.convert(expectedDocs);
+        throw TestFailure(
+            'JSON mismatch\nExpected:\n$expectedStr\nActual:\n$actualJson');
+      }
+    }
+  }
+}
+
+/// Splits concatenated JSON documents into separate strings
+Iterable<String> splitMultiJson(String json) sync* {
+  final scanner = StringScanner(json);
+
+  while (!scanner.isDone) {
+    scanner.scan(RegExp(r'\s+'));
+    if (scanner.isDone) break;
+
+    final start = scanner.position;
+    if (scanner.scan(RegExp(r'[{[]'))) {
+      var depth = 1;
+      while (depth > 0 && !scanner.isDone) {
+        if (scanner.scan(RegExp(r'"(?:\\.|[^"\\])*"'))) continue;
+        if (scanner.scan(RegExp(r'[{[]'))) {
+          depth++;
+        } else if (scanner.scan(RegExp(r'[}\]]'))) {
+          depth--;
+        } else {
+          scanner.readChar();
+        }
+      }
+    } else if (scanner.scan(RegExp(r'"(?:\\.|[^"\\])*"'))) {
+      // scanned string
+    } else {
+      // primitive (number, true, false, null)
+      scanner.scan(RegExp(r'[^ \n\r\t,\]}]+'));
+    }
+    yield json.substring(start, scanner.position);
+  }
+}
+
+/// Recursively converts Yaml nodes to standard JSON-encodable Dart objects.
+Object? _toJson(Object? node) {
+  if (node is YamlMap) {
+    final map = <String, Object?>{};
+    for (final entry in node.entries) {
+      final key = entry.key;
+      map[_toJson(key)?.toString() ?? 'null'] = _toJson(entry.value);
+    }
+    return map;
+  } else if (node is YamlList) {
+    return node.map(_toJson).toList();
+  } else if (node is YamlScalar) {
+    final val = node.value;
+    if (val is double) {
+      if (val.isNaN) return '.nan';
+      if (val == double.infinity) return '.inf';
+      if (val == double.negativeInfinity) return '-.inf';
+    }
+    return val;
+  }
+  return node;
+}

--- a/pkgs/yaml/test/yaml_test_suite_test.dart
+++ b/pkgs/yaml/test/yaml_test_suite_test.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'package:test/test.dart';
+
+import 'yaml_test_suite.dart';
+
+void main() {
+  final cases = loadYamlTestSuite();
+
+  for (final c in cases) {
+    test(c.name, () {
+      if (_expectedFailures.contains(c.id)) {
+        try {
+          c.runTest();
+        } on TestFailure {
+          return; // Expected failure, exit the test successfully.
+        } catch (e) {
+          return; // Other errors from package:yaml are also expected failures.
+        }
+        fail(
+          'Test ${c.id} was expected to fail, but it passed. '
+          'Please remove it from _expectedFailures!',
+        );
+      } else {
+        c.runTest();
+      }
+    });
+  }
+}
+
+const _expectedFailures = <String>[
+  'VJP3-0',
+  '7FWL-0',
+  '565N-0',
+  '6CK3-0',
+  'J7PZ-0',
+  'UGM3-0',
+  'X4QW-0',
+  'CC74-0',
+  'CVW2-0',
+  'QB6E-0',
+  'SU5Z-0',
+  'DK4H-0',
+  '5TYM-0',
+  'Y79Y-0',
+  'Y79Y-3',
+  'Y79Y-4',
+  'Y79Y-5',
+  'Y79Y-6',
+  'Y79Y-7',
+  'Y79Y-8',
+  'Y79Y-9',
+  '9C9N-0',
+  'DK95-0',
+  'DK95-1',
+  'DK95-4',
+  'LHL4-0',
+  'ZXT5-0',
+  'L24T-1',
+  'P76L-0',
+  '9JBA-0',
+  'S98Z-0',
+  '2JQS-0',
+  'MUS6-0',
+  'MUS6-1',
+  'BS4K-0',
+  'X38W-0',
+  'ZYU8-2',
+  'RHX7-0',
+  'UKK6-1',
+  '2XXW-0',
+  '9HCY-0',
+  'KS4U-0',
+  'Z9M4-0',
+  'EB22-0',
+  '3HFZ-0',
+];

--- a/pkgs/yaml/third_party/yaml-test-suite/LICENSE
+++ b/pkgs/yaml/third_party/yaml-test-suite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-2020 Ingy döt Net
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkgs/yaml/third_party/yaml-test-suite/README.md
+++ b/pkgs/yaml/third_party/yaml-test-suite/README.md
@@ -1,0 +1,175 @@
+YAML Test Suite
+===============
+
+Comprehensive Test Suite for YAML
+
+## Overview
+
+This repository contains data for testing the correctness of YAML processors.
+
+The types of data include:
+
+* Metadata about the test
+  * Name (short phrase)
+  * Tags
+  * Description
+* Input YAML
+* Canonical output YAML
+* Matching JSON
+* Token stream notation
+* Event stream notation
+* Error data
+* etc
+
+To get a quick overview of the tests you can have a look at the [YAML Test
+Matrix](http://matrix.yaml.info/), made from
+<https://github.com/perlpunk/yaml-test-matrix>.
+
+You can also view the latest test results from 15 different parsers in
+[this Google sheet](https://tinyurl.com/2p97ah8a).
+
+## Usage
+
+The tests are available in 2 forms.
+Files in the `src` directory encode all the data for YAML using YAML.
+The data from these tests is also available in a form where each test
+has its own directory.
+
+For that, use the latest data release under
+[https://github.com/yaml/yaml-test-suite/releases](
+https://github.com/yaml/yaml-test-suite/releases):
+
+    git clone https://github.com/yaml/yaml-test-suite -b data-YYYY-MM-DD
+
+There are tests which have multiple similar subtests. Those subtests are
+in their own numeric directories under the parent id, e.g.:
+
+    VJP3/
+    VJP3/00
+    VJP3/00/===
+    VJP3/00/error
+    VJP3/00/in.yaml
+    VJP3/00/test.event
+    VJP3/01
+    ...
+
+
+The releases are made from the `data` branch, which is made from the data in
+the YAML in the `main` branch.
+You shouldn't use the data branch directly as the branch contains unreleased
+commits which might be wrong, and it is squashed and force pushed from time to
+time.
+
+### Special Characters
+
+The YAML files use a number of non-ascii unicode characters to indicate the
+presence of certain characters that would be otherwise hard to read.
+
+* `␣` is used for trailing space characters
+* Hard tabs are reresented by one of:  (expanding to 4 spaces)
+  * `———»`
+  * `——»`
+  * `—»`
+  * `»`
+* `↵` us used to show trailing newline characters
+* `∎` is used at the end when there is no final newline character
+* `←` indicates a carriage return character
+* `⇔` indicates a byte order mark (BOM) character
+
+Also these are used in test event output:
+
+* `<SPC>` for a space character
+* `<TAB>` for a tab character
+
+## The `data` branch files
+
+The YAML test files in the `src/` dir are turned into data files in the `data`
+branch.
+The `make data-update` command generates the `data` branch files under the
+`./data/` directory.
+For instance, a file `src/AB3D.yaml` will generate a `data/AB3D/` directory.
+
+A YAML test file can have 1 or more tests.
+Originally each file had one test, and all the data files were under
+`data/AB3D/`.
+If a YAML test file has more than one test, subdirectories are created:
+`data/AB3D/00/`, `data/AB3D/01/`, `data/AB3D/02/`, etc.
+
+The test files are:
+
+* `===` -- The name/label of the test
+* `in.yaml` -- The YAML input to be parsed or loaded
+* `test.event` -- The event DSL produced by the parser test program
+* `in.json` -- The JSON value that shoiuld load the same as `in.yaml`
+* `out.yaml` -- The most normal output a dumper would produce
+* `error` -- This file indicates the YAML should fail to parse
+* `emit.yaml` -- Output an emitter would produce
+
+## Makefile Targets
+
+The Makefile has a number of targets for automating the process of adding new
+tests and also preprocessing them into the `data` branch.
+
+* `make data`
+
+  Create a `data` worktree subdirectory with all the tests as data files.
+
+* `make data-update`
+
+  Update the `data` branch directory with the latest info in the `src`
+  directory.
+
+* `make export`
+
+  Creates an `export.tsv` file with all the data from the `src` test files.
+  This tsv data can be copied into a google spreadsheet.
+  The [YAML parser playground](https://play.yaml.io/main/parser) has a button
+  to copy a test to the same tsv form.
+
+* `make import`
+
+  Make a directory called `new` from a file named `import.tsv`.
+  The `import.tsv` file should have data copied from a google spreadsheet.
+
+* `make add-new`
+
+  Copy the new tests under `new/` into `src/` to make a PR for new tests.
+
+* `make testml`
+
+  Generate `.tml` files under a `testml/` directory for all the suite tests.
+
+* `make clean`
+
+  Remove generated files and directories.
+
+## Libaries using this test suite
+
+* C
+  * [libyaml](https://github.com/yaml/libyaml)
+  * [libfyaml](https://github.com/pantoniou/libfyaml)
+* C++
+  * [rapidyaml](https://github.com/biojppm/rapidyaml)
+* C#
+  * [YamlDotNet](https://github.com/aaubry/YamlDotNet)
+* D
+  * [dyaml](https://github.com/dlang-community/D-YAML)
+* Delphi
+  * [Neslib.Yaml](https://github.com/neslib/Neslib.Yaml)
+* Haskell
+  * [HsYAML](https://github.com/haskell-hvr/HsYAML)
+* Java
+  * [SnakeYAML Engine](https://bitbucket.org/asomov/snakeyaml-engine)
+* Javascript
+  * [yaml](https://github.com/eemeli/yaml)
+* Nim
+  * [NimYAML](https://github.com/flyx/NimYAML)
+* Perl 5
+  * [YAML::PP](https://github.com/perlpunk/YAML-PP-p5)
+* PHP
+  * [php-yaml-parser](https://github.com/maxbeckers/php-yaml-parser)
+* Scala
+  * [Scala-Yaml](https://github.com/VirtusLab/scala-yaml)
+
+If your library is using the test suite, drop us a line and we can add it here.
+It would also be nice if you could add a link back to this test suite.

--- a/pkgs/yaml/third_party/yaml-test-suite/src/229Q.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/229Q.yaml
@@ -1,0 +1,56 @@
+---
+- name: Spec Example 2.4. Sequence of Mappings
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760193
+  tags: sequence mapping spec
+  yaml: |
+    -
+      name: Mark McGwire
+      hr:   65
+      avg:  0.278
+    -
+      name: Sammy Sosa
+      hr:   63
+      avg:  0.288
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        =VAL :name
+        =VAL :Mark McGwire
+        =VAL :hr
+        =VAL :65
+        =VAL :avg
+        =VAL :0.278
+       -MAP
+       +MAP
+        =VAL :name
+        =VAL :Sammy Sosa
+        =VAL :hr
+        =VAL :63
+        =VAL :avg
+        =VAL :0.288
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "name": "Mark McGwire",
+        "hr": 65,
+        "avg": 0.278
+      },
+      {
+        "name": "Sammy Sosa",
+        "hr": 63,
+        "avg": 0.288
+      }
+    ]
+  dump: |
+    - name: Mark McGwire
+      hr: 65
+      avg: 0.278
+    - name: Sammy Sosa
+      hr: 63
+      avg: 0.288

--- a/pkgs/yaml/third_party/yaml-test-suite/src/236B.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/236B.yaml
@@ -1,0 +1,15 @@
+---
+- name: Invalid value after mapping
+  from: '@perlpunk'
+  tags: error mapping
+  fail: true
+  yaml: |
+    foo:
+      bar
+    invalid
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL :bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/26DV.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/26DV.yaml
@@ -1,0 +1,82 @@
+---
+- name: Whitespace around colon in mappings
+  from: '@perlpunk'
+  tags: alias mapping whitespace
+  yaml: |
+    "top1" :␣
+      "key1" : &alias1 scalar1
+    'top2' :␣
+      'key2' : &alias2 scalar2
+    top3: &node3␣
+      *alias1 : scalar3
+    top4:␣
+      *alias2 : scalar4
+    top5   :␣␣␣␣
+      scalar5
+    top6:␣
+      &anchor6 'key6' : scalar6
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL "top1
+       +MAP
+        =VAL "key1
+        =VAL &alias1 :scalar1
+       -MAP
+       =VAL 'top2
+       +MAP
+        =VAL 'key2
+        =VAL &alias2 :scalar2
+       -MAP
+       =VAL :top3
+       +MAP &node3
+        =ALI *alias1
+        =VAL :scalar3
+       -MAP
+       =VAL :top4
+       +MAP
+        =ALI *alias2
+        =VAL :scalar4
+       -MAP
+       =VAL :top5
+       =VAL :scalar5
+       =VAL :top6
+       +MAP
+        =VAL &anchor6 'key6
+        =VAL :scalar6
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "top1": {
+        "key1": "scalar1"
+      },
+      "top2": {
+        "key2": "scalar2"
+      },
+      "top3": {
+        "scalar1": "scalar3"
+      },
+      "top4": {
+        "scalar2": "scalar4"
+      },
+      "top5": "scalar5",
+      "top6": {
+        "key6": "scalar6"
+      }
+    }
+  dump: |
+    "top1":
+      "key1": &alias1 scalar1
+    'top2':
+      'key2': &alias2 scalar2
+    top3: &node3
+      *alias1 : scalar3
+    top4:
+      *alias2 : scalar4
+    top5: scalar5
+    top6:
+      &anchor6 'key6': scalar6

--- a/pkgs/yaml/third_party/yaml-test-suite/src/27NA.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/27NA.yaml
@@ -1,0 +1,17 @@
+---
+- name: Spec Example 5.9. Directive Indicator
+  from: http://www.yaml.org/spec/1.2/spec.html#id2774058
+  tags: spec directive 1.3-err
+  yaml: |
+    %YAML 1.2
+    --- text
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :text
+     -DOC
+    -STR
+  json: |
+    "text"
+  dump: |
+    --- text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/2AUY.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/2AUY.yaml
@@ -1,0 +1,32 @@
+---
+- name: Tags in Block Sequence
+  from: NimYAML tests
+  tags: tag sequence
+  yaml: |2
+     - !!str a
+     - b
+     - !!int 42
+     - d
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL <tag:yaml.org,2002:str> :a
+       =VAL :b
+       =VAL <tag:yaml.org,2002:int> :42
+       =VAL :d
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "a",
+      "b",
+      42,
+      "d"
+    ]
+  dump: |
+    - !!str a
+    - b
+    - !!int 42
+    - d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/2CMS.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/2CMS.yaml
@@ -1,0 +1,12 @@
+---
+- name: Invalid mapping in plain multiline
+  from: '@perlpunk'
+  tags: error mapping
+  fail: true
+  yaml: |
+    this
+     is
+      invalid: x
+  tree: |
+    +STR
+     +DOC

--- a/pkgs/yaml/third_party/yaml-test-suite/src/2EBW.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/2EBW.yaml
@@ -1,0 +1,41 @@
+---
+- name: Allowed characters in keys
+  from: '@perlpunk'
+  tags: mapping scalar
+  yaml: |
+    a!"#$%&'()*+,-./09:;<=>?@AZ[\]^_`az{|}~: safe
+    ?foo: safe question mark
+    :foo: safe colon
+    -foo: safe dash
+    this is#not: a comment
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a!"#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~
+       =VAL :safe
+       =VAL :?foo
+       =VAL :safe question mark
+       =VAL ::foo
+       =VAL :safe colon
+       =VAL :-foo
+       =VAL :safe dash
+       =VAL :this is#not
+       =VAL :a comment
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a!\"#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~": "safe",
+      "?foo": "safe question mark",
+      ":foo": "safe colon",
+      "-foo": "safe dash",
+      "this is#not": "a comment"
+    }
+  dump: |
+    a!"#$%&'()*+,-./09:;<=>?@AZ[\]^_`az{|}~: safe
+    ?foo: safe question mark
+    :foo: safe colon
+    -foo: safe dash
+    this is#not: a comment

--- a/pkgs/yaml/third_party/yaml-test-suite/src/2G84.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/2G84.yaml
@@ -1,0 +1,38 @@
+---
+- name: Literal modifers
+  from: '@ingydotnet'
+  tags: literal scalar
+  fail: true
+  yaml: |
+    --- |0
+  tree: |
+    +STR
+     +DOC ---
+
+- fail: true
+  yaml: |
+    --- |10
+
+- yaml: |
+    --- |1-∎
+  tree: |
+    +STR
+     +DOC ---
+      =VAL |
+     -DOC
+    -STR
+  json: |
+    ""
+  emit: |
+    --- ""
+
+- yaml: |
+    --- |1+∎
+  tree: |
+    +STR
+     +DOC ---
+      =VAL |
+     -DOC
+    -STR
+  emit: |
+    --- ""

--- a/pkgs/yaml/third_party/yaml-test-suite/src/2JQS.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/2JQS.yaml
@@ -1,0 +1,18 @@
+---
+- name: Block Mapping with Missing Keys
+  from: NimYAML tests
+  tags: duplicate-key mapping empty-key
+  yaml: |
+    : a
+    : b
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :
+       =VAL :a
+       =VAL :
+       =VAL :b
+      -MAP
+     -DOC
+    -STR

--- a/pkgs/yaml/third_party/yaml-test-suite/src/2LFX.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/2LFX.yaml
@@ -1,0 +1,22 @@
+---
+- name: Spec Example 6.13. Reserved Directives [1.3]
+  from: 6LVF, modified for YAML 1.3
+  tags: spec directive header double 1.3-mod
+  yaml: |
+    %FOO  bar baz # Should be ignored
+                  # with a warning.
+    ---
+    "foo"
+  tree: |
+    +STR
+     +DOC ---
+      =VAL "foo
+     -DOC
+    -STR
+  json: |
+    "foo"
+  dump: |
+    ---
+    "foo"
+  emit: |
+    --- "foo"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/2SXE.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/2SXE.yaml
@@ -1,0 +1,27 @@
+---
+- name: Anchors With Colon in Name
+  from: Mailing List Discussion
+  tags: alias edge mapping 1.3-err
+  yaml: |
+    &a: key: &a value
+    foo:
+      *a:
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL &a: :key
+       =VAL &a :value
+       =VAL :foo
+       =ALI *a:
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": "value",
+      "foo": "key"
+    }
+  dump: |
+    &a: key: &a value
+    foo: *a:

--- a/pkgs/yaml/third_party/yaml-test-suite/src/2XXW.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/2XXW.yaml
@@ -1,0 +1,36 @@
+---
+- name: Spec Example 2.25. Unordered Sets
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761758
+  tags: spec mapping unknown-tag explicit-key
+  yaml: |
+    # Sets are represented as a
+    # Mapping where each key is
+    # associated with a null value
+    --- !!set
+    ? Mark McGwire
+    ? Sammy Sosa
+    ? Ken Griff
+  tree: |
+    +STR
+     +DOC ---
+      +MAP <tag:yaml.org,2002:set>
+       =VAL :Mark McGwire
+       =VAL :
+       =VAL :Sammy Sosa
+       =VAL :
+       =VAL :Ken Griff
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "Mark McGwire": null,
+      "Sammy Sosa": null,
+      "Ken Griff": null
+    }
+  dump: |
+    --- !!set
+    Mark McGwire:
+    Sammy Sosa:
+    Ken Griff:

--- a/pkgs/yaml/third_party/yaml-test-suite/src/33X3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/33X3.yaml
@@ -1,0 +1,30 @@
+---
+- name: Three explicit integers in a block sequence
+  from: IRC
+  tags: sequence tag
+  yaml: |
+    ---
+    - !!int 1
+    - !!int -2
+    - !!int 33
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       =VAL <tag:yaml.org,2002:int> :1
+       =VAL <tag:yaml.org,2002:int> :-2
+       =VAL <tag:yaml.org,2002:int> :33
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      1,
+      -2,
+      33
+    ]
+  dump: |
+    ---
+    - !!int 1
+    - !!int -2
+    - !!int 33

--- a/pkgs/yaml/third_party/yaml-test-suite/src/35KP.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/35KP.yaml
@@ -1,0 +1,44 @@
+---
+- name: Tags for Root Objects
+  from: NimYAML tests
+  tags: explicit-key header mapping tag
+  yaml: |
+    --- !!map
+    ? a
+    : b
+    --- !!seq
+    - !!str c
+    --- !!str
+    d
+    e
+  tree: |
+    +STR
+     +DOC ---
+      +MAP <tag:yaml.org,2002:map>
+       =VAL :a
+       =VAL :b
+      -MAP
+     -DOC
+     +DOC ---
+      +SEQ <tag:yaml.org,2002:seq>
+       =VAL <tag:yaml.org,2002:str> :c
+      -SEQ
+     -DOC
+     +DOC ---
+      =VAL <tag:yaml.org,2002:str> :d e
+     -DOC
+    -STR
+  json: |
+    {
+      "a": "b"
+    }
+    [
+      "c"
+    ]
+    "d e"
+  dump: |
+    --- !!map
+    a: b
+    --- !!seq
+    - !!str c
+    --- !!str d e

--- a/pkgs/yaml/third_party/yaml-test-suite/src/36F6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/36F6.yaml
@@ -1,0 +1,28 @@
+---
+- name: Multiline plain scalar with empty line
+  from: '@perlpunk'
+  tags: mapping scalar
+  yaml: |
+    ---
+    plain: a
+     b
+
+     c
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :plain
+       =VAL :a b\nc
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "plain": "a b\nc"
+    }
+  dump: |
+    ---
+    plain: 'a b
+
+      c'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/3ALJ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/3ALJ.yaml
@@ -1,0 +1,28 @@
+---
+- name: Block Sequence in Block Sequence
+  from: NimYAML tests
+  tags: sequence
+  yaml: |
+    - - s1_i1
+      - s1_i2
+    - s2
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ
+        =VAL :s1_i1
+        =VAL :s1_i2
+       -SEQ
+       =VAL :s2
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      [
+        "s1_i1",
+        "s1_i2"
+      ],
+      "s2"
+    ]

--- a/pkgs/yaml/third_party/yaml-test-suite/src/3GZX.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/3GZX.yaml
@@ -1,0 +1,31 @@
+---
+- name: Spec Example 7.1. Alias Nodes
+  from: http://www.yaml.org/spec/1.2/spec.html#id2786448
+  tags: mapping spec alias
+  yaml: |
+    First occurrence: &anchor Foo
+    Second occurrence: *anchor
+    Override anchor: &anchor Bar
+    Reuse anchor: *anchor
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :First occurrence
+       =VAL &anchor :Foo
+       =VAL :Second occurrence
+       =ALI *anchor
+       =VAL :Override anchor
+       =VAL &anchor :Bar
+       =VAL :Reuse anchor
+       =ALI *anchor
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "First occurrence": "Foo",
+      "Second occurrence": "Foo",
+      "Override anchor": "Bar",
+      "Reuse anchor": "Bar"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/3HFZ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/3HFZ.yaml
@@ -1,0 +1,17 @@
+---
+- name: Invalid content after document end marker
+  from: '@perlpunk'
+  tags: error footer
+  fail: true
+  yaml: |
+    ---
+    key: value
+    ... invalid
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :key
+       =VAL :value
+      -MAP
+     -DOC ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/3MYT.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/3MYT.yaml
@@ -1,0 +1,18 @@
+---
+- name: Plain Scalar looking like key, comment, anchor and tag
+  from: https://gist.github.com/anonymous/a98d50ce42a59b1e999552bea7a31f57 via @ingydotnet
+  tags: scalar
+  yaml: |
+    ---
+    k:#foo
+     &a !t s
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :k:#foo &a !t s
+     -DOC
+    -STR
+  json: |
+    "k:#foo &a !t s"
+  dump: |
+    --- k:#foo &a !t s

--- a/pkgs/yaml/third_party/yaml-test-suite/src/3R3P.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/3R3P.yaml
@@ -1,0 +1,22 @@
+---
+- name: Single block sequence with anchor
+  from: '@perlpunk'
+  tags: anchor sequence
+  yaml: |
+    &sequence
+    - a
+  tree: |
+    +STR
+     +DOC
+      +SEQ &sequence
+       =VAL :a
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "a"
+    ]
+  dump: |
+    &sequence
+    - a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/3RLN.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/3RLN.yaml
@@ -1,0 +1,87 @@
+---
+- name: Leading tabs in double quoted
+  from: '@ingydotnet'
+  tags: double whitespace
+  yaml: |
+    "1 leading
+        \ttab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "1 leading \ttab
+     -DOC
+    -STR
+  json: |
+    "1 leading \ttab"
+  emit: |
+    "1 leading \ttab"
+
+- yaml: |
+    "2 leading
+        \———»tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "2 leading \ttab
+     -DOC
+    -STR
+  json: |
+    "2 leading \ttab"
+  emit: |
+    "2 leading \ttab"
+
+- yaml: |
+    "3 leading
+        ————»tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "3 leading tab
+     -DOC
+    -STR
+  json: |
+    "3 leading tab"
+  emit: |
+    "3 leading tab"
+
+- yaml: |
+    "4 leading
+        \t  tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "4 leading \t  tab
+     -DOC
+    -STR
+  json: |
+    "4 leading \t  tab"
+  emit: |
+    "4 leading \t  tab"
+
+- yaml: |
+    "5 leading
+        \———»  tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "5 leading \t  tab
+     -DOC
+    -STR
+  json: |
+    "5 leading \t  tab"
+  emit: |
+    "5 leading \t  tab"
+
+- yaml: |
+    "6 leading
+        ————»  tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "6 leading tab
+     -DOC
+    -STR
+  json: |
+    "6 leading tab"
+  emit: |
+    "6 leading tab"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/3UYS.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/3UYS.yaml
@@ -1,0 +1,21 @@
+---
+- name: Escaped slash in double quotes
+  from: '@perlpunk'
+  tags: double
+  yaml: |
+    escaped slash: "a\/b"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :escaped slash
+       =VAL "a/b
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "escaped slash": "a/b"
+    }
+  dump: |
+    escaped slash: "a/b"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4ABK.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4ABK.yaml
@@ -1,0 +1,27 @@
+---
+- name: Flow Mapping Separate Values
+  from: http://www.yaml.org/spec/1.2/spec.html#id2791704
+  tags: flow mapping
+  yaml: |
+    {
+    unquoted : "separate",
+    http://foo.com,
+    omitted value:,
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :unquoted
+       =VAL "separate
+       =VAL :http://foo.com
+       =VAL :
+       =VAL :omitted value
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    unquoted: "separate"
+    http://foo.com: null
+    omitted value: null

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4CQQ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4CQQ.yaml
@@ -1,0 +1,30 @@
+---
+- name: Spec Example 2.18. Multi-line Flow Scalars
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761268
+  tags: spec scalar
+  yaml: |
+    plain:
+      This unquoted scalar
+      spans many lines.
+
+    quoted: "So does this
+      quoted scalar.\n"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :plain
+       =VAL :This unquoted scalar spans many lines.
+       =VAL :quoted
+       =VAL "So does this quoted scalar.\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "plain": "This unquoted scalar spans many lines.",
+      "quoted": "So does this quoted scalar.\n"
+    }
+  dump: |
+    plain: This unquoted scalar spans many lines.
+    quoted: "So does this quoted scalar.\n"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4EJS.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4EJS.yaml
@@ -1,0 +1,15 @@
+---
+- name: Invalid tabs as indendation in a mapping
+  from: https://github.com/nodeca/js-yaml/issues/80
+  tags: error mapping whitespace
+  fail: true
+  yaml: |
+    ---
+    a:
+    ———»b:
+    ———»———»c: value
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4FJ6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4FJ6.yaml
@@ -1,0 +1,42 @@
+---
+- name: Nested implicit complex keys
+  from: '@perlpunk'
+  tags: complex-key flow mapping sequence
+  yaml: |
+    ---
+    [
+      [ a, [ [[b,c]]: d, e]]: 23
+    ]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []
+       +MAP {}
+        +SEQ []
+         =VAL :a
+         +SEQ []
+          +MAP {}
+           +SEQ []
+            +SEQ []
+             =VAL :b
+             =VAL :c
+            -SEQ
+           -SEQ
+           =VAL :d
+          -MAP
+          =VAL :e
+         -SEQ
+        -SEQ
+        =VAL :23
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  dump: |
+    ---
+    - ? - a
+        - - ? - - b
+                - c
+            : d
+          - e
+      : 23

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4GC6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4GC6.yaml
@@ -1,0 +1,14 @@
+---
+- name: Spec Example 7.7. Single Quoted Characters
+  from: http://www.yaml.org/spec/1.2/spec.html#id2788307
+  tags: spec scalar 1.3-err
+  yaml: |
+    'here''s to "quotes"'
+  tree: |
+    +STR
+     +DOC
+      =VAL 'here's to "quotes"
+     -DOC
+    -STR
+  json: |
+    "here's to \"quotes\""

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4H7K.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4H7K.yaml
@@ -1,0 +1,17 @@
+---
+- name: Flow sequence with invalid extra closing bracket
+  from: '@perlpunk'
+  tags: error flow sequence
+  fail: true
+  yaml: |
+    ---
+    [ a, b, c ] ]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       =VAL :a
+       =VAL :b
+       =VAL :c
+      -SEQ
+     -DOC

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4HVU.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4HVU.yaml
@@ -1,0 +1,19 @@
+---
+- name: Wrong indendation in Sequence
+  from: '@perlpunk'
+  tags: error sequence indent
+  fail: true
+  yaml: |
+    key:
+       - ok
+       - also ok
+      - wrong
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       +SEQ
+        =VAL :ok
+        =VAL :also ok
+       -SEQ

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4JVG.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4JVG.yaml
@@ -1,0 +1,20 @@
+---
+- name: Scalar value with two anchors
+  from: '@perlpunk'
+  tags: anchor error mapping
+  fail: true
+  yaml: |
+    top1: &node1
+      &k1 key1: val1
+    top2: &node2
+      &v2 val2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :top1
+       +MAP &node1
+        =VAL &k1 :key1
+        =VAL :val1
+       -MAP
+       =VAL :top2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4MUZ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4MUZ.yaml
@@ -1,0 +1,56 @@
+---
+- name: Flow mapping colon on line after key
+  from: '@ingydotnet'
+  tags: flow mapping
+  yaml: |
+    {"foo"
+    : "bar"}
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL "foo
+       =VAL "bar
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "bar"
+    }
+  emit: |
+    "foo": "bar"
+
+- yaml: |
+    {"foo"
+    : bar}
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL "foo
+       =VAL :bar
+      -MAP
+     -DOC
+    -STR
+  emit: |
+    "foo": bar
+
+- yaml: |
+    {foo
+    : bar}
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :foo
+       =VAL :bar
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "bar"
+    }
+  emit: |
+    foo: bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4Q9F.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4Q9F.yaml
@@ -1,0 +1,29 @@
+---
+- name: Folded Block Scalar [1.3]
+  from: TS54, modified for YAML 1.3
+  tags: folded scalar 1.3-mod whitespace
+  yaml: |
+    --- >
+     ab
+     cd
+    ␣
+     ef
+
+
+     gh
+  tree: |
+    +STR
+     +DOC ---
+      =VAL >ab cd\nef\n\ngh\n
+     -DOC
+    -STR
+  json: |
+    "ab cd\nef\n\ngh\n"
+  dump: |
+    --- >
+      ab cd
+
+      ef
+
+
+      gh

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4QFQ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4QFQ.yaml
@@ -1,0 +1,44 @@
+---
+- name: Spec Example 8.2. Block Indentation Indicator [1.3]
+  from: R4YG, modified for YAML 1.3
+  tags: spec literal folded scalar libyaml-err 1.3-mod whitespace
+  yaml: |
+    - |
+     detected
+    - >
+    ␣
+    ␣␣
+      # detected
+    - |1
+      explicit
+    - >
+     detected
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL |detected\n
+       =VAL >\n\n# detected\n
+       =VAL | explicit\n
+       =VAL >detected\n
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "detected\n",
+      "\n\n# detected\n",
+      " explicit\n",
+      "detected\n"
+    ]
+  emit: |
+    - |
+      detected
+    - >2
+
+
+      # detected
+    - |2
+       explicit
+    - >
+      detected

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4RWC.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4RWC.yaml
@@ -1,0 +1,27 @@
+---
+- name: Trailing spaces after flow collection
+  tags: flow whitespace
+  from: '@ingydotnet'
+  yaml: |2
+      [1, 2, 3]␣␣
+    ␣␣∎
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       =VAL :1
+       =VAL :2
+       =VAL :3
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      1,
+      2,
+      3
+    ]
+  dump: |
+    - 1
+    - 2
+    - 3

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4UYU.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4UYU.yaml
@@ -1,0 +1,14 @@
+---
+- name: Colon in Double Quoted String
+  from: NimYAML tests
+  tags: mapping scalar 1.3-err
+  yaml: |
+    "foo: bar\": baz"
+  tree: |
+    +STR
+     +DOC
+      =VAL "foo: bar": baz
+     -DOC
+    -STR
+  json: |
+    "foo: bar\": baz"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4V8U.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4V8U.yaml
@@ -1,0 +1,17 @@
+---
+- name: Plain scalar with backslashes
+  from: '@perlpunk'
+  tags: scalar
+  yaml: |
+    ---
+    plain\value\with\backslashes
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :plain\\value\\with\\backslashes
+     -DOC
+    -STR
+  json: |
+    "plain\\value\\with\\backslashes"
+  dump: |
+    --- plain\value\with\backslashes

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4WA9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4WA9.yaml
@@ -1,0 +1,40 @@
+---
+- name: Literal scalars
+  from: '@ingydotnet'
+  tags: indent literal
+  yaml: |
+    - aaa: |2
+        xxx
+      bbb: |
+        xxx
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        =VAL :aaa
+        =VAL |xxx\n
+        =VAL :bbb
+        =VAL |xxx\n
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "aaa" : "xxx\n",
+        "bbb" : "xxx\n"
+      }
+    ]
+  dump: |
+    ---
+    - aaa: |
+        xxx
+      bbb: |
+        xxx
+  emit: |
+    - aaa: |
+        xxx
+      bbb: |
+        xxx

--- a/pkgs/yaml/third_party/yaml-test-suite/src/4ZYM.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/4ZYM.yaml
@@ -1,0 +1,41 @@
+---
+- name: Spec Example 6.4. Line Prefixes
+  from: http://www.yaml.org/spec/1.2/spec.html#id2778720
+  tags: spec scalar literal double upto-1.2 whitespace
+  yaml: |
+    plain: text
+      lines
+    quoted: "text
+      —»lines"
+    block: |
+      text
+       »lines
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :plain
+       =VAL :text lines
+       =VAL :quoted
+       =VAL "text lines
+       =VAL :block
+       =VAL |text\n \tlines\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "plain": "text lines",
+      "quoted": "text lines",
+      "block": "text\n \tlines\n"
+    }
+  dump: |
+    plain: text lines
+    quoted: "text lines"
+    block: "text\n \tlines\n"
+  emit: |
+    plain: text lines
+    quoted: "text lines"
+    block: |
+      text
+       »lines

--- a/pkgs/yaml/third_party/yaml-test-suite/src/52DL.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/52DL.yaml
@@ -1,0 +1,17 @@
+---
+- name: Explicit Non-Specific Tag [1.3]
+  from: 8MK2, modified for YAML 1.3
+  tags: tag 1.3-mod
+  yaml: |
+    ---
+    ! a
+  tree: |
+    +STR
+     +DOC ---
+      =VAL <!> :a
+     -DOC
+    -STR
+  json: |
+    "a"
+  dump: |
+    --- ! a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/54T7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/54T7.yaml
@@ -1,0 +1,25 @@
+---
+- name: Flow Mapping
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/mapping.tml
+  tags: flow mapping
+  yaml: |
+    {foo: you, bar: far}
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :foo
+       =VAL :you
+       =VAL :bar
+       =VAL :far
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "you",
+      "bar": "far"
+    }
+  dump: |
+    foo: you
+    bar: far

--- a/pkgs/yaml/third_party/yaml-test-suite/src/55WF.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/55WF.yaml
@@ -1,0 +1,11 @@
+---
+- name: Invalid escape in double quoted string
+  from: '@perlpunk'
+  tags: error double
+  fail: true
+  yaml: |
+    ---
+    "\."
+  tree: |
+    +STR
+     +DOC ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/565N.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/565N.yaml
@@ -1,0 +1,36 @@
+---
+- name: Construct Binary
+  from: https://github.com/yaml/pyyaml/blob/master/tests/data/construct-binary-py2.data
+  tags: tag unknown-tag
+  yaml: |
+    canonical: !!binary "\
+     R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5\
+     OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+\
+     +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC\
+     AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
+    generic: !!binary |
+     R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5
+     OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+
+     +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC
+     AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=
+    description:
+     The binary value above is a tiny arrow encoded as a gif image.
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :canonical
+       =VAL <tag:yaml.org,2002:binary> "R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLCAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=
+       =VAL :generic
+       =VAL <tag:yaml.org,2002:binary> |R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5\nOTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+\n+f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC\nAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=\n
+       =VAL :description
+       =VAL :The binary value above is a tiny arrow encoded as a gif image.
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "canonical": "R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLCAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=",
+      "generic": "R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5\nOTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+\n+f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC\nAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=\n",
+      "description": "The binary value above is a tiny arrow encoded as a gif image."
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/57H4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/57H4.yaml
@@ -1,0 +1,49 @@
+---
+- name: Spec Example 8.22. Block Collection Nodes
+  from: http://www.yaml.org/spec/1.2/spec.html#id2800008
+  tags: sequence mapping tag
+  yaml: |
+    sequence: !!seq
+    - entry
+    - !!seq
+     - nested
+    mapping: !!map
+     foo: bar
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :sequence
+       +SEQ <tag:yaml.org,2002:seq>
+        =VAL :entry
+        +SEQ <tag:yaml.org,2002:seq>
+         =VAL :nested
+        -SEQ
+       -SEQ
+       =VAL :mapping
+       +MAP <tag:yaml.org,2002:map>
+        =VAL :foo
+        =VAL :bar
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "sequence": [
+        "entry",
+        [
+          "nested"
+        ]
+      ],
+      "mapping": {
+        "foo": "bar"
+      }
+    }
+  dump: |
+    sequence: !!seq
+    - entry
+    - !!seq
+      - nested
+    mapping: !!map
+      foo: bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/58MP.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/58MP.yaml
@@ -1,0 +1,21 @@
+---
+- name: Flow mapping edge cases
+  from: '@ingydotnet'
+  tags: edge flow mapping
+  yaml: |
+    {x: :x}
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :x
+       =VAL ::x
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "x": ":x"
+    }
+  dump: |
+    x: :x

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5BVJ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5BVJ.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 5.7. Block Scalar Indicators
+  from: http://www.yaml.org/spec/1.2/spec.html#id2773653
+  tags: spec literal folded scalar
+  yaml: |
+    literal: |
+      some
+      text
+    folded: >
+      some
+      text
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :literal
+       =VAL |some\ntext\n
+       =VAL :folded
+       =VAL >some text\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "literal": "some\ntext\n",
+      "folded": "some text\n"
+    }
+  dump: |
+    literal: |
+      some
+      text
+    folded: >
+      some text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5C5M.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5C5M.yaml
@@ -1,0 +1,42 @@
+---
+- name: Spec Example 7.15. Flow Mappings
+  from: http://www.yaml.org/spec/1.2/spec.html#id2791018
+  tags: spec flow mapping
+  yaml: |
+    - { one : two , three: four , }
+    - {five: six,seven : eight}
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP {}
+        =VAL :one
+        =VAL :two
+        =VAL :three
+        =VAL :four
+       -MAP
+       +MAP {}
+        =VAL :five
+        =VAL :six
+        =VAL :seven
+        =VAL :eight
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "one": "two",
+        "three": "four"
+      },
+      {
+        "five": "six",
+        "seven": "eight"
+      }
+    ]
+  dump: |
+    - one: two
+      three: four
+    - five: six
+      seven: eight

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5GBF.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5GBF.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 6.5. Empty Lines
+  from: http://www.yaml.org/spec/1.2/spec.html#id2778971
+  tags: double literal spec scalar upto-1.2 whitespace
+  yaml: |
+    Folding:
+      "Empty line
+       »
+      as a line feed"
+    Chomping: |
+      Clipped empty lines
+    ␣
+    ↵
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :Folding
+       =VAL "Empty line\nas a line feed
+       =VAL :Chomping
+       =VAL |Clipped empty lines\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "Folding": "Empty line\nas a line feed",
+      "Chomping": "Clipped empty lines\n"
+    }
+  dump: |
+    Folding: "Empty line\nas a line feed"
+    Chomping: |
+      Clipped empty lines

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5KJE.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5KJE.yaml
@@ -1,0 +1,38 @@
+---
+- name: Spec Example 7.13. Flow Sequence
+  from: http://www.yaml.org/spec/1.2/spec.html#id2790506
+  tags: spec flow sequence
+  yaml: |
+    - [ one, two, ]
+    - [three ,four]
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ []
+        =VAL :one
+        =VAL :two
+       -SEQ
+       +SEQ []
+        =VAL :three
+        =VAL :four
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      [
+        "one",
+        "two"
+      ],
+      [
+        "three",
+        "four"
+      ]
+    ]
+  dump: |
+    - - one
+      - two
+    - - three
+      - four

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5LLU.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5LLU.yaml
@@ -1,0 +1,16 @@
+---
+- name: Block scalar with wrong indented line after spaces only
+  from: '@perlpunk'
+  tags: error folded whitespace
+  fail: true
+  yaml: |
+    block scalar: >
+    ␣
+    ␣␣
+    ␣␣␣
+     invalid
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :block scalar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5MUD.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5MUD.yaml
@@ -1,0 +1,24 @@
+---
+- name: Colon and adjacent value on next line
+  from: '@perlpunk'
+  tags: double flow mapping
+  yaml: |
+    ---
+    { "foo"
+      :bar }
+  tree: |
+    +STR
+     +DOC ---
+      +MAP {}
+       =VAL "foo
+       =VAL :bar
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "bar"
+    }
+  dump: |
+    ---
+    "foo": bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5NYZ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5NYZ.yaml
@@ -1,0 +1,22 @@
+---
+- name: Spec Example 6.9. Separated Comment
+  from: http://www.yaml.org/spec/1.2/spec.html#id2780342
+  tags: mapping spec comment
+  yaml: |
+    key:    # Comment
+      value
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       =VAL :value
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": "value"
+    }
+  dump: |
+    key: value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5T43.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5T43.yaml
@@ -1,0 +1,37 @@
+---
+- name: Colon at the beginning of adjacent flow scalar
+  from: '@perlpunk'
+  tags: flow mapping scalar
+  yaml: |
+    - { "key":value }
+    - { "key"::value }
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP {}
+        =VAL "key
+        =VAL :value
+       -MAP
+       +MAP {}
+        =VAL "key
+        =VAL ::value
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "key": "value"
+      },
+      {
+        "key": ":value"
+      }
+    ]
+  dump: |
+    - key: value
+    - key: :value
+  emit: |
+    - "key": value
+    - "key": :value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5TRB.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5TRB.yaml
@@ -1,0 +1,13 @@
+---
+- name: Invalid document-start marker in doublequoted tring
+  from: '@perlpunk'
+  tags: header double error
+  fail: true
+  yaml: |
+    ---
+    "
+    ---
+    "
+  tree: |
+    +STR
+     +DOC ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5TYM.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5TYM.yaml
@@ -1,0 +1,24 @@
+---
+- name: Spec Example 6.21. Local Tag Prefix
+  from: http://www.yaml.org/spec/1.2/spec.html#id2783499
+  tags: local-tag spec directive tag
+  yaml: |
+    %TAG !m! !my-
+    --- # Bulb here
+    !m!light fluorescent
+    ...
+    %TAG !m! !my-
+    --- # Color here
+    !m!light green
+  tree: |
+    +STR
+     +DOC ---
+      =VAL <!my-light> :fluorescent
+     -DOC ...
+     +DOC ---
+      =VAL <!my-light> :green
+     -DOC
+    -STR
+  json: |
+    "fluorescent"
+    "green"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5U3A.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5U3A.yaml
@@ -1,0 +1,13 @@
+---
+- name: Sequence on same Line as Mapping Key
+  from: '@perlpunk'
+  tags: error sequence mapping
+  fail: true
+  yaml: |
+    key: - a
+         - b
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key

--- a/pkgs/yaml/third_party/yaml-test-suite/src/5WE3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/5WE3.yaml
@@ -1,0 +1,38 @@
+---
+- name: Spec Example 8.17. Explicit Block Mapping Entries
+  from: http://www.yaml.org/spec/1.2/spec.html#id2798425
+  tags: explicit-key spec mapping comment literal sequence
+  yaml: |
+    ? explicit key # Empty value
+    ? |
+      block key
+    : - one # Explicit compact
+      - two # block value
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :explicit key
+       =VAL :
+       =VAL |block key\n
+       +SEQ
+        =VAL :one
+        =VAL :two
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "explicit key": null,
+      "block key\n": [
+        "one",
+        "two"
+      ]
+    }
+  dump: |
+    explicit key:
+    ? |
+      block key
+    : - one
+      - two

--- a/pkgs/yaml/third_party/yaml-test-suite/src/62EZ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/62EZ.yaml
@@ -1,0 +1,17 @@
+---
+- name: Invalid block mapping key on same line as previous key
+  from: '@perlpunk'
+  tags: error flow mapping
+  fail: true
+  yaml: |
+    ---
+    x: { y: z }in: valid
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :x
+       +MAP {}
+        =VAL :y
+        =VAL :z
+       -MAP

--- a/pkgs/yaml/third_party/yaml-test-suite/src/652Z.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/652Z.yaml
@@ -1,0 +1,31 @@
+---
+- name: Question mark at start of flow key
+  from: '@ingydotnet'
+  tags: flow
+  yaml: |
+    { ?foo: bar,
+    bar: 42
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :?foo
+       =VAL :bar
+       =VAL :bar
+       =VAL :42
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "?foo" : "bar",
+      "bar" : 42
+    }
+  dump: |
+    ---
+    ?foo: bar
+    bar: 42
+  emit: |
+    ?foo: bar
+    bar: 42

--- a/pkgs/yaml/third_party/yaml-test-suite/src/65WH.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/65WH.yaml
@@ -1,0 +1,18 @@
+---
+- name: Single Entry Block Sequence
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/sequence.tml
+  tags: sequence
+  yaml: |
+    - foo
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :foo
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "foo"
+    ]

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6BCT.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6BCT.yaml
@@ -1,0 +1,37 @@
+---
+- name: Spec Example 6.3. Separation Spaces
+  from: http://www.yaml.org/spec/1.2/spec.html#id2778394
+  tags: spec libyaml-err sequence whitespace upto-1.2
+  yaml: |
+    - foo:—» bar
+    - - baz
+      -»baz
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        =VAL :foo
+        =VAL :bar
+       -MAP
+       +SEQ
+        =VAL :baz
+        =VAL :baz
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "foo": "bar"
+      },
+      [
+        "baz",
+        "baz"
+      ]
+    ]
+  dump: |
+    - foo: bar
+    - - baz
+      - baz

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6BFJ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6BFJ.yaml
@@ -1,0 +1,28 @@
+---
+- name: Mapping, key and flow sequence item anchors
+  from: '@perlpunk'
+  tags: anchor complex-key flow mapping sequence
+  yaml: |
+    ---
+    &mapping
+    &key [ &item a, b, c ]: value
+  tree: |
+    +STR
+     +DOC ---
+      +MAP &mapping
+       +SEQ [] &key
+        =VAL &item :a
+        =VAL :b
+        =VAL :c
+       -SEQ
+       =VAL :value
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    --- &mapping
+    ? &key
+    - &item a
+    - b
+    - c
+    : value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6CA3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6CA3.yaml
@@ -1,0 +1,18 @@
+---
+- name: Tab indented top flow
+  from: '@ingydotnet'
+  tags: indent whitespace
+  yaml: |
+    ————»[
+    ————»]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    []
+  emit: |
+    --- []

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6CK3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6CK3.yaml
@@ -1,0 +1,26 @@
+---
+- name: Spec Example 6.26. Tag Shorthands
+  from: http://www.yaml.org/spec/1.2/spec.html#id2785009
+  tags: spec tag local-tag
+  yaml: |
+    %TAG !e! tag:example.com,2000:app/
+    ---
+    - !local foo
+    - !!str bar
+    - !e!tag%21 baz
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       =VAL <!local> :foo
+       =VAL <tag:yaml.org,2002:str> :bar
+       =VAL <tag:example.com,2000:app/tag!> :baz
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "foo",
+      "bar",
+      "baz"
+    ]

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6FWR.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6FWR.yaml
@@ -1,0 +1,27 @@
+---
+- name: Block Scalar Keep
+  from: NimYAML tests
+  tags: literal scalar whitespace
+  yaml: |
+    --- |+
+     ab
+    ␣
+    ␣␣
+    ...
+  tree: |
+    +STR
+     +DOC ---
+      =VAL |ab\n\n \n
+     -DOC ...
+    -STR
+  json: |
+    "ab\n\n \n"
+  dump: |
+    "ab\n\n \n"
+    ...
+  emit: |
+    --- |
+      ab
+
+    ␣␣␣
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6H3V.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6H3V.yaml
@@ -1,0 +1,21 @@
+---
+- name: Backslashes in singlequotes
+  from: '@perlpunk'
+  tags: scalar single
+  yaml: |
+    'foo: bar\': baz'
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL 'foo: bar\\
+       =VAL :baz'
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo: bar\\": "baz'"
+    }
+  dump: |
+    'foo: bar\': baz'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6HB6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6HB6.yaml
@@ -1,0 +1,55 @@
+---
+- name: Spec Example 6.1. Indentation Spaces
+  from: http://www.yaml.org/spec/1.2/spec.html#id2777865
+  tags: comment flow spec indent upto-1.2 whitespace
+  yaml: |2
+      # Leading comment line spaces are
+       # neither content nor indentation.
+    ␣␣␣␣
+    Not indented:
+     By one space: |
+        By four
+          spaces
+     Flow style: [    # Leading spaces
+       By two,        # in flow style
+      Also by two,    # are neither
+      —»Still by two   # content nor
+        ]             # indentation.
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :Not indented
+       +MAP
+        =VAL :By one space
+        =VAL |By four\n  spaces\n
+        =VAL :Flow style
+        +SEQ []
+         =VAL :By two
+         =VAL :Also by two
+         =VAL :Still by two
+        -SEQ
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "Not indented": {
+        "By one space": "By four\n  spaces\n",
+        "Flow style": [
+          "By two",
+          "Also by two",
+          "Still by two"
+        ]
+      }
+    }
+  dump: |
+    Not indented:
+      By one space: |
+        By four
+          spaces
+      Flow style:
+      - By two
+      - Also by two
+      - Still by two

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6JQW.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6JQW.yaml
@@ -1,0 +1,21 @@
+---
+- name: Spec Example 2.13. In literals, newlines are preserved
+  from: http://www.yaml.org/spec/1.2/spec.html#id2759963
+  tags: spec scalar literal comment
+  yaml: |
+    # ASCII Art
+    --- |
+      \//||\/||
+      // ||  ||__
+  tree: |
+    +STR
+     +DOC ---
+      =VAL |\\//||\\/||\n// ||  ||__\n
+     -DOC
+    -STR
+  json: |
+    "\\//||\\/||\n// ||  ||__\n"
+  dump: |
+    --- |
+      \//||\/||
+      // ||  ||__

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6JTT.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6JTT.yaml
@@ -1,0 +1,17 @@
+---
+- name: Flow sequence without closing bracket
+  from: '@perlpunk'
+  tags: error flow sequence
+  fail: true
+  yaml: |
+    ---
+    [ [ a, b, c ]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []
+       +SEQ []
+        =VAL :a
+        =VAL :b
+        =VAL :c
+       -SEQ

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6JWB.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6JWB.yaml
@@ -1,0 +1,38 @@
+---
+- name: Tags for Block Objects
+  from: NimYAML tests
+  tags: mapping sequence tag
+  yaml: |
+    foo: !!seq
+      - !!str a
+      - !!map
+        key: !!str value
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       +SEQ <tag:yaml.org,2002:seq>
+        =VAL <tag:yaml.org,2002:str> :a
+        +MAP <tag:yaml.org,2002:map>
+         =VAL :key
+         =VAL <tag:yaml.org,2002:str> :value
+        -MAP
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": [
+        "a",
+        {
+          "key": "value"
+        }
+      ]
+    }
+  dump: |
+    foo: !!seq
+    - !!str a
+    - !!map
+      key: !!str value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6KGN.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6KGN.yaml
@@ -1,0 +1,28 @@
+---
+- name: Anchor for empty node
+  from: https://github.com/nodeca/js-yaml/issues/301
+  tags: alias anchor
+  yaml: |
+    ---
+    a: &anchor
+    b: *anchor
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :a
+       =VAL &anchor :
+       =VAL :b
+       =ALI *anchor
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": null,
+      "b": null
+    }
+  dump: |
+    ---
+    a: &anchor
+    b: *anchor

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6LVF.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6LVF.yaml
@@ -1,0 +1,18 @@
+---
+- name: Spec Example 6.13. Reserved Directives
+  from: http://www.yaml.org/spec/1.2/spec.html#id2781445
+  tags: spec directive header double 1.3-err
+  yaml: |
+    %FOO  bar baz # Should be ignored
+                  # with a warning.
+    --- "foo"
+  tree: |
+    +STR
+     +DOC ---
+      =VAL "foo
+     -DOC
+    -STR
+  json: |
+    "foo"
+  dump: |
+    --- "foo"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6M2F.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6M2F.yaml
@@ -1,0 +1,22 @@
+---
+- name: Aliases in Explicit Block Mapping
+  from: NimYAML tests
+  tags: alias explicit-key empty-key
+  yaml: |
+    ? &a a
+    : &b b
+    : *a
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL &a :a
+       =VAL &b :b
+       =VAL :
+       =ALI *a
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    &a a: &b b
+    : *a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6PBE.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6PBE.yaml
@@ -1,0 +1,33 @@
+---
+- name: Zero-indented sequences in explicit mapping keys
+  from: '@perlpunk'
+  tags: explicit-key mapping sequence
+  yaml: |
+    ---
+    ?
+    - a
+    - b
+    :
+    - c
+    - d
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       +SEQ
+        =VAL :a
+        =VAL :b
+       -SEQ
+       +SEQ
+        =VAL :c
+        =VAL :d
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  emit: |
+    ---
+    ? - a
+      - b
+    : - c
+      - d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6S55.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6S55.yaml
@@ -1,0 +1,18 @@
+---
+- name: Invalid scalar at the end of sequence
+  from: '@perlpunk'
+  tags: error mapping sequence
+  fail: true
+  yaml: |
+    key:
+     - bar
+     - baz
+     invalid
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       +SEQ
+        =VAL :bar
+        =VAL :baz

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6SLA.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6SLA.yaml
@@ -1,0 +1,27 @@
+---
+- name: Allowed characters in quoted mapping key
+  from: '@perlpunk'
+  tags: mapping single double
+  yaml: |
+    "foo\nbar:baz\tx \\$%^&*()x": 23
+    'x\ny:z\tx $%^&*()x': 24
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL "foo\nbar:baz\tx \\$%^&*()x
+       =VAL :23
+       =VAL 'x\\ny:z\\tx $%^&*()x
+       =VAL :24
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo\nbar:baz\tx \\$%^&*()x": 23,
+      "x\\ny:z\\tx $%^&*()x": 24
+    }
+  dump: |
+    ? "foo\nbar:baz\tx \\$%^&*()x"
+    : 23
+    'x\ny:z\tx $%^&*()x': 24

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6VJK.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6VJK.yaml
@@ -1,0 +1,29 @@
+---
+- name: Spec Example 2.15. Folded newlines are preserved for "more indented" and blank lines
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761056
+  tags: spec folded scalar 1.3-err
+  yaml: |
+    >
+     Sammy Sosa completed another
+     fine season with great stats.
+
+       63 Home Runs
+       0.288 Batting Average
+
+     What a year!
+  tree: |
+    +STR
+     +DOC
+      =VAL >Sammy Sosa completed another fine season with great stats.\n\n  63 Home Runs\n  0.288 Batting Average\n\nWhat a year!\n
+     -DOC
+    -STR
+  json: |
+    "Sammy Sosa completed another fine season with great stats.\n\n  63 Home Runs\n  0.288 Batting Average\n\nWhat a year!\n"
+  dump: |
+    >
+      Sammy Sosa completed another fine season with great stats.
+
+        63 Home Runs
+        0.288 Batting Average
+
+      What a year!

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6WLZ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6WLZ.yaml
@@ -1,0 +1,35 @@
+---
+- name: Spec Example 6.18. Primary Tag Handle [1.3]
+  from: 9WXW, modified for YAML 1.3
+  tags: local-tag spec directive tag 1.3-mod
+  yaml: |
+    # Private
+    ---
+    !foo "bar"
+    ...
+    # Global
+    %TAG ! tag:example.com,2000:app/
+    ---
+    !foo "bar"
+  tree: |
+    +STR
+     +DOC ---
+      =VAL <!foo> "bar
+     -DOC ...
+     +DOC ---
+      =VAL <tag:example.com,2000:app/foo> "bar
+     -DOC
+    -STR
+  json: |
+    "bar"
+    "bar"
+  dump: |
+    ---
+    !foo "bar"
+    ...
+    --- !<tag:example.com,2000:app/foo>
+    "bar"
+  emit: |
+    --- !foo "bar"
+    ...
+    --- !<tag:example.com,2000:app/foo> "bar"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6WPF.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6WPF.yaml
@@ -1,0 +1,25 @@
+---
+- name: Spec Example 6.8. Flow Folding [1.3]
+  from: TL85, modified for YAML 1.3
+  tags: double spec whitespace scalar 1.3-mod
+  yaml: |
+    ---
+    "
+      foo␣
+    ␣
+        bar
+
+      baz
+    "
+  tree: |
+    +STR
+     +DOC ---
+      =VAL " foo\nbar\nbaz␣
+     -DOC
+    -STR
+  json: |
+    " foo\nbar\nbaz "
+  dump: |
+    " foo\nbar\nbaz "
+  emit: |
+    --- " foo\nbar\nbaz "

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6XDY.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6XDY.yaml
@@ -1,0 +1,22 @@
+---
+- name: Two document start markers
+  from: '@perlpunk'
+  tags: header
+  yaml: |
+    ---
+    ---
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :
+     -DOC
+     +DOC ---
+      =VAL :
+     -DOC
+    -STR
+  json: |
+    null
+    null
+  dump: |
+    ---
+    ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/6ZKB.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/6ZKB.yaml
@@ -1,0 +1,40 @@
+---
+- name: Spec Example 9.6. Stream
+  from: http://www.yaml.org/spec/1.2/spec.html#id2801896
+  tags: spec header 1.3-err
+  yaml: |
+    Document
+    ---
+    # Empty
+    ...
+    %YAML 1.2
+    ---
+    matches %: 20
+  tree: |
+    +STR
+     +DOC
+      =VAL :Document
+     -DOC
+     +DOC ---
+      =VAL :
+     -DOC ...
+     +DOC ---
+      +MAP
+       =VAL :matches %
+       =VAL :20
+      -MAP
+     -DOC
+    -STR
+  json: |
+    "Document"
+    null
+    {
+      "matches %": 20
+    }
+  emit: |
+    Document
+    ---
+    ...
+    %YAML 1.2
+    ---
+    matches %: 20

--- a/pkgs/yaml/third_party/yaml-test-suite/src/735Y.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/735Y.yaml
@@ -1,0 +1,38 @@
+---
+- name: Spec Example 8.20. Block Node Types
+  from: http://www.yaml.org/spec/1.2/spec.html#id2799426
+  tags: comment double spec folded tag
+  yaml: |
+    -
+      "flow in block"
+    - >
+     Block scalar
+    - !!map # Block collection
+      foo : bar
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL "flow in block
+       =VAL >Block scalar\n
+       +MAP <tag:yaml.org,2002:map>
+        =VAL :foo
+        =VAL :bar
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "flow in block",
+      "Block scalar\n",
+      {
+        "foo": "bar"
+      }
+    ]
+  dump: |
+    - "flow in block"
+    - >
+      Block scalar
+    - !!map
+      foo: bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/74H7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/74H7.yaml
@@ -1,0 +1,41 @@
+---
+- name: Tags in Implicit Mapping
+  from: NimYAML tests
+  tags: tag mapping
+  yaml: |
+    !!str a: b
+    c: !!int 42
+    e: !!str f
+    g: h
+    !!str 23: !!bool false
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL <tag:yaml.org,2002:str> :a
+       =VAL :b
+       =VAL :c
+       =VAL <tag:yaml.org,2002:int> :42
+       =VAL :e
+       =VAL <tag:yaml.org,2002:str> :f
+       =VAL :g
+       =VAL :h
+       =VAL <tag:yaml.org,2002:str> :23
+       =VAL <tag:yaml.org,2002:bool> :false
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": "b",
+      "c": 42,
+      "e": "f",
+      "g": "h",
+      "23": false
+    }
+  dump: |
+    !!str a: b
+    c: !!int 42
+    e: !!str f
+    g: h
+    !!str 23: !!bool false

--- a/pkgs/yaml/third_party/yaml-test-suite/src/753E.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/753E.yaml
@@ -1,0 +1,22 @@
+---
+- name: Block Scalar Strip [1.3]
+  from: MYW6, modified for YAML 1.3
+  tags: literal scalar 1.3-mod whitespace
+  yaml: |
+    --- |-
+     ab
+    ␣
+    ␣
+    ...
+  tree: |
+    +STR
+     +DOC ---
+      =VAL |ab
+     -DOC ...
+    -STR
+  json: |
+    "ab"
+  dump: |
+    --- |-
+      ab
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7A4E.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7A4E.yaml
@@ -1,0 +1,19 @@
+---
+- name: Spec Example 7.6. Double Quoted Lines
+  from: http://www.yaml.org/spec/1.2/spec.html#id2787994
+  tags: spec scalar upto-1.2 whitespace
+  yaml: |
+    " 1st non-empty
+
+     2nd non-empty␣
+    ———»3rd non-empty "
+  tree: |
+    +STR
+     +DOC
+      =VAL " 1st non-empty\n2nd non-empty 3rd non-empty␣
+     -DOC
+    -STR
+  json: |
+    " 1st non-empty\n2nd non-empty 3rd non-empty "
+  dump: |
+    " 1st non-empty\n2nd non-empty 3rd non-empty "

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7BMT.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7BMT.yaml
@@ -1,0 +1,90 @@
+---
+- name: Node and Mapping Key Anchors [1.3]
+  from: U3XV, modified for YAML 1.3
+  tags: anchor comment mapping 1.3-mod
+  yaml: |
+    ---
+    top1: &node1
+      &k1 key1: one
+    top2: &node2 # comment
+      key2: two
+    top3:
+      &k3 key3: three
+    top4: &node4
+      &k4 key4: four
+    top5: &node5
+      key5: five
+    top6: &val6
+      six
+    top7:
+      &val7 seven
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :top1
+       +MAP &node1
+        =VAL &k1 :key1
+        =VAL :one
+       -MAP
+       =VAL :top2
+       +MAP &node2
+        =VAL :key2
+        =VAL :two
+       -MAP
+       =VAL :top3
+       +MAP
+        =VAL &k3 :key3
+        =VAL :three
+       -MAP
+       =VAL :top4
+       +MAP &node4
+        =VAL &k4 :key4
+        =VAL :four
+       -MAP
+       =VAL :top5
+       +MAP &node5
+        =VAL :key5
+        =VAL :five
+       -MAP
+       =VAL :top6
+       =VAL &val6 :six
+       =VAL :top7
+       =VAL &val7 :seven
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "top1": {
+        "key1": "one"
+      },
+      "top2": {
+        "key2": "two"
+      },
+      "top3": {
+        "key3": "three"
+      },
+      "top4": {
+        "key4": "four"
+      },
+      "top5": {
+        "key5": "five"
+      },
+      "top6": "six",
+      "top7": "seven"
+    }
+  dump: |
+    ---
+    top1: &node1
+      &k1 key1: one
+    top2: &node2
+      key2: two
+    top3:
+      &k3 key3: three
+    top4: &node4
+      &k4 key4: four
+    top5: &node5
+      key5: five
+    top6: &val6 six
+    top7: &val7 seven

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7BUB.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7BUB.yaml
@@ -1,0 +1,49 @@
+---
+- name: Spec Example 2.10. Node for “Sammy Sosa” appears twice in this document
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760658
+  tags: mapping sequence spec alias
+  yaml: |
+    ---
+    hr:
+      - Mark McGwire
+      # Following node labeled SS
+      - &SS Sammy Sosa
+    rbi:
+      - *SS # Subsequent occurrence
+      - Ken Griffey
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :hr
+       +SEQ
+        =VAL :Mark McGwire
+        =VAL &SS :Sammy Sosa
+       -SEQ
+       =VAL :rbi
+       +SEQ
+        =ALI *SS
+        =VAL :Ken Griffey
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "hr": [
+        "Mark McGwire",
+        "Sammy Sosa"
+      ],
+      "rbi": [
+        "Sammy Sosa",
+        "Ken Griffey"
+      ]
+    }
+  dump: |
+    ---
+    hr:
+    - Mark McGwire
+    - &SS Sammy Sosa
+    rbi:
+    - *SS
+    - Ken Griffey

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7FWL.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7FWL.yaml
@@ -1,0 +1,22 @@
+---
+- name: Spec Example 6.24. Verbatim Tags
+  from: http://www.yaml.org/spec/1.2/spec.html#id2784370
+  tags: mapping spec tag unknown-tag
+  yaml: |
+    !<tag:yaml.org,2002:str> foo :
+      !<!bar> baz
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL <tag:yaml.org,2002:str> :foo
+       =VAL <!bar> :baz
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "baz"
+    }
+  dump: |
+    !!str foo: !bar baz

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7LBH.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7LBH.yaml
@@ -1,0 +1,15 @@
+---
+- name: Multiline double quoted implicit keys
+  from: '@perlpunk'
+  tags: error double
+  fail: true
+  yaml: |
+    "a\nb": 1
+    "c
+     d": 1
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL "a\nb
+       =VAL :1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7MNF.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7MNF.yaml
@@ -1,0 +1,18 @@
+---
+- name: Missing colon
+  from: '@perlpunk'
+  tags: error mapping
+  fail: true
+  yaml: |
+    top1:
+      key1: val1
+    top2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :top1
+       +MAP
+        =VAL :key1
+        =VAL :val1
+       -MAP

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7T8X.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7T8X.yaml
@@ -1,0 +1,41 @@
+---
+- name: Spec Example 8.10. Folded Lines - 8.13. Final Empty Lines
+  from: http://www.yaml.org/spec/1.2/spec.html#id2796543
+  tags: spec folded scalar comment 1.3-err
+  yaml: |
+    >
+
+     folded
+     line
+
+     next
+     line
+       * bullet
+
+       * list
+       * lines
+
+     last
+     line
+
+    # Comment
+  tree: |
+    +STR
+     +DOC
+      =VAL >\nfolded line\nnext line\n  * bullet\n\n  * list\n  * lines\n\nlast line\n
+     -DOC
+    -STR
+  json: |
+    "\nfolded line\nnext line\n  * bullet\n\n  * list\n  * lines\n\nlast line\n"
+  dump: |
+    >
+
+      folded line
+
+      next line
+        * bullet
+
+        * list
+        * lines
+
+      last line

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7TMG.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7TMG.yaml
@@ -1,0 +1,27 @@
+---
+- name: Comment in flow sequence before comma
+  from: '@perlpunk'
+  tags: comment flow sequence
+  yaml: |
+    ---
+    [ word1
+    # comment
+    , word2]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []
+       =VAL :word1
+       =VAL :word2
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "word1",
+      "word2"
+    ]
+  dump: |
+    ---
+    - word1
+    - word2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7W2P.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7W2P.yaml
@@ -1,0 +1,31 @@
+---
+- name: Block Mapping with Missing Values
+  from: NimYAML tests
+  tags: explicit-key mapping
+  yaml: |
+    ? a
+    ? b
+    c:
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL :
+       =VAL :b
+       =VAL :
+       =VAL :c
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": null,
+      "b": null,
+      "c": null
+    }
+  dump: |
+    a:
+    b:
+    c:

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7Z25.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7Z25.yaml
@@ -1,0 +1,30 @@
+---
+- name: Bare document after document end marker
+  from: '@perlpunk'
+  tags: footer
+  yaml: |
+    ---
+    scalar1
+    ...
+    key: value
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :scalar1
+     -DOC ...
+     +DOC
+      +MAP
+       =VAL :key
+       =VAL :value
+      -MAP
+     -DOC
+    -STR
+  json: |
+    "scalar1"
+    {
+      "key": "value"
+    }
+  dump: |
+    --- scalar1
+    ...
+    key: value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/7ZZ5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/7ZZ5.yaml
@@ -1,0 +1,63 @@
+---
+- name: Empty flow collections
+  from: '@perlpunk'
+  tags: flow mapping sequence
+  yaml: |
+    ---
+    nested sequences:
+    - - - []
+    - - - {}
+    key1: []
+    key2: {}
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :nested sequences
+       +SEQ
+        +SEQ
+         +SEQ
+          +SEQ []
+          -SEQ
+         -SEQ
+        -SEQ
+        +SEQ
+         +SEQ
+          +MAP {}
+          -MAP
+         -SEQ
+        -SEQ
+       -SEQ
+       =VAL :key1
+       +SEQ []
+       -SEQ
+       =VAL :key2
+       +MAP {}
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "nested sequences": [
+        [
+          [
+            []
+          ]
+        ],
+        [
+          [
+            {}
+          ]
+        ]
+      ],
+      "key1": [],
+      "key2": {}
+    }
+  dump: |
+    ---
+    nested sequences:
+    - - - []
+    - - - {}
+    key1: []
+    key2: {}

--- a/pkgs/yaml/third_party/yaml-test-suite/src/82AN.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/82AN.yaml
@@ -1,0 +1,17 @@
+---
+- name: Three dashes and content without space
+  from: '@perlpunk'
+  tags: scalar 1.3-err
+  yaml: |
+    ---word1
+    word2
+  tree: |
+    +STR
+     +DOC
+      =VAL :---word1 word2
+     -DOC
+    -STR
+  json: |
+    "---word1 word2"
+  dump: |
+    '---word1 word2'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/87E4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/87E4.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 7.8. Single Quoted Implicit Keys
+  from: http://www.yaml.org/spec/1.2/spec.html#id2788496
+  tags: spec flow sequence mapping
+  yaml: |
+    'implicit block key' : [
+      'implicit flow key' : value,
+     ]
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL 'implicit block key
+       +SEQ []
+        +MAP {}
+         =VAL 'implicit flow key
+         =VAL :value
+        -MAP
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "implicit block key": [
+        {
+          "implicit flow key": "value"
+        }
+      ]
+    }
+  dump: |
+    'implicit block key':
+    - 'implicit flow key': value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/8CWC.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/8CWC.yaml
@@ -1,0 +1,23 @@
+---
+- name: Plain mapping key ending with colon
+  from: '@perlpunk'
+  tags: mapping scalar
+  yaml: |
+    ---
+    key ends with two colons::: value
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :key ends with two colons::
+       =VAL :value
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key ends with two colons::": "value"
+    }
+  dump: |
+    ---
+    'key ends with two colons::': value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/8G76.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/8G76.yaml
@@ -1,0 +1,14 @@
+---
+- name: Spec Example 6.10. Comment Lines
+  from: http://www.yaml.org/spec/1.2/spec.html#id2780544
+  tags: spec comment empty scalar whitespace
+  yaml: |2
+      # Comment
+    ␣␣␣
+    ↵
+    ↵
+  tree: |
+    +STR
+    -STR
+  json: ''
+  dump: ''

--- a/pkgs/yaml/third_party/yaml-test-suite/src/8KB6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/8KB6.yaml
@@ -1,0 +1,45 @@
+---
+- name: Multiline plain flow mapping key without value
+  from: '@perlpunk'
+  tags: flow mapping
+  yaml: |
+    ---
+    - { single line, a: b}
+    - { multi
+      line, a: b}
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       +MAP {}
+        =VAL :single line
+        =VAL :
+        =VAL :a
+        =VAL :b
+       -MAP
+       +MAP {}
+        =VAL :multi line
+        =VAL :
+        =VAL :a
+        =VAL :b
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "single line": null,
+        "a": "b"
+      },
+      {
+        "multi line": null,
+        "a": "b"
+      }
+    ]
+  dump: |
+    ---
+    - single line:
+      a: b
+    - multi line:
+      a: b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/8MK2.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/8MK2.yaml
@@ -1,0 +1,14 @@
+---
+- name: Explicit Non-Specific Tag
+  from: NimYAML tests
+  tags: tag 1.3-err
+  yaml: |
+    ! a
+  tree: |
+    +STR
+     +DOC
+      =VAL <!> :a
+     -DOC
+    -STR
+  json: |
+    "a"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/8QBE.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/8QBE.yaml
@@ -1,0 +1,31 @@
+---
+- name: Block Sequence in Block Mapping
+  from: NimYAML tests
+  tags: mapping sequence
+  yaml: |
+    key:
+     - item1
+     - item2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       +SEQ
+        =VAL :item1
+        =VAL :item2
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": [
+        "item1",
+        "item2"
+      ]
+    }
+  dump: |
+    key:
+    - item1
+    - item2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/8UDB.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/8UDB.yaml
@@ -1,0 +1,48 @@
+---
+- name: Spec Example 7.14. Flow Sequence Entries
+  from: http://www.yaml.org/spec/1.2/spec.html#id2790726
+  tags: spec flow sequence
+  yaml: |
+    [
+    "double
+     quoted", 'single
+               quoted',
+    plain
+     text, [ nested ],
+    single: pair,
+    ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       =VAL "double quoted
+       =VAL 'single quoted
+       =VAL :plain text
+       +SEQ []
+        =VAL :nested
+       -SEQ
+       +MAP {}
+        =VAL :single
+        =VAL :pair
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "double quoted",
+      "single quoted",
+      "plain text",
+      [
+        "nested"
+      ],
+      {
+        "single": "pair"
+      }
+    ]
+  dump: |
+    - "double quoted"
+    - 'single quoted'
+    - plain text
+    - - nested
+    - single: pair

--- a/pkgs/yaml/third_party/yaml-test-suite/src/8XDJ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/8XDJ.yaml
@@ -1,0 +1,15 @@
+---
+- name: Comment in plain multiline value
+  from: https://gist.github.com/anonymous/deeb1ace28d5bf21fb56d80c13e2dc69 via @ingydotnet
+  tags: error comment scalar
+  fail: true
+  yaml: |
+    key: word1
+    #  xxx
+      word2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       =VAL :word1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/8XYN.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/8XYN.yaml
@@ -1,0 +1,22 @@
+---
+- name: Anchor with unicode character
+  from: https://github.com/yaml/pyyaml/issues/94
+  tags: anchor
+  yaml: |
+    ---
+    - &😁 unicode anchor
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       =VAL &😁 :unicode anchor
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "unicode anchor"
+    ]
+  dump: |
+    ---
+    - &😁 unicode anchor

--- a/pkgs/yaml/third_party/yaml-test-suite/src/93JH.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/93JH.yaml
@@ -1,0 +1,40 @@
+---
+- name: Block Mappings in Block Sequence
+  from: NimYAML tests
+  tags: mapping sequence
+  yaml: |2
+     - key: value
+       key2: value2
+     -
+       key3: value3
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        =VAL :key
+        =VAL :value
+        =VAL :key2
+        =VAL :value2
+       -MAP
+       +MAP
+        =VAL :key3
+        =VAL :value3
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "key": "value",
+        "key2": "value2"
+      },
+      {
+        "key3": "value3"
+      }
+    ]
+  dump: |
+    - key: value
+      key2: value2
+    - key3: value3

--- a/pkgs/yaml/third_party/yaml-test-suite/src/93WF.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/93WF.yaml
@@ -1,0 +1,27 @@
+---
+- name: Spec Example 6.6. Line Folding [1.3]
+  from: K527, modified for YAML 1.3
+  tags: folded spec whitespace scalar 1.3-mod
+  yaml: |
+    --- >-
+      trimmed
+    ␣␣
+    ␣
+
+      as
+      space
+  tree: |
+    +STR
+     +DOC ---
+      =VAL >trimmed\n\n\nas space
+     -DOC
+    -STR
+  json: |
+    "trimmed\n\n\nas space"
+  dump: |
+    --- >-
+      trimmed
+
+
+
+      as space

--- a/pkgs/yaml/third_party/yaml-test-suite/src/96L6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/96L6.yaml
@@ -1,0 +1,20 @@
+---
+- name: Spec Example 2.14. In the folded scalars, newlines become spaces
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761032
+  tags: spec folded scalar
+  yaml: |
+    --- >
+      Mark McGwire's
+      year was crippled
+      by a knee injury.
+  tree: |
+    +STR
+     +DOC ---
+      =VAL >Mark McGwire's year was crippled by a knee injury.\n
+     -DOC
+    -STR
+  json: |
+    "Mark McGwire's year was crippled by a knee injury.\n"
+  dump: |
+    --- >
+      Mark McGwire's year was crippled by a knee injury.

--- a/pkgs/yaml/third_party/yaml-test-suite/src/96NN.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/96NN.yaml
@@ -1,0 +1,25 @@
+---
+- name: Leading tab content in literals
+  from: '@ingydotnet'
+  tags: indent literal whitespace
+  yaml: |
+    foo: |-
+     ——»bar
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL |\tbar
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {"foo":"\tbar"}
+  dump: |
+    foo: |-
+      ——»bar
+
+- yaml: |
+    foo: |-
+     ——»bar∎

--- a/pkgs/yaml/third_party/yaml-test-suite/src/98YD.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/98YD.yaml
@@ -1,0 +1,11 @@
+---
+- name: Spec Example 5.5. Comment Indicator
+  from: http://www.yaml.org/spec/1.2/spec.html#id2773032
+  tags: spec comment empty
+  yaml: |
+    # Comment only.
+  tree: |
+    +STR
+    -STR
+  json: ''
+  dump: ''

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9BXH.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9BXH.yaml
@@ -1,0 +1,45 @@
+---
+- name: Multiline doublequoted flow mapping key without value
+  from: '@perlpunk'
+  tags: double flow mapping
+  yaml: |
+    ---
+    - { "single line", a: b}
+    - { "multi
+      line", a: b}
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       +MAP {}
+        =VAL "single line
+        =VAL :
+        =VAL :a
+        =VAL :b
+       -MAP
+       +MAP {}
+        =VAL "multi line
+        =VAL :
+        =VAL :a
+        =VAL :b
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "single line": null,
+        "a": "b"
+      },
+      {
+        "multi line": null,
+        "a": "b"
+      }
+    ]
+  dump: |
+    ---
+    - "single line":
+      a: b
+    - "multi line":
+      a: b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9C9N.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9C9N.yaml
@@ -1,0 +1,17 @@
+---
+- name: Wrong indented flow sequence
+  from: '@perlpunk'
+  tags: error flow indent sequence
+  fail: true
+  yaml: |
+    ---
+    flow: [a,
+    b,
+    c]
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :flow
+       +SEQ []
+        =VAL :a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9CWY.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9CWY.yaml
@@ -1,0 +1,19 @@
+---
+- name: Invalid scalar at the end of mapping
+  from: '@perlpunk'
+  tags: error mapping sequence
+  fail: true
+  yaml: |
+    key:
+     - item1
+     - item2
+    invalid
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       +SEQ
+        =VAL :item1
+        =VAL :item2
+       -SEQ

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9DXL.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9DXL.yaml
@@ -1,0 +1,45 @@
+---
+- name: Spec Example 9.6. Stream [1.3]
+  from: 6ZKB, modified for YAML 1.3
+  tags: spec header 1.3-mod
+  yaml: |
+    Mapping: Document
+    ---
+    # Empty
+    ...
+    %YAML 1.2
+    ---
+    matches %: 20
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :Mapping
+       =VAL :Document
+      -MAP
+     -DOC
+     +DOC ---
+      =VAL :
+     -DOC ...
+     +DOC ---
+      +MAP
+       =VAL :matches %
+       =VAL :20
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "Mapping": "Document"
+    }
+    null
+    {
+      "matches %": 20
+    }
+  emit: |
+    Mapping: Document
+    ---
+    ...
+    %YAML 1.2
+    ---
+    matches %: 20

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9FMG.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9FMG.yaml
@@ -1,0 +1,45 @@
+---
+- name: Multi-level Mapping Indent
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/indent.tml
+  tags: mapping indent
+  yaml: |
+    a:
+      b:
+        c: d
+      e:
+        f: g
+    h: i
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       +MAP
+        =VAL :b
+        +MAP
+         =VAL :c
+         =VAL :d
+        -MAP
+        =VAL :e
+        +MAP
+         =VAL :f
+         =VAL :g
+        -MAP
+       -MAP
+       =VAL :h
+       =VAL :i
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": {
+        "b": {
+          "c": "d"
+        },
+        "e": {
+          "f": "g"
+        }
+      },
+      "h": "i"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9HCY.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9HCY.yaml
@@ -1,0 +1,14 @@
+---
+- name: Need document footer before directives
+  from: '@ingydotnet'
+  tags: directive error footer tag unknown-tag
+  fail: true
+  yaml: |
+    !foo "bar"
+    %TAG ! tag:example.com,2000:app/
+    ---
+    !foo "bar"
+  tree: |
+    +STR
+     +DOC
+      =VAL <!foo> "bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9J7A.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9J7A.yaml
@@ -1,0 +1,25 @@
+---
+- name: Simple Mapping Indent
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/indent.tml
+  tags: simple mapping indent
+  yaml: |
+    foo:
+      bar: baz
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       +MAP
+        =VAL :bar
+        =VAL :baz
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": {
+        "bar": "baz"
+      }
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9JBA.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9JBA.yaml
@@ -1,0 +1,16 @@
+---
+- name: Invalid comment after end of flow sequence
+  from: '@perlpunk'
+  tags: comment error flow sequence
+  fail: true
+  yaml: |
+    ---
+    [ a, b, c, ]#invalid
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []
+       =VAL :a
+       =VAL :b
+       =VAL :c
+      -SEQ

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9KAX.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9KAX.yaml
@@ -1,0 +1,104 @@
+---
+- name: Various combinations of tags and anchors
+  from: '@perlpunk'
+  tags: anchor mapping 1.3-err tag
+  yaml: |
+    ---
+    &a1
+    !!str
+    scalar1
+    ---
+    !!str
+    &a2
+    scalar2
+    ---
+    &a3
+    !!str scalar3
+    ---
+    &a4 !!map
+    &a5 !!str key5: value4
+    ---
+    a6: 1
+    &anchor6 b6: 2
+    ---
+    !!map
+    &a8 !!str key8: value7
+    ---
+    !!map
+    !!str &a10 key10: value9
+    ---
+    !!str &a11
+    value11
+  tree: |
+    +STR
+     +DOC ---
+      =VAL &a1 <tag:yaml.org,2002:str> :scalar1
+     -DOC
+     +DOC ---
+      =VAL &a2 <tag:yaml.org,2002:str> :scalar2
+     -DOC
+     +DOC ---
+      =VAL &a3 <tag:yaml.org,2002:str> :scalar3
+     -DOC
+     +DOC ---
+      +MAP &a4 <tag:yaml.org,2002:map>
+       =VAL &a5 <tag:yaml.org,2002:str> :key5
+       =VAL :value4
+      -MAP
+     -DOC
+     +DOC ---
+      +MAP
+       =VAL :a6
+       =VAL :1
+       =VAL &anchor6 :b6
+       =VAL :2
+      -MAP
+     -DOC
+     +DOC ---
+      +MAP <tag:yaml.org,2002:map>
+       =VAL &a8 <tag:yaml.org,2002:str> :key8
+       =VAL :value7
+      -MAP
+     -DOC
+     +DOC ---
+      +MAP <tag:yaml.org,2002:map>
+       =VAL &a10 <tag:yaml.org,2002:str> :key10
+       =VAL :value9
+      -MAP
+     -DOC
+     +DOC ---
+      =VAL &a11 <tag:yaml.org,2002:str> :value11
+     -DOC
+    -STR
+  json: |
+    "scalar1"
+    "scalar2"
+    "scalar3"
+    {
+      "key5": "value4"
+    }
+    {
+      "a6": 1,
+      "b6": 2
+    }
+    {
+      "key8": "value7"
+    }
+    {
+      "key10": "value9"
+    }
+    "value11"
+  dump: |
+    --- &a1 !!str scalar1
+    --- &a2 !!str scalar2
+    --- &a3 !!str scalar3
+    --- &a4 !!map
+    &a5 !!str key5: value4
+    ---
+    a6: 1
+    &anchor6 b6: 2
+    --- !!map
+    &a8 !!str key8: value7
+    --- !!map
+    &a10 !!str key10: value9
+    --- &a11 !!str value11

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9KBC.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9KBC.yaml
@@ -1,0 +1,11 @@
+---
+- name: Mapping starting at --- line
+  from: https://gist.github.com/anonymous/c728390e92ec93fb371ac77f21435cca via @ingydotnet
+  tags: error header mapping
+  fail: true
+  yaml: |
+    --- key1: value1
+        key2: value2
+  tree: |
+    +STR
+     +DOC ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9MAG.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9MAG.yaml
@@ -1,0 +1,12 @@
+---
+- name: Flow sequence with invalid comma at the beginning
+  from: '@perlpunk'
+  tags: error flow sequence
+  fail: true
+  yaml: |
+    ---
+    [ , a, b, c ]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9MMA.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9MMA.yaml
@@ -1,0 +1,9 @@
+---
+- name: Directive by itself with no document
+  from: '@ingydotnet'
+  tags: error directive
+  fail: true
+  yaml: |
+    %YAML 1.2
+  tree: |
+    +STR

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9MMW.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9MMW.yaml
@@ -1,0 +1,41 @@
+---
+- name: Single Pair Implicit Entries
+  from: '@perlpunk, Spec Example 7.21'
+  tags: flow mapping sequence
+  yaml: |
+    - [ YAML : separate ]
+    - [ "JSON like":adjacent ]
+    - [ {JSON: like}:adjacent ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ []
+        +MAP {}
+         =VAL :YAML
+         =VAL :separate
+        -MAP
+       -SEQ
+       +SEQ []
+        +MAP {}
+         =VAL "JSON like
+         =VAL :adjacent
+        -MAP
+       -SEQ
+       +SEQ []
+        +MAP {}
+         +MAP {}
+          =VAL :JSON
+          =VAL :like
+         -MAP
+         =VAL :adjacent
+        -MAP
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  dump: |
+    - - YAML: separate
+    - - "JSON like": adjacent
+    - - ? JSON: like
+        : adjacent

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9MQT.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9MQT.yaml
@@ -1,0 +1,31 @@
+---
+- name: Scalar doc with '...' in content
+  from: '@ingydotnet'
+  tags: double scalar
+  yaml: |
+    --- "a
+    ...x
+    b"
+  tree: |
+    +STR
+     +DOC ---
+      =VAL "a ...x b
+     -DOC
+    -STR
+  json: |
+    "a ...x b"
+  dump: |
+    --- a ...x b
+  emit: |
+    --- "a ...x b"
+
+- fail: true
+  yaml: |
+    --- "a
+    ... x
+    b"
+  tree: |
+    +STR
+     +DOC ---
+  dump: null
+  emit: null

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9SA2.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9SA2.yaml
@@ -1,0 +1,37 @@
+---
+- name: Multiline double quoted flow mapping key
+  from: '@perlpunk'
+  tags: double flow mapping
+  yaml: |
+    ---
+    - { "single line": value}
+    - { "multi
+      line": value}
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       +MAP {}
+        =VAL "single line
+        =VAL :value
+       -MAP
+       +MAP {}
+        =VAL "multi line
+        =VAL :value
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "single line": "value"
+      },
+      {
+        "multi line": "value"
+      }
+    ]
+  dump: |
+    ---
+    - "single line": value
+    - "multi line": value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9SHH.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9SHH.yaml
@@ -1,0 +1,23 @@
+---
+- name: Spec Example 5.8. Quoted Scalar Indicators
+  from: http://www.yaml.org/spec/1.2/spec.html#id2773890
+  tags: spec scalar
+  yaml: |
+    single: 'text'
+    double: "text"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :single
+       =VAL 'text
+       =VAL :double
+       =VAL "text
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "single": "text",
+      "double": "text"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9TFX.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9TFX.yaml
@@ -1,0 +1,22 @@
+---
+- name: Spec Example 7.6. Double Quoted Lines [1.3]
+  from: 7A4E, modified for YAML 1.3
+  tags: double spec scalar whitespace 1.3-mod
+  yaml: |
+    ---
+    " 1st non-empty
+
+     2nd non-empty␣
+     3rd non-empty "
+  tree: |
+    +STR
+     +DOC ---
+      =VAL " 1st non-empty\n2nd non-empty 3rd non-empty␣
+     -DOC
+    -STR
+  json: |
+    " 1st non-empty\n2nd non-empty 3rd non-empty "
+  dump: |
+    " 1st non-empty\n2nd non-empty 3rd non-empty "
+  emit: |
+    --- " 1st non-empty\n2nd non-empty 3rd non-empty "

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9U5K.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9U5K.yaml
@@ -1,0 +1,61 @@
+---
+- name: Spec Example 2.12. Compact Nested Mapping
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760821
+  tags: spec mapping sequence
+  yaml: |
+    ---
+    # Products purchased
+    - item    : Super Hoop
+      quantity: 1
+    - item    : Basketball
+      quantity: 4
+    - item    : Big Shoes
+      quantity: 1
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       +MAP
+        =VAL :item
+        =VAL :Super Hoop
+        =VAL :quantity
+        =VAL :1
+       -MAP
+       +MAP
+        =VAL :item
+        =VAL :Basketball
+        =VAL :quantity
+        =VAL :4
+       -MAP
+       +MAP
+        =VAL :item
+        =VAL :Big Shoes
+        =VAL :quantity
+        =VAL :1
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "item": "Super Hoop",
+        "quantity": 1
+      },
+      {
+        "item": "Basketball",
+        "quantity": 4
+      },
+      {
+        "item": "Big Shoes",
+        "quantity": 1
+      }
+    ]
+  dump: |
+    ---
+    - item: Super Hoop
+      quantity: 1
+    - item: Basketball
+      quantity: 4
+    - item: Big Shoes
+      quantity: 1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9WXW.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9WXW.yaml
@@ -1,0 +1,28 @@
+---
+- name: Spec Example 6.18. Primary Tag Handle
+  from: http://www.yaml.org/spec/1.2/spec.html#id2782728
+  tags: local-tag spec directive tag unknown-tag 1.3-err
+  yaml: |
+    # Private
+    !foo "bar"
+    ...
+    # Global
+    %TAG ! tag:example.com,2000:app/
+    ---
+    !foo "bar"
+  tree: |
+    +STR
+     +DOC
+      =VAL <!foo> "bar
+     -DOC ...
+     +DOC ---
+      =VAL <tag:example.com,2000:app/foo> "bar
+     -DOC
+    -STR
+  json: |
+    "bar"
+    "bar"
+  dump: |
+    !foo "bar"
+    ...
+    --- !<tag:example.com,2000:app/foo> "bar"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/9YRD.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/9YRD.yaml
@@ -1,0 +1,23 @@
+---
+- name: Multiline Scalar at Top Level
+  from: NimYAML tests
+  tags: scalar whitespace 1.3-err
+  yaml: |
+    a
+    b␣␣
+      c
+    d
+
+    e
+  tree: |
+    +STR
+     +DOC
+      =VAL :a b c d\ne
+     -DOC
+    -STR
+  json: |
+    "a b c d\ne"
+  dump: |
+    'a b c d
+
+      e'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/A2M4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/A2M4.yaml
@@ -1,0 +1,39 @@
+---
+- name: Spec Example 6.2. Indentation Indicators
+  from: http://www.yaml.org/spec/1.2/spec.html#id2778101
+  tags: explicit-key spec libyaml-err indent whitespace sequence upto-1.2
+  yaml: |
+    ? a
+    : -»b
+      -  -—»c
+         - d
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       +SEQ
+        =VAL :b
+        +SEQ
+         =VAL :c
+         =VAL :d
+        -SEQ
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": [
+        "b",
+        [
+          "c",
+          "d"
+        ]
+      ]
+    }
+  dump: |
+    a:
+    - b
+    - - c
+      - d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/A6F9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/A6F9.yaml
@@ -1,0 +1,37 @@
+---
+- name: Spec Example 8.4. Chomping Final Line Break
+  from: http://www.yaml.org/spec/1.2/spec.html#id2795034
+  tags: spec literal scalar
+  yaml: |
+    strip: |-
+      text
+    clip: |
+      text
+    keep: |+
+      text
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :strip
+       =VAL |text
+       =VAL :clip
+       =VAL |text\n
+       =VAL :keep
+       =VAL |text\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "strip": "text",
+      "clip": "text\n",
+      "keep": "text\n"
+    }
+  dump: |
+    strip: |-
+      text
+    clip: |
+      text
+    keep: |
+      text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/A984.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/A984.yaml
@@ -1,0 +1,29 @@
+---
+- name: Multiline Scalar in Mapping
+  from: NimYAML tests
+  tags: scalar
+  yaml: |
+    a: b
+     c
+    d:
+     e
+      f
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL :b c
+       =VAL :d
+       =VAL :e f
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": "b c",
+      "d": "e f"
+    }
+  dump: |
+    a: b c
+    d: e f

--- a/pkgs/yaml/third_party/yaml-test-suite/src/AB8U.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/AB8U.yaml
@@ -1,0 +1,21 @@
+---
+- name: Sequence entry that looks like two with wrong indentation
+  from: '@perlpunk'
+  tags: scalar sequence
+  yaml: |
+    - single multiline
+     - sequence entry
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :single multiline - sequence entry
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "single multiline - sequence entry"
+    ]
+  dump: |
+    - single multiline - sequence entry

--- a/pkgs/yaml/third_party/yaml-test-suite/src/AVM7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/AVM7.yaml
@@ -1,0 +1,10 @@
+---
+- name: Empty Stream
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/misc.tml
+  tags: edge
+  yaml: |
+    ∎
+  tree: |
+    +STR
+    -STR
+  json: ''

--- a/pkgs/yaml/third_party/yaml-test-suite/src/AZ63.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/AZ63.yaml
@@ -1,0 +1,31 @@
+---
+- name: Sequence With Same Indentation as Parent Mapping
+  from: NimYAML tests
+  tags: indent mapping sequence
+  yaml: |
+    one:
+    - 2
+    - 3
+    four: 5
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :one
+       +SEQ
+        =VAL :2
+        =VAL :3
+       -SEQ
+       =VAL :four
+       =VAL :5
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "one": [
+        2,
+        3
+      ],
+      "four": 5
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/AZW3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/AZW3.yaml
@@ -1,0 +1,31 @@
+---
+- name: Lookahead test cases
+  from: NimYAML tests
+  tags: mapping edge
+  yaml: |
+    - bla"keks: foo
+    - bla]keks: foo
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        =VAL :bla"keks
+        =VAL :foo
+       -MAP
+       +MAP
+        =VAL :bla]keks
+        =VAL :foo
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "bla\"keks": "foo"
+      },
+      {
+        "bla]keks": "foo"
+      }
+    ]

--- a/pkgs/yaml/third_party/yaml-test-suite/src/B3HG.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/B3HG.yaml
@@ -1,0 +1,24 @@
+---
+- name: Spec Example 8.9. Folded Scalar [1.3]
+  from: G992, modified for YAML 1.3
+  tags: spec folded scalar 1.3-mod
+  yaml: |
+    --- >
+     folded
+     text
+    ↵
+    ↵
+  tree: |
+    +STR
+     +DOC ---
+      =VAL >folded text\n
+     -DOC
+    -STR
+  json: |
+    "folded text\n"
+  dump: |
+    >
+      folded text
+  emit: |
+    --- >
+      folded text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/B63P.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/B63P.yaml
@@ -1,0 +1,10 @@
+---
+- name: Directive without document
+  from: AdaYaml tests
+  tags: error directive document
+  fail: true
+  yaml: |
+    %YAML 1.2
+    ...
+  tree: |
+    +STR

--- a/pkgs/yaml/third_party/yaml-test-suite/src/BD7L.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/BD7L.yaml
@@ -1,0 +1,15 @@
+---
+- name: Invalid mapping after sequence
+  from: '@perlpunk'
+  tags: error mapping sequence
+  fail: true
+  yaml: |
+    - item1
+    - item2
+    invalid: x
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :item1
+       =VAL :item2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/BEC7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/BEC7.yaml
@@ -1,0 +1,19 @@
+---
+- name: Spec Example 6.14. “YAML” directive
+  from: http://www.yaml.org/spec/1.2/spec.html#id2781929
+  tags: spec directive
+  yaml: |
+    %YAML 1.3 # Attempt parsing
+              # with a warning
+    ---
+    "foo"
+  tree: |
+    +STR
+     +DOC ---
+      =VAL "foo
+     -DOC
+    -STR
+  json: |
+    "foo"
+  dump: |
+    --- "foo"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/BF9H.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/BF9H.yaml
@@ -1,0 +1,16 @@
+---
+- name: Trailing comment in multiline plain scalar
+  from: '@perlpunk'
+  tags: comment error scalar
+  fail: true
+  yaml: |
+    ---
+    plain: a
+           b # end of scalar
+           c
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :plain
+       =VAL :a b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/BS4K.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/BS4K.yaml
@@ -1,0 +1,13 @@
+---
+- name: Comment between plain scalar lines
+  from: https://gist.github.com/anonymous/269f16d582fdd30a7dcf8c9249c5da7f via @ingydotnet
+  tags: error scalar
+  fail: true
+  yaml: |
+    word1  # comment
+    word2
+  tree: |
+    +STR
+     +DOC
+      =VAL :word1
+     -DOC

--- a/pkgs/yaml/third_party/yaml-test-suite/src/BU8L.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/BU8L.yaml
@@ -1,0 +1,29 @@
+---
+- name: Node Anchor and Tag on Seperate Lines
+  from: https://gist.github.com/anonymous/f192e7dab6da31831f264dbf1947cb83 via @ingydotnet
+  tags: anchor indent 1.3-err tag
+  yaml: |
+    key: &anchor
+     !!map
+      a: b
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       +MAP &anchor <tag:yaml.org,2002:map>
+        =VAL :a
+        =VAL :b
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": {
+        "a": "b"
+      }
+    }
+  dump: |
+    key: &anchor !!map
+      a: b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/C2DT.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/C2DT.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 7.18. Flow Mapping Adjacent Values
+  from: http://www.yaml.org/spec/1.2/spec.html#id2792073
+  tags: spec flow mapping
+  yaml: |
+    {
+    "adjacent":value,
+    "readable": value,
+    "empty":
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL "adjacent
+       =VAL :value
+       =VAL "readable
+       =VAL :value
+       =VAL "empty
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "adjacent": "value",
+      "readable": "value",
+      "empty": null
+    }
+  dump: |
+    "adjacent": value
+    "readable": value
+    "empty":

--- a/pkgs/yaml/third_party/yaml-test-suite/src/C2SP.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/C2SP.yaml
@@ -1,0 +1,13 @@
+---
+- name: Flow Mapping Key on two lines
+  from: '@perlpunk'
+  tags: error flow mapping
+  fail: true
+  yaml: |
+    [23
+    ]: 42
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       =VAL :23

--- a/pkgs/yaml/third_party/yaml-test-suite/src/C4HZ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/C4HZ.yaml
@@ -1,0 +1,100 @@
+---
+- name: Spec Example 2.24. Global Tags
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761719
+  tags: spec tag alias directive local-tag
+  yaml: |
+    %TAG ! tag:clarkevans.com,2002:
+    --- !shape
+      # Use the ! handle for presenting
+      # tag:clarkevans.com,2002:circle
+    - !circle
+      center: &ORIGIN {x: 73, y: 129}
+      radius: 7
+    - !line
+      start: *ORIGIN
+      finish: { x: 89, y: 102 }
+    - !label
+      start: *ORIGIN
+      color: 0xFFEEBB
+      text: Pretty vector drawing.
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ <tag:clarkevans.com,2002:shape>
+       +MAP <tag:clarkevans.com,2002:circle>
+        =VAL :center
+        +MAP {} &ORIGIN
+         =VAL :x
+         =VAL :73
+         =VAL :y
+         =VAL :129
+        -MAP
+        =VAL :radius
+        =VAL :7
+       -MAP
+       +MAP <tag:clarkevans.com,2002:line>
+        =VAL :start
+        =ALI *ORIGIN
+        =VAL :finish
+        +MAP {}
+         =VAL :x
+         =VAL :89
+         =VAL :y
+         =VAL :102
+        -MAP
+       -MAP
+       +MAP <tag:clarkevans.com,2002:label>
+        =VAL :start
+        =ALI *ORIGIN
+        =VAL :color
+        =VAL :0xFFEEBB
+        =VAL :text
+        =VAL :Pretty vector drawing.
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "center": {
+          "x": 73,
+          "y": 129
+        },
+        "radius": 7
+      },
+      {
+        "start": {
+          "x": 73,
+          "y": 129
+        },
+        "finish": {
+          "x": 89,
+          "y": 102
+        }
+      },
+      {
+        "start": {
+          "x": 73,
+          "y": 129
+        },
+        "color": 16772795,
+        "text": "Pretty vector drawing."
+      }
+    ]
+  dump: |
+    --- !<tag:clarkevans.com,2002:shape>
+    - !<tag:clarkevans.com,2002:circle>
+      center: &ORIGIN
+        x: 73
+        y: 129
+      radius: 7
+    - !<tag:clarkevans.com,2002:line>
+      start: *ORIGIN
+      finish:
+        x: 89
+        y: 102
+    - !<tag:clarkevans.com,2002:label>
+      start: *ORIGIN
+      color: 0xFFEEBB
+      text: Pretty vector drawing.

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CC74.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CC74.yaml
@@ -1,0 +1,18 @@
+---
+- name: Spec Example 6.20. Tag Handles
+  from: http://www.yaml.org/spec/1.2/spec.html#id2783195
+  tags: spec directive tag unknown-tag
+  yaml: |
+    %TAG !e! tag:example.com,2000:app/
+    ---
+    !e!foo "bar"
+  tree: |
+    +STR
+     +DOC ---
+      =VAL <tag:example.com,2000:app/foo> "bar
+     -DOC
+    -STR
+  json: |
+    "bar"
+  dump: |
+    --- !<tag:example.com,2000:app/foo> "bar"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CFD4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CFD4.yaml
@@ -1,0 +1,29 @@
+---
+- name: Empty implicit key in single pair flow sequences
+  from: '@perlpunk'
+  tags: empty-key flow sequence
+  yaml: |
+    - [ : empty key ]
+    - [: another empty key]
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ []
+        +MAP {}
+         =VAL :
+         =VAL :empty key
+        -MAP
+       -SEQ
+       +SEQ []
+        +MAP {}
+         =VAL :
+         =VAL :another empty key
+        -MAP
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  dump: |
+    - - : empty key
+    - - : another empty key

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CML9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CML9.yaml
@@ -1,0 +1,16 @@
+---
+- name: Missing comma in flow
+  from: ihttps://gist.github.com/anonymous/4ba3365607cc14b4f656e391b45bf4f4 via @ingydotnet
+  tags: error flow comment
+  fail: true
+  yaml: |
+    key: [ word1
+    #  xxx
+      word2 ]
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       +SEQ []
+        =VAL :word1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CN3R.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CN3R.yaml
@@ -1,0 +1,56 @@
+---
+- name: Various location of anchors in flow sequence
+  from: '@perlpunk'
+  tags: anchor flow mapping sequence
+  yaml: |
+    &flowseq [
+     a: b,
+     &c c: d,
+     { &e e: f },
+     &g { g: h }
+    ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ [] &flowseq
+       +MAP {}
+        =VAL :a
+        =VAL :b
+       -MAP
+       +MAP {}
+        =VAL &c :c
+        =VAL :d
+       -MAP
+       +MAP {}
+        =VAL &e :e
+        =VAL :f
+       -MAP
+       +MAP {} &g
+        =VAL :g
+        =VAL :h
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "a": "b"
+      },
+      {
+        "c": "d"
+      },
+      {
+        "e": "f"
+      },
+      {
+        "g": "h"
+      }
+    ]
+  dump: |
+    &flowseq
+    - a: b
+    - &c c: d
+    - &e e: f
+    - &g
+      g: h

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CPZ3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CPZ3.yaml
@@ -1,0 +1,23 @@
+---
+- name: Doublequoted scalar starting with a tab
+  from: '@perlpunk'
+  tags: double scalar
+  yaml: |
+    ---
+    tab: "\tstring"
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :tab
+       =VAL "\tstring
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "tab": "\tstring"
+    }
+  dump: |
+    ---
+    tab: "\tstring"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CQ3W.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CQ3W.yaml
@@ -1,0 +1,13 @@
+---
+- name: Double quoted string without closing quote
+  from: '@perlpunk'
+  tags: error double
+  fail: true
+  yaml: |
+    ---
+    key: "missing closing quote
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :key

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CT4Q.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CT4Q.yaml
@@ -1,0 +1,28 @@
+---
+- name: Spec Example 7.20. Single Pair Explicit Entry
+  from: http://www.yaml.org/spec/1.2/spec.html#id2792424
+  tags: explicit-key spec flow mapping
+  yaml: |
+    [
+    ? foo
+     bar : baz
+    ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       +MAP {}
+        =VAL :foo bar
+        =VAL :baz
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "foo bar": "baz"
+      }
+    ]
+  dump: |
+    - foo bar: baz

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CTN5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CTN5.yaml
@@ -1,0 +1,15 @@
+---
+- name: Flow sequence with invalid extra comma
+  from: '@perlpunk'
+  tags: error flow sequence
+  fail: true
+  yaml: |
+    ---
+    [ a, b, c, , ]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []
+       =VAL :a
+       =VAL :b
+       =VAL :c

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CUP7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CUP7.yaml
@@ -1,0 +1,26 @@
+---
+- name: Spec Example 5.6. Node Property Indicators
+  from: http://www.yaml.org/spec/1.2/spec.html#id2773402
+  tags: local-tag spec tag alias
+  yaml: |
+    anchored: !local &anchor value
+    alias: *anchor
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :anchored
+       =VAL &anchor <!local> :value
+       =VAL :alias
+       =ALI *anchor
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "anchored": "value",
+      "alias": "value"
+    }
+  dump: |
+    anchored: &anchor !local value
+    alias: *anchor

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CVW2.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CVW2.yaml
@@ -1,0 +1,16 @@
+---
+- name: Invalid comment after comma
+  from: '@perlpunk'
+  tags: comment error flow sequence
+  fail: true
+  yaml: |
+    ---
+    [ a, b, c,#invalid
+    ]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []
+       =VAL :a
+       =VAL :b
+       =VAL :c

--- a/pkgs/yaml/third_party/yaml-test-suite/src/CXX2.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/CXX2.yaml
@@ -1,0 +1,10 @@
+---
+- name: Mapping with anchor on document start line
+  from: '@perlpunk'
+  tags: anchor error header mapping
+  fail: true
+  yaml: |
+    --- &anchor a: b
+  tree: |
+    +STR
+     +DOC ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/D49Q.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/D49Q.yaml
@@ -1,0 +1,15 @@
+---
+- name: Multiline single quoted implicit keys
+  from: '@perlpunk'
+  tags: error single mapping
+  fail: true
+  yaml: |
+    'a\nb': 1
+    'c
+     d': 1
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL 'a\\nb
+       =VAL :1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/D83L.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/D83L.yaml
@@ -1,0 +1,28 @@
+---
+- name: Block scalar indicator order
+  from: '@perlpunk'
+  tags: indent literal
+  yaml: |
+    - |2-
+      explicit indent and chomp
+    - |-2
+      chomp and explicit indent
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL |explicit indent and chomp
+       =VAL |chomp and explicit indent
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "explicit indent and chomp",
+      "chomp and explicit indent"
+    ]
+  dump: |
+    - |-
+      explicit indent and chomp
+    - |-
+      chomp and explicit indent

--- a/pkgs/yaml/third_party/yaml-test-suite/src/D88J.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/D88J.yaml
@@ -1,0 +1,29 @@
+---
+- name: Flow Sequence in Block Mapping
+  from: NimYAML tests
+  tags: flow sequence mapping
+  yaml: |
+    a: [b, c]
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       +SEQ []
+        =VAL :b
+        =VAL :c
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": [
+        "b",
+        "c"
+      ]
+    }
+  dump: |
+    a:
+    - b
+    - c

--- a/pkgs/yaml/third_party/yaml-test-suite/src/D9TU.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/D9TU.yaml
@@ -1,0 +1,19 @@
+---
+- name: Single Pair Block Mapping
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/mapping.tml
+  tags: simple mapping
+  yaml: |
+    foo: bar
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL :bar
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "bar"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DBG4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DBG4.yaml
@@ -1,0 +1,62 @@
+---
+- name: Spec Example 7.10. Plain Characters
+  from: http://www.yaml.org/spec/1.2/spec.html#id2789510
+  tags: spec flow sequence scalar
+  yaml: |
+    # Outside flow collection:
+    - ::vector
+    - ": - ()"
+    - Up, up, and away!
+    - -123
+    - http://example.com/foo#bar
+    # Inside flow collection:
+    - [ ::vector,
+      ": - ()",
+      "Up, up and away!",
+      -123,
+      http://example.com/foo#bar ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :::vector
+       =VAL ": - ()
+       =VAL :Up, up, and away!
+       =VAL :-123
+       =VAL :http://example.com/foo#bar
+       +SEQ []
+        =VAL :::vector
+        =VAL ": - ()
+        =VAL "Up, up and away!
+        =VAL :-123
+        =VAL :http://example.com/foo#bar
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "::vector",
+      ": - ()",
+      "Up, up, and away!",
+      -123,
+      "http://example.com/foo#bar",
+      [
+        "::vector",
+        ": - ()",
+        "Up, up and away!",
+        -123,
+        "http://example.com/foo#bar"
+      ]
+    ]
+  dump: |
+    - ::vector
+    - ": - ()"
+    - Up, up, and away!
+    - -123
+    - http://example.com/foo#bar
+    - - ::vector
+      - ": - ()"
+      - "Up, up and away!"
+      - -123
+      - http://example.com/foo#bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DC7X.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DC7X.yaml
@@ -1,0 +1,37 @@
+---
+- name: Various trailing tabs
+  from: '@perlpunk'
+  tags: comment whitespace
+  yaml: |
+    a: b———»
+    seq:———»
+     - a———»
+    c: d———»#X
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL :b
+       =VAL :seq
+       +SEQ
+        =VAL :a
+       -SEQ
+       =VAL :c
+       =VAL :d
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": "b",
+      "seq": [
+        "a"
+      ],
+      "c": "d"
+    }
+  dump: |
+    a: b
+    seq:
+    - a
+    c: d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DE56.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DE56.yaml
@@ -1,0 +1,87 @@
+---
+- name: Trailing tabs in double quoted
+  from: '@ingydotnet'
+  tags: double whitespace
+  yaml: |
+    "1 trailing\t
+        tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "1 trailing\t tab
+     -DOC
+    -STR
+  json: |
+    "1 trailing\t tab"
+  dump: |
+    "1 trailing\t tab"
+
+- yaml: |
+    "2 trailing\t␣␣
+        tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "2 trailing\t tab
+     -DOC
+    -STR
+  json: |
+    "2 trailing\t tab"
+  dump: |
+    "2 trailing\t tab"
+
+- yaml: |
+    "3 trailing\————»
+        tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "3 trailing\t tab
+     -DOC
+    -STR
+  json: |
+    "3 trailing\t tab"
+  dump: |
+    "3 trailing\t tab"
+
+- yaml: |
+    "4 trailing\————»␣␣
+        tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "4 trailing\t tab
+     -DOC
+    -STR
+  json: |
+    "4 trailing\t tab"
+  dump: |
+    "4 trailing\t tab"
+
+- yaml: |
+    "5 trailing—»
+        tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "5 trailing tab
+     -DOC
+    -STR
+  json: |
+    "5 trailing tab"
+  dump: |
+    "5 trailing tab"
+
+- yaml: |
+    "6 trailing—»␣␣
+        tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "6 trailing tab
+     -DOC
+    -STR
+  json: |
+    "6 trailing tab"
+  dump: |
+    "6 trailing tab"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DFF7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DFF7.yaml
@@ -1,0 +1,27 @@
+---
+- name: Spec Example 7.16. Flow Mapping Entries
+  from: http://www.yaml.org/spec/1.2/spec.html#id2791260
+  tags: explicit-key spec flow mapping
+  yaml: |
+    {
+    ? explicit: entry,
+    implicit: entry,
+    ?
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :explicit
+       =VAL :entry
+       =VAL :implicit
+       =VAL :entry
+       =VAL :
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    explicit: entry
+    implicit: entry
+    :

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DHP8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DHP8.yaml
@@ -1,0 +1,26 @@
+---
+- name: Flow Sequence
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/sequence.tml
+  tags: flow sequence
+  yaml: |
+    [foo, bar, 42]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       =VAL :foo
+       =VAL :bar
+       =VAL :42
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "foo",
+      "bar",
+      42
+    ]
+  dump: |
+    - foo
+    - bar
+    - 42

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DK3J.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DK3J.yaml
@@ -1,0 +1,20 @@
+---
+- name: Zero indented block scalar with line that looks like a comment
+  from: '@perlpunk'
+  tags: comment folded scalar
+  yaml: |
+    --- >
+    line1
+    # no comment
+    line3
+  tree: |
+    +STR
+     +DOC ---
+      =VAL >line1 # no comment line3\n
+     -DOC
+    -STR
+  json: |
+    "line1 # no comment line3\n"
+  dump: |
+    --- >
+      line1 # no comment line3

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DK4H.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DK4H.yaml
@@ -1,0 +1,14 @@
+---
+- name: Implicit key followed by newline
+  from: '@perlpunk'
+  tags: error flow mapping sequence
+  fail: true
+  yaml: |
+    ---
+    [ key
+      : value ]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []
+       =VAL :key

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DK95.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DK95.yaml
@@ -1,0 +1,172 @@
+---
+- name: Tabs that look like indentation
+  from: '@ingydotnet'
+  tags: indent whitespace
+  yaml: |
+    foo:
+     ———»bar
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL :bar
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo" : "bar"
+    }
+  emit: |
+    ---
+    foo: bar
+
+- fail: true
+  yaml: |
+    foo: "bar
+    ————»baz"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+
+- yaml: |
+    foo: "bar
+      ——»baz"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL "bar baz
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo" : "bar baz"
+    }
+  emit: |
+    ---
+    foo: "bar baz"
+
+- yaml: |2
+     ———»
+    foo: 1
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL :1
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo" : 1
+    }
+  emit: |
+    ---
+    foo: 1
+
+- yaml: |
+    foo: 1
+    ————»
+    bar: 2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL :1
+       =VAL :bar
+       =VAL :2
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo" : 1,
+      "bar" : 2
+    }
+  emit: |
+    ---
+    foo: 1
+    bar: 2
+
+- yaml: |
+    foo: 1
+     ———»
+    bar: 2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL :1
+       =VAL :bar
+       =VAL :2
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo" : 1,
+      "bar" : 2
+    }
+  emit: |
+    ---
+    foo: 1
+    bar: 2
+
+- fail: true
+  yaml: |
+    foo:
+      a: 1
+      ——»b: 2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       +MAP
+        =VAL :a
+        =VAL :1
+
+- yaml: |
+    %YAML 1.2
+    ————»
+    ---
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :
+     -DOC
+    -STR
+  json: |
+    null
+  emit: |
+    --- null
+
+- yaml: |
+    foo: "bar
+     ———» ——» baz ——» ——» "
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL "bar baz \t \t␣
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo" : "bar baz \t \t "
+    }
+  emit: |
+    ---
+    foo: "bar baz \t \t "

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DMG6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DMG6.yaml
@@ -1,0 +1,18 @@
+---
+- name: Wrong indendation in Map
+  from: '@perlpunk'
+  tags: error mapping indent
+  fail: true
+  yaml: |
+    key:
+      ok: 1
+     wrong: 2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       +MAP
+        =VAL :ok
+        =VAL :1
+       -MAP

--- a/pkgs/yaml/third_party/yaml-test-suite/src/DWX9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/DWX9.yaml
@@ -1,0 +1,32 @@
+---
+- name: Spec Example 8.8. Literal Content
+  from: http://www.yaml.org/spec/1.2/spec.html#id2796118
+  tags: spec literal scalar comment whitespace 1.3-err
+  yaml: |
+    |
+    ␣
+    ␣␣
+      literal
+    ␣␣␣
+    ␣␣
+      text
+
+     # Comment
+  tree: |
+    +STR
+     +DOC
+      =VAL |\n\nliteral\n \n\ntext\n
+     -DOC
+    -STR
+  json: |
+    "\n\nliteral\n \n\ntext\n"
+  dump: |
+    "\n\nliteral\n \n\ntext\n"
+  emit: |
+    |
+
+
+      literal
+    ␣␣␣
+
+      text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/E76Z.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/E76Z.yaml
@@ -1,0 +1,26 @@
+---
+- name: Aliases in Implicit Block Mapping
+  from: NimYAML tests
+  tags: mapping alias
+  yaml: |
+    &a a: &b b
+    *b : *a
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL &a :a
+       =VAL &b :b
+       =ALI *b
+       =ALI *a
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": "b",
+      "b": "a"
+    }
+  dump: |
+    &a a: &b b
+    *b : *a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/EB22.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/EB22.yaml
@@ -1,0 +1,16 @@
+---
+- name: Missing document-end marker before directive
+  from: '@perlpunk'
+  tags: error directive footer
+  fail: true
+  yaml: |
+    ---
+    scalar1 # comment
+    %YAML 1.2
+    ---
+    scalar2
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :scalar1
+     -DOC

--- a/pkgs/yaml/third_party/yaml-test-suite/src/EHF6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/EHF6.yaml
@@ -1,0 +1,33 @@
+---
+- name: Tags for Flow Objects
+  from: NimYAML tests
+  tags: tag flow mapping sequence
+  yaml: |
+    !!map {
+      k: !!seq
+      [ a, !!str b]
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP {} <tag:yaml.org,2002:map>
+       =VAL :k
+       +SEQ [] <tag:yaml.org,2002:seq>
+        =VAL :a
+        =VAL <tag:yaml.org,2002:str> :b
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "k": [
+        "a",
+        "b"
+      ]
+    }
+  dump: |
+    !!map
+    k: !!seq
+    - a
+    - !!str b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/EW3V.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/EW3V.yaml
@@ -1,0 +1,13 @@
+---
+- name: Wrong indendation in mapping
+  from: '@perlpunk'
+  tags: error mapping indent
+  fail: true
+  yaml: |
+    k1: v1
+     k2: v2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :k1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/EX5H.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/EX5H.yaml
@@ -1,0 +1,28 @@
+---
+- name: Multiline Scalar at Top Level [1.3]
+  from: 9YRD, modified for YAML 1.3
+  tags: scalar whitespace 1.3-mod
+  yaml: |
+    ---
+    a
+    b␣␣
+      c
+    d
+
+    e
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :a b c d\ne
+     -DOC
+    -STR
+  json: |
+    "a b c d\ne"
+  dump: |
+    'a b c d
+
+      e'
+  emit: |
+    --- a b c d
+
+    e

--- a/pkgs/yaml/third_party/yaml-test-suite/src/EXG3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/EXG3.yaml
@@ -1,0 +1,20 @@
+---
+- name: Three dashes and content without space [1.3]
+  from: 82AN, modified for YAML 1.3
+  tags: scalar 1.3-mod
+  yaml: |
+    ---
+    ---word1
+    word2
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :---word1 word2
+     -DOC
+    -STR
+  json: |
+    "---word1 word2"
+  dump: |
+    '---word1 word2'
+  emit: |
+    --- '---word1 word2'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/F2C7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/F2C7.yaml
@@ -1,0 +1,32 @@
+---
+- name: Anchors and Tags
+  from: NimYAML tests
+  tags: anchor tag
+  yaml: |2
+     - &a !!str a
+     - !!int 2
+     - !!int &c 4
+     - &d d
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL &a <tag:yaml.org,2002:str> :a
+       =VAL <tag:yaml.org,2002:int> :2
+       =VAL &c <tag:yaml.org,2002:int> :4
+       =VAL &d :d
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "a",
+      2,
+      4,
+      "d"
+    ]
+  dump: |
+    - &a !!str a
+    - !!int 2
+    - &c !!int 4
+    - &d d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/F3CP.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/F3CP.yaml
@@ -1,0 +1,47 @@
+---
+- name: Nested flow collections on one line
+  from: '@perlpunk'
+  tags: flow mapping sequence
+  yaml: |
+    ---
+    { a: [b, c, { d: [e, f] } ] }
+  tree: |
+    +STR
+     +DOC ---
+      +MAP {}
+       =VAL :a
+       +SEQ []
+        =VAL :b
+        =VAL :c
+        +MAP {}
+         =VAL :d
+         +SEQ []
+          =VAL :e
+          =VAL :f
+         -SEQ
+        -MAP
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": [
+        "b",
+        "c",
+        {
+          "d": [
+            "e",
+            "f"
+          ]
+        }
+      ]
+    }
+  dump: |
+    ---
+    a:
+    - b
+    - c
+    - d:
+      - e
+      - f

--- a/pkgs/yaml/third_party/yaml-test-suite/src/F6MC.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/F6MC.yaml
@@ -1,0 +1,40 @@
+---
+- name: More indented lines at the beginning of folded block scalars
+  from: '@perlpunk'
+  tags: folded indent
+  yaml: |
+    ---
+    a: >2
+       more indented
+      regular
+    b: >2
+
+
+       more indented
+      regular
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :a
+       =VAL > more indented\nregular\n
+       =VAL :b
+       =VAL >\n\n more indented\nregular\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": " more indented\nregular\n",
+      "b": "\n\n more indented\nregular\n"
+    }
+  emit: |
+    ---
+    a: >2
+       more indented
+      regular
+    b: >2
+
+
+       more indented
+      regular

--- a/pkgs/yaml/third_party/yaml-test-suite/src/F8F9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/F8F9.yaml
@@ -1,0 +1,52 @@
+---
+- name: Spec Example 8.5. Chomping Trailing Lines
+  from: http://www.yaml.org/spec/1.2/spec.html#id2795435
+  tags: spec literal scalar comment
+  yaml: |2
+     # Strip
+      # Comments:
+    strip: |-
+      # text
+    ␣␣
+     # Clip
+      # comments:
+
+    clip: |
+      # text
+    ␣
+     # Keep
+      # comments:
+
+    keep: |+
+      # text
+
+     # Trail
+      # comments.
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :strip
+       =VAL |# text
+       =VAL :clip
+       =VAL |# text\n
+       =VAL :keep
+       =VAL |# text\n\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "strip": "# text",
+      "clip": "# text\n",
+      "keep": "# text\n\n"
+    }
+  dump: |
+    strip: |-
+      # text
+    clip: |
+      # text
+    keep: |+
+      # text
+
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/FBC9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/FBC9.yaml
@@ -1,0 +1,37 @@
+---
+- name: Allowed characters in plain scalars
+  from: '@perlpunk'
+  tags: scalar
+  yaml: |
+    safe: a!"#$%&'()*+,-./09:;<=>?@AZ[\]^_`az{|}~
+         !"#$%&'()*+,-./09:;<=>?@AZ[\]^_`az{|}~
+    safe question mark: ?foo
+    safe colon: :foo
+    safe dash: -foo
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :safe
+       =VAL :a!"#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~ !"#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~
+       =VAL :safe question mark
+       =VAL :?foo
+       =VAL :safe colon
+       =VAL ::foo
+       =VAL :safe dash
+       =VAL :-foo
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "safe": "a!\"#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~ !\"#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~",
+      "safe question mark": "?foo",
+      "safe colon": ":foo",
+      "safe dash": "-foo"
+    }
+  dump: |
+    safe: a!"#$%&'()*+,-./09:;<=>?@AZ[\]^_`az{|}~ !"#$%&'()*+,-./09:;<=>?@AZ[\]^_`az{|}~
+    safe question mark: ?foo
+    safe colon: :foo
+    safe dash: -foo

--- a/pkgs/yaml/third_party/yaml-test-suite/src/FH7J.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/FH7J.yaml
@@ -1,0 +1,33 @@
+---
+- name: Tags on Empty Scalars
+  from: NimYAML tests
+  tags: tag scalar
+  yaml: |
+    - !!str
+    -
+      !!null : a
+      b: !!str
+    - !!str : !!null
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL <tag:yaml.org,2002:str> :
+       +MAP
+        =VAL <tag:yaml.org,2002:null> :
+        =VAL :a
+        =VAL :b
+        =VAL <tag:yaml.org,2002:str> :
+       -MAP
+       +MAP
+        =VAL <tag:yaml.org,2002:str> :
+        =VAL <tag:yaml.org,2002:null> :
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  dump: |
+    - !!str
+    - !!null : a
+      b: !!str
+    - !!str : !!null

--- a/pkgs/yaml/third_party/yaml-test-suite/src/FP8R.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/FP8R.yaml
@@ -1,0 +1,20 @@
+---
+- name: Zero indented block scalar
+  from: '@perlpunk'
+  tags: folded indent scalar
+  yaml: |
+    --- >
+    line1
+    line2
+    line3
+  tree: |
+    +STR
+     +DOC ---
+      =VAL >line1 line2 line3\n
+     -DOC
+    -STR
+  json: |
+    "line1 line2 line3\n"
+  dump: |
+    --- >
+      line1 line2 line3

--- a/pkgs/yaml/third_party/yaml-test-suite/src/FQ7F.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/FQ7F.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 2.1. Sequence of Scalars
+  from: http://www.yaml.org/spec/1.2/spec.html#id2759963
+  tags: spec sequence
+  yaml: |
+    - Mark McGwire
+    - Sammy Sosa
+    - Ken Griffey
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :Mark McGwire
+       =VAL :Sammy Sosa
+       =VAL :Ken Griffey
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "Mark McGwire",
+      "Sammy Sosa",
+      "Ken Griffey"
+    ]
+  toke: |
+    SEQ-MARK 0 1 1 1
+    WS-SPACE 1 1 1 2
+    TEXT-VAL 2 12 1 3 :Mark McGwire
+    WS-NEWLN 14 1 1 15
+    SEQ-MARK 15 1 2 1
+    WS-SPACE 1 1 1 2
+    TEXT-VAL 2 12 1 3 :Sammy Sosa
+    WS-NEWLN 14 1 1 15

--- a/pkgs/yaml/third_party/yaml-test-suite/src/FRK4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/FRK4.yaml
@@ -1,0 +1,20 @@
+---
+- name: Spec Example 7.3. Completely Empty Flow Nodes
+  from: http://www.yaml.org/spec/1.2/spec.html#id2786868
+  tags: empty-key explicit-key spec flow mapping
+  yaml: |
+    {
+      ? foo :,
+      : bar,
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :foo
+       =VAL :
+       =VAL :
+       =VAL :bar
+      -MAP
+     -DOC
+    -STR

--- a/pkgs/yaml/third_party/yaml-test-suite/src/FTA2.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/FTA2.yaml
@@ -1,0 +1,22 @@
+---
+- name: Single block sequence with anchor and explicit document start
+  from: '@perlpunk'
+  tags: anchor header sequence
+  yaml: |
+    --- &sequence
+    - a
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ &sequence
+       =VAL :a
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "a"
+    ]
+  dump: |
+    --- &sequence
+    - a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/FUP4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/FUP4.yaml
@@ -1,0 +1,30 @@
+---
+- name: Flow Sequence in Flow Sequence
+  from: NimYAML tests
+  tags: sequence flow
+  yaml: |
+    [a, [b, c]]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       =VAL :a
+       +SEQ []
+        =VAL :b
+        =VAL :c
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "a",
+      [
+        "b",
+        "c"
+      ]
+    ]
+  dump: |
+    - a
+    - - b
+      - c

--- a/pkgs/yaml/third_party/yaml-test-suite/src/G4RS.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/G4RS.yaml
@@ -1,0 +1,47 @@
+---
+- name: Spec Example 2.17. Quoted Scalars
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761245
+  tags: spec scalar
+  yaml: |
+    unicode: "Sosa did fine.\u263A"
+    control: "\b1998\t1999\t2000\n"
+    hex esc: "\x0d\x0a is \r\n"
+
+    single: '"Howdy!" he cried.'
+    quoted: ' # Not a ''comment''.'
+    tie-fighter: '|\-*-/|'
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :unicode
+       =VAL "Sosa did fine.☺
+       =VAL :control
+       =VAL "\b1998\t1999\t2000\n
+       =VAL :hex esc
+       =VAL "\r\n is \r\n
+       =VAL :single
+       =VAL '"Howdy!" he cried.
+       =VAL :quoted
+       =VAL ' # Not a 'comment'.
+       =VAL :tie-fighter
+       =VAL '|\\-*-/|
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "unicode": "Sosa did fine.☺",
+      "control": "\b1998\t1999\t2000\n",
+      "hex esc": "\r\n is \r\n",
+      "single": "\"Howdy!\" he cried.",
+      "quoted": " # Not a 'comment'.",
+      "tie-fighter": "|\\-*-/|"
+    }
+  dump: |
+    unicode: "Sosa did fine.\u263A"
+    control: "\b1998\t1999\t2000\n"
+    hex esc: "\r\n is \r\n"
+    single: '"Howdy!" he cried.'
+    quoted: ' # Not a ''comment''.'
+    tie-fighter: '|\-*-/|'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/G5U8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/G5U8.yaml
@@ -1,0 +1,13 @@
+---
+- name: Plain dashes in flow sequence
+  from: '@ingydotnet'
+  tags: flow sequence
+  fail: true
+  yaml: |
+    ---
+    - [-, -]
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       +SEQ []

--- a/pkgs/yaml/third_party/yaml-test-suite/src/G7JE.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/G7JE.yaml
@@ -1,0 +1,15 @@
+---
+- name: Multiline implicit keys
+  from: '@perlpunk'
+  tags: error mapping
+  fail: true
+  yaml: |
+    a\nb: 1
+    c
+     d: 1
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a\\nb
+       =VAL :1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/G992.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/G992.yaml
@@ -1,0 +1,21 @@
+---
+- name: Spec Example 8.9. Folded Scalar
+  from: http://www.yaml.org/spec/1.2/spec.html#id2796371
+  tags: spec folded scalar 1.3-err
+  yaml: |
+    >
+     folded
+     text
+    ↵
+    ↵
+  tree: |
+    +STR
+     +DOC
+      =VAL >folded text\n
+     -DOC
+    -STR
+  json: |
+    "folded text\n"
+  dump: |
+    >
+      folded text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/G9HC.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/G9HC.yaml
@@ -1,0 +1,16 @@
+---
+- name: Invalid anchor in zero indented sequence
+  from: '@perlpunk'
+  tags: anchor error sequence
+  fail: true
+  yaml: |
+    ---
+    seq:
+    &anchor
+    - a
+    - b
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :seq

--- a/pkgs/yaml/third_party/yaml-test-suite/src/GDY7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/GDY7.yaml
@@ -1,0 +1,14 @@
+---
+- name: Comment that looks like a mapping key
+  from: '@perlpunk'
+  tags: comment error mapping
+  fail: true
+  yaml: |
+    key: value
+    this is #not a: key
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       =VAL :value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/GH63.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/GH63.yaml
@@ -1,0 +1,27 @@
+---
+- name: Mixed Block Mapping (explicit to implicit)
+  from: NimYAML tests
+  tags: explicit-key mapping
+  yaml: |
+    ? a
+    : 1.3
+    fifteen: d
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL :1.3
+       =VAL :fifteen
+       =VAL :d
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": 1.3,
+      "fifteen": "d"
+    }
+  dump: |
+    a: 1.3
+    fifteen: d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/GT5M.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/GT5M.yaml
@@ -1,0 +1,14 @@
+---
+- name: Node anchor in sequence
+  from: '@perlpunk'
+  tags: anchor error sequence
+  fail: true
+  yaml: |
+    - item1
+    &node
+    - item2
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :item1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/H2RW.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/H2RW.yaml
@@ -1,0 +1,51 @@
+---
+- name: Blank lines
+  from: IRC discussion with leont
+  tags: comment literal scalar whitespace
+  yaml: |
+    foo: 1
+
+    bar: 2
+    ␣␣␣␣
+    text: |
+      a
+    ␣␣␣␣
+      b
+
+      c
+    ␣
+      d
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL :1
+       =VAL :bar
+       =VAL :2
+       =VAL :text
+       =VAL |a\n  \nb\n\nc\n\nd\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": 1,
+      "bar": 2,
+      "text": "a\n  \nb\n\nc\n\nd\n"
+    }
+  dump: |
+    foo: 1
+    bar: 2
+    text: "a\n  \nb\n\nc\n\nd\n"
+  emit: |
+    foo: 1
+    bar: 2
+    text: |
+      a
+    ␣␣␣␣
+      b
+
+      c
+
+      d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/H3Z8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/H3Z8.yaml
@@ -1,0 +1,23 @@
+---
+- name: Literal unicode
+  from: '@perlpunk'
+  tags: scalar
+  yaml: |
+    ---
+    wanted: love ♥ and peace ☮
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :wanted
+       =VAL :love ♥ and peace ☮
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "wanted": "love ♥ and peace ☮"
+    }
+  dump: |
+    ---
+    wanted: "love \u2665 and peace \u262E"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/H7J7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/H7J7.yaml
@@ -1,0 +1,15 @@
+---
+- name: Node anchor not indented
+  from: https://gist.github.com/anonymous/f192e7dab6da31831f264dbf1947cb83 via @ingydotnet
+  tags: anchor error indent tag
+  fail: true
+  yaml: |
+    key: &x
+    !!map
+      a: b
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       =VAL &x :

--- a/pkgs/yaml/third_party/yaml-test-suite/src/H7TQ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/H7TQ.yaml
@@ -1,0 +1,10 @@
+---
+- name: Extra words on %YAML directive
+  from: '@ingydotnet'
+  tags: directive
+  fail: true
+  yaml: |
+    %YAML 1.2 foo
+    ---
+  tree: |
+    +STR

--- a/pkgs/yaml/third_party/yaml-test-suite/src/HM87.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/HM87.yaml
@@ -1,0 +1,37 @@
+---
+- name: Scalars in flow start with syntax char
+  from: '@ingydotnet'
+  tags: flow scalar
+  yaml: |
+    [:x]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       =VAL ::x
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      ":x"
+    ]
+  dump: |
+    - :x
+
+- yaml: |
+    [?x]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       =VAL :?x
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "?x"
+    ]
+  dump: |
+    - ?x

--- a/pkgs/yaml/third_party/yaml-test-suite/src/HMK4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/HMK4.yaml
@@ -1,0 +1,38 @@
+---
+- name: Spec Example 2.16. Indentation determines scope
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761083
+  tags: spec folded literal
+  yaml: |
+    name: Mark McGwire
+    accomplishment: >
+      Mark set a major league
+      home run record in 1998.
+    stats: |
+      65 Home Runs
+      0.278 Batting Average
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :name
+       =VAL :Mark McGwire
+       =VAL :accomplishment
+       =VAL >Mark set a major league home run record in 1998.\n
+       =VAL :stats
+       =VAL |65 Home Runs\n0.278 Batting Average\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "name": "Mark McGwire",
+      "accomplishment": "Mark set a major league home run record in 1998.\n",
+      "stats": "65 Home Runs\n0.278 Batting Average\n"
+    }
+  dump: |
+    name: Mark McGwire
+    accomplishment: >
+      Mark set a major league home run record in 1998.
+    stats: |
+      65 Home Runs
+      0.278 Batting Average

--- a/pkgs/yaml/third_party/yaml-test-suite/src/HMQ5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/HMQ5.yaml
@@ -1,0 +1,27 @@
+---
+- name: Spec Example 6.23. Node Properties
+  from: http://www.yaml.org/spec/1.2/spec.html#id2783940
+  tags: spec tag alias
+  yaml: |
+    !!str &a1 "foo":
+      !!str bar
+    &a2 baz : *a1
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL &a1 <tag:yaml.org,2002:str> "foo
+       =VAL <tag:yaml.org,2002:str> :bar
+       =VAL &a2 :baz
+       =ALI *a1
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "bar",
+      "baz": "foo"
+    }
+  dump: |
+    &a1 !!str "foo": !!str bar
+    &a2 baz: *a1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/HRE5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/HRE5.yaml
@@ -1,0 +1,13 @@
+---
+- name: Double quoted scalar with escaped single quote
+  from: https://github.com/yaml/libyaml/issues/68
+  tags: double error single
+  fail: true
+  yaml: |
+    ---
+    double: "quoted \' scalar"
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :double

--- a/pkgs/yaml/third_party/yaml-test-suite/src/HS5T.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/HS5T.yaml
@@ -1,0 +1,21 @@
+---
+- name: Spec Example 7.12. Plain Lines
+  from: http://www.yaml.org/spec/1.2/spec.html#id2789986
+  tags: spec scalar whitespace upto-1.2
+  yaml: |
+    1st non-empty
+
+     2nd non-empty␣
+    ———»3rd non-empty
+  tree: |
+    +STR
+     +DOC
+      =VAL :1st non-empty\n2nd non-empty 3rd non-empty
+     -DOC
+    -STR
+  json: |
+    "1st non-empty\n2nd non-empty 3rd non-empty"
+  dump: |
+    '1st non-empty
+
+      2nd non-empty 3rd non-empty'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/HU3P.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/HU3P.yaml
@@ -1,0 +1,14 @@
+---
+- name: Invalid Mapping in plain scalar
+  from: https://gist.github.com/anonymous/d305fd8e54cfe7a484088c91a8a2e533 via @ingydotnet
+  tags: error mapping scalar
+  fail: true
+  yaml: |
+    key:
+      word1 word2
+      no: key
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key

--- a/pkgs/yaml/third_party/yaml-test-suite/src/HWV9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/HWV9.yaml
@@ -1,0 +1,11 @@
+---
+- name: Document-end marker
+  from: '@perlpunk'
+  tags: footer
+  yaml: |
+    ...
+  tree: |
+    +STR
+    -STR
+  json: ''
+  dump: ''

--- a/pkgs/yaml/third_party/yaml-test-suite/src/J3BT.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/J3BT.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 5.12. Tabs and Spaces
+  from: http://www.yaml.org/spec/1.2/spec.html#id2775350
+  tags: spec whitespace upto-1.2
+  yaml: |
+    # Tabs and spaces
+    quoted: "Quoted ———»"
+    block:—»|
+      void main() {
+      —»printf("Hello, world!\n");
+      }
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :quoted
+       =VAL "Quoted \t
+       =VAL :block
+       =VAL |void main() {\n\tprintf("Hello, world!\\n");\n}\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "quoted": "Quoted \t",
+      "block": "void main() {\n\tprintf(\"Hello, world!\\n\");\n}\n"
+    }
+  dump: |
+    quoted: "Quoted \t"
+    block: |
+      void main() {
+      —»printf("Hello, world!\n");
+      }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/J5UC.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/J5UC.yaml
@@ -1,0 +1,27 @@
+---
+- name: Multiple Pair Block Mapping
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/mapping.tml
+  tags: mapping
+  yaml: |
+    foo: blue
+    bar: arrr
+    baz: jazz
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL :blue
+       =VAL :bar
+       =VAL :arrr
+       =VAL :baz
+       =VAL :jazz
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "blue",
+      "bar": "arrr",
+      "baz": "jazz"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/J7PZ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/J7PZ.yaml
@@ -1,0 +1,52 @@
+---
+- name: Spec Example 2.26. Ordered Mappings
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761780
+  tags: spec mapping tag unknown-tag
+  yaml: |
+    # The !!omap tag is one of the optional types
+    # introduced for YAML 1.1. In 1.2, it is not
+    # part of the standard tags and should not be
+    # enabled by default.
+    # Ordered maps are represented as
+    # A sequence of mappings, with
+    # each mapping having one key
+    --- !!omap
+    - Mark McGwire: 65
+    - Sammy Sosa: 63
+    - Ken Griffy: 58
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ <tag:yaml.org,2002:omap>
+       +MAP
+        =VAL :Mark McGwire
+        =VAL :65
+       -MAP
+       +MAP
+        =VAL :Sammy Sosa
+        =VAL :63
+       -MAP
+       +MAP
+        =VAL :Ken Griffy
+        =VAL :58
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "Mark McGwire": 65
+      },
+      {
+        "Sammy Sosa": 63
+      },
+      {
+        "Ken Griffy": 58
+      }
+    ]
+  dump: |
+    --- !!omap
+    - Mark McGwire: 65
+    - Sammy Sosa: 63
+    - Ken Griffy: 58

--- a/pkgs/yaml/third_party/yaml-test-suite/src/J7VC.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/J7VC.yaml
@@ -1,0 +1,28 @@
+---
+- name: Empty Lines Between Mapping Elements
+  from: NimYAML tests
+  tags: whitespace mapping
+  yaml: |
+    one: 2
+
+
+    three: 4
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :one
+       =VAL :2
+       =VAL :three
+       =VAL :4
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "one": 2,
+      "three": 4
+    }
+  dump: |
+    one: 2
+    three: 4

--- a/pkgs/yaml/third_party/yaml-test-suite/src/J9HZ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/J9HZ.yaml
@@ -1,0 +1,49 @@
+---
+- name: Spec Example 2.9. Single Document with Two Comments
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760633
+  tags: mapping sequence spec comment
+  yaml: |
+    ---
+    hr: # 1998 hr ranking
+      - Mark McGwire
+      - Sammy Sosa
+    rbi:
+      # 1998 rbi ranking
+      - Sammy Sosa
+      - Ken Griffey
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :hr
+       +SEQ
+        =VAL :Mark McGwire
+        =VAL :Sammy Sosa
+       -SEQ
+       =VAL :rbi
+       +SEQ
+        =VAL :Sammy Sosa
+        =VAL :Ken Griffey
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "hr": [
+        "Mark McGwire",
+        "Sammy Sosa"
+      ],
+      "rbi": [
+        "Sammy Sosa",
+        "Ken Griffey"
+      ]
+    }
+  dump: |
+    ---
+    hr:
+    - Mark McGwire
+    - Sammy Sosa
+    rbi:
+    - Sammy Sosa
+    - Ken Griffey

--- a/pkgs/yaml/third_party/yaml-test-suite/src/JEF9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/JEF9.yaml
@@ -1,0 +1,53 @@
+---
+- name: Trailing whitespace in streams
+  from: '@ingydotnet'
+  tags: literal
+  yaml: |
+    - |+
+    ↵
+    ↵
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL |\n\n
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "\n\n"
+    ]
+  dump: |
+    - |+
+    ↵
+    ↵
+    ...
+
+- yaml: |
+    - |+
+    ␣␣␣
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL |\n
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "\n"
+    ]
+  dump: |
+    - |+
+
+    ...
+
+- yaml: |
+    - |+
+    ␣␣␣∎
+  dump: |
+    - |+
+
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/JHB9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/JHB9.yaml
@@ -1,0 +1,49 @@
+---
+- name: Spec Example 2.7. Two Documents in a Stream
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760493
+  tags: spec header
+  yaml: |
+    # Ranking of 1998 home runs
+    ---
+    - Mark McGwire
+    - Sammy Sosa
+    - Ken Griffey
+
+    # Team ranking
+    ---
+    - Chicago Cubs
+    - St Louis Cardinals
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       =VAL :Mark McGwire
+       =VAL :Sammy Sosa
+       =VAL :Ken Griffey
+      -SEQ
+     -DOC
+     +DOC ---
+      +SEQ
+       =VAL :Chicago Cubs
+       =VAL :St Louis Cardinals
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "Mark McGwire",
+      "Sammy Sosa",
+      "Ken Griffey"
+    ]
+    [
+      "Chicago Cubs",
+      "St Louis Cardinals"
+    ]
+  dump: |
+    ---
+    - Mark McGwire
+    - Sammy Sosa
+    - Ken Griffey
+    ---
+    - Chicago Cubs
+    - St Louis Cardinals

--- a/pkgs/yaml/third_party/yaml-test-suite/src/JKF3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/JKF3.yaml
@@ -1,0 +1,13 @@
+---
+- name: Multiline unidented double quoted block key
+  from: '@ingydotnet'
+  tags: indent
+  fail: true
+  yaml: |
+    - - "bar
+    bar": x
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ

--- a/pkgs/yaml/third_party/yaml-test-suite/src/JQ4R.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/JQ4R.yaml
@@ -1,0 +1,36 @@
+---
+- name: Spec Example 8.14. Block Sequence
+  from: http://www.yaml.org/spec/1.2/spec.html#id2797596
+  tags: mapping spec sequence
+  yaml: |
+    block sequence:
+      - one
+      - two : three
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :block sequence
+       +SEQ
+        =VAL :one
+        +MAP
+         =VAL :two
+         =VAL :three
+        -MAP
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "block sequence": [
+        "one",
+        {
+          "two": "three"
+        }
+      ]
+    }
+  dump: |
+    block sequence:
+    - one
+    - two: three

--- a/pkgs/yaml/third_party/yaml-test-suite/src/JR7V.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/JR7V.yaml
@@ -1,0 +1,76 @@
+---
+- name: Question marks in scalars
+  from: '@perlpunk'
+  tags: flow scalar
+  yaml: |
+    - a?string
+    - another ? string
+    - key: value?
+    - [a?string]
+    - [another ? string]
+    - {key: value? }
+    - {key: value?}
+    - {key?: value }
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :a?string
+       =VAL :another ? string
+       +MAP
+        =VAL :key
+        =VAL :value?
+       -MAP
+       +SEQ []
+        =VAL :a?string
+       -SEQ
+       +SEQ []
+        =VAL :another ? string
+       -SEQ
+       +MAP {}
+        =VAL :key
+        =VAL :value?
+       -MAP
+       +MAP {}
+        =VAL :key
+        =VAL :value?
+       -MAP
+       +MAP {}
+        =VAL :key?
+        =VAL :value
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "a?string",
+      "another ? string",
+      {
+        "key": "value?"
+      },
+      [
+        "a?string"
+      ],
+      [
+        "another ? string"
+      ],
+      {
+        "key": "value?"
+      },
+      {
+        "key": "value?"
+      },
+      {
+        "key?": "value"
+      }
+    ]
+  dump: |
+    - a?string
+    - another ? string
+    - key: value?
+    - - a?string
+    - - another ? string
+    - key: value?
+    - key: value?
+    - key?: value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/JS2J.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/JS2J.yaml
@@ -1,0 +1,23 @@
+---
+- name: Spec Example 6.29. Node Anchors
+  from: http://www.yaml.org/spec/1.2/spec.html#id2785977
+  tags: spec alias
+  yaml: |
+    First occurrence: &anchor Value
+    Second occurrence: *anchor
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :First occurrence
+       =VAL &anchor :Value
+       =VAL :Second occurrence
+       =ALI *anchor
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "First occurrence": "Value",
+      "Second occurrence": "Value"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/JTV5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/JTV5.yaml
@@ -1,0 +1,30 @@
+---
+- name: Block Mapping with Multiline Scalars
+  from: NimYAML tests
+  tags: explicit-key mapping scalar
+  yaml: |
+    ? a
+      true
+    : null
+      d
+    ? e
+      42
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a true
+       =VAL :null d
+       =VAL :e 42
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a true": "null d",
+      "e 42": null
+    }
+  dump: |
+    a true: null d
+    e 42:

--- a/pkgs/yaml/third_party/yaml-test-suite/src/JY7Z.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/JY7Z.yaml
@@ -1,0 +1,17 @@
+---
+- name: Trailing content that looks like a mapping
+  from: '@perlpunk'
+  tags: error mapping double
+  fail: true
+  yaml: |
+    key1: "quoted1"
+    key2: "quoted2" no key: nor value
+    key3: "quoted3"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key1
+       =VAL "quoted1
+       =VAL :key2
+       =VAL "quoted2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/K3WX.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/K3WX.yaml
@@ -1,0 +1,24 @@
+---
+- name: Colon and adjacent value after comment on next line
+  from: <Source URL or description>
+  tags: comment flow mapping
+  yaml: |
+    ---
+    { "foo" # comment
+      :bar }
+  tree: |
+    +STR
+     +DOC ---
+      +MAP {}
+       =VAL "foo
+       =VAL :bar
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "bar"
+    }
+  dump: |
+    ---
+    "foo": bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/K4SU.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/K4SU.yaml
@@ -1,0 +1,24 @@
+---
+- name: Multiple Entry Block Sequence
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/sequence.tml
+  tags: sequence
+  yaml: |
+    - foo
+    - bar
+    - 42
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :foo
+       =VAL :bar
+       =VAL :42
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "foo",
+      "bar",
+      42
+    ]

--- a/pkgs/yaml/third_party/yaml-test-suite/src/K527.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/K527.yaml
@@ -1,0 +1,27 @@
+---
+- name: Spec Example 6.6. Line Folding
+  from: http://www.yaml.org/spec/1.2/spec.html#id2779289
+  tags: folded spec whitespace scalar 1.3-err
+  yaml: |
+    >-
+      trimmed
+    ␣␣
+    ␣
+
+      as
+      space
+  tree: |
+    +STR
+     +DOC
+      =VAL >trimmed\n\n\nas space
+     -DOC
+    -STR
+  json: |
+    "trimmed\n\n\nas space"
+  dump: |
+    >-
+      trimmed
+
+
+
+      as space

--- a/pkgs/yaml/third_party/yaml-test-suite/src/K54U.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/K54U.yaml
@@ -1,0 +1,17 @@
+---
+- name: Tab after document header
+  from: '@perlpunk'
+  tags: header whitespace
+  yaml: |
+    ---»scalar
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :scalar
+     -DOC
+    -STR
+  json: |
+    "scalar"
+  dump: |
+    --- scalar
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/K858.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/K858.yaml
@@ -1,0 +1,36 @@
+---
+- name: Spec Example 8.6. Empty Scalar Chomping
+  from: http://www.yaml.org/spec/1.2/spec.html#id2795596
+  tags: spec folded literal whitespace
+  yaml: |
+    strip: >-
+
+    clip: >
+
+    keep: |+
+    ↵
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :strip
+       =VAL >
+       =VAL :clip
+       =VAL >
+       =VAL :keep
+       =VAL |\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "strip": "",
+      "clip": "",
+      "keep": "\n"
+    }
+  dump: |
+    strip: ""
+    clip: ""
+    keep: |2+
+
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/KH5V.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/KH5V.yaml
@@ -1,0 +1,40 @@
+---
+- name: Inline tabs in double quoted
+  from: '@ingydotnet'
+  tags: double whitespace
+  yaml: |
+    "1 inline\ttab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "1 inline\ttab
+     -DOC
+    -STR
+  json: |
+    "1 inline\ttab"
+
+- yaml: |
+    "2 inline\——»tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "2 inline\ttab
+     -DOC
+    -STR
+  json: |
+    "2 inline\ttab"
+  dump: |
+    "2 inline\ttab"
+
+- yaml: |
+    "3 inline———»tab"
+  tree: |
+    +STR
+     +DOC
+      =VAL "3 inline\ttab
+     -DOC
+    -STR
+  json: |
+    "3 inline\ttab"
+  dump: |
+    "3 inline\ttab"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/KK5P.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/KK5P.yaml
@@ -1,0 +1,81 @@
+---
+- name: Various combinations of explicit block mappings
+  from: '@perlpunk'
+  tags: explicit-key mapping sequence
+  yaml: |
+    complex1:
+      ? - a
+    complex2:
+      ? - a
+      : b
+    complex3:
+      ? - a
+      : >
+        b
+    complex4:
+      ? >
+        a
+      :
+    complex5:
+      ? - a
+      : - b
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :complex1
+       +MAP
+        +SEQ
+         =VAL :a
+        -SEQ
+        =VAL :
+       -MAP
+       =VAL :complex2
+       +MAP
+        +SEQ
+         =VAL :a
+        -SEQ
+        =VAL :b
+       -MAP
+       =VAL :complex3
+       +MAP
+        +SEQ
+         =VAL :a
+        -SEQ
+        =VAL >b\n
+       -MAP
+       =VAL :complex4
+       +MAP
+        =VAL >a\n
+        =VAL :
+       -MAP
+       =VAL :complex5
+       +MAP
+        +SEQ
+         =VAL :a
+        -SEQ
+        +SEQ
+         =VAL :b
+        -SEQ
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    complex1:
+      ? - a
+      :
+    complex2:
+      ? - a
+      : b
+    complex3:
+      ? - a
+      : >
+        b
+    complex4:
+      ? >
+        a
+      :
+    complex5:
+      ? - a
+      : - b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/KMK3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/KMK3.yaml
@@ -1,0 +1,29 @@
+---
+- name: Block Submapping
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/mapping.tml
+  tags: mapping
+  yaml: |
+    foo:
+      bar: 1
+    baz: 2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       +MAP
+        =VAL :bar
+        =VAL :1
+       -MAP
+       =VAL :baz
+       =VAL :2
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": {
+        "bar": 1
+      },
+      "baz": 2
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/KS4U.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/KS4U.yaml
@@ -1,0 +1,17 @@
+---
+- name: Invalid item after end of flow sequence
+  from: '@perlpunk'
+  tags: error flow sequence
+  fail: true
+  yaml: |
+    ---
+    [
+    sequence item
+    ]
+    invalid item
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ []
+       =VAL :sequence item
+      -SEQ

--- a/pkgs/yaml/third_party/yaml-test-suite/src/KSS4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/KSS4.yaml
@@ -1,0 +1,27 @@
+---
+- name: Scalars on --- line
+  from: '@perlpunk'
+  tags: anchor header scalar 1.3-err
+  yaml: |
+    --- "quoted
+    string"
+    --- &node foo
+  tree: |
+    +STR
+     +DOC ---
+      =VAL "quoted string
+     -DOC
+     +DOC ---
+      =VAL &node :foo
+     -DOC
+    -STR
+  json: |
+    "quoted string"
+    "foo"
+  dump: |
+    --- "quoted string"
+    --- &node foo
+    ...
+  emit: |
+    --- "quoted string"
+    --- &node foo

--- a/pkgs/yaml/third_party/yaml-test-suite/src/L24T.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/L24T.yaml
@@ -1,0 +1,45 @@
+---
+- name: Trailing line of spaces
+  from: '@ingydotnet'
+  tags: whitespace
+  yaml: |
+    foo: |
+      x
+    ␣␣␣
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL |x\n \n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo" : "x\n \n"
+    }
+  emit: |
+    ---
+    foo: "x\n \n"
+
+- yaml: |
+    foo: |
+      x
+    ␣␣␣∎
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL |x\n \n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo" : "x\n \n"
+    }
+  emit: |
+    ---
+    foo: "x\n \n"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/L383.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/L383.yaml
@@ -1,0 +1,22 @@
+---
+- name: Two scalar docs with trailing comments
+  from: '@ingydotnet'
+  tags: comment
+  yaml: |
+    --- foo  # comment
+    --- foo  # comment
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :foo
+     -DOC
+     +DOC ---
+      =VAL :foo
+     -DOC
+    -STR
+  json: |
+    "foo"
+    "foo"
+  dump: |
+    --- foo
+    --- foo

--- a/pkgs/yaml/third_party/yaml-test-suite/src/L94M.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/L94M.yaml
@@ -1,0 +1,28 @@
+---
+- name: Tags in Explicit Mapping
+  from: NimYAML tests
+  tags: explicit-key tag mapping
+  yaml: |
+    ? !!str a
+    : !!int 47
+    ? c
+    : !!str d
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL <tag:yaml.org,2002:str> :a
+       =VAL <tag:yaml.org,2002:int> :47
+       =VAL :c
+       =VAL <tag:yaml.org,2002:str> :d
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": 47,
+      "c": "d"
+    }
+  dump: |
+    !!str a: !!int 47
+    c: !!str d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/L9U5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/L9U5.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 7.11. Plain Implicit Keys
+  from: http://www.yaml.org/spec/1.2/spec.html#id2789794
+  tags: spec flow mapping
+  yaml: |
+    implicit block key : [
+      implicit flow key : value,
+     ]
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :implicit block key
+       +SEQ []
+        +MAP {}
+         =VAL :implicit flow key
+         =VAL :value
+        -MAP
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "implicit block key": [
+        {
+          "implicit flow key": "value"
+        }
+      ]
+    }
+  dump: |
+    implicit block key:
+    - implicit flow key: value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/LE5A.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/LE5A.yaml
@@ -1,0 +1,30 @@
+---
+- name: Spec Example 7.24. Flow Nodes
+  from: http://www.yaml.org/spec/1.2/spec.html#id2793490
+  tags: spec tag alias
+  yaml: |
+    - !!str "a"
+    - 'b'
+    - &anchor "c"
+    - *anchor
+    - !!str
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL <tag:yaml.org,2002:str> "a
+       =VAL 'b
+       =VAL &anchor "c
+       =ALI *anchor
+       =VAL <tag:yaml.org,2002:str> :
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "a",
+      "b",
+      "c",
+      "c",
+      ""
+    ]

--- a/pkgs/yaml/third_party/yaml-test-suite/src/LHL4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/LHL4.yaml
@@ -1,0 +1,11 @@
+---
+- name: Invalid tag
+  from: '@perlpunk'
+  tags: error tag
+  fail: true
+  yaml: |
+    ---
+    !invalid{}tag scalar
+  tree: |
+    +STR
+     +DOC ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/LP6E.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/LP6E.yaml
@@ -1,0 +1,55 @@
+---
+- name: Whitespace After Scalars in Flow
+  from: NimYAML tests
+  tags: flow scalar whitespace
+  yaml: |
+    - [a, b , c ]
+    - { "a"  : b
+       , c : 'd' ,
+       e   : "f"
+      }
+    - [      ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ []
+        =VAL :a
+        =VAL :b
+        =VAL :c
+       -SEQ
+       +MAP {}
+        =VAL "a
+        =VAL :b
+        =VAL :c
+        =VAL 'd
+        =VAL :e
+        =VAL "f
+       -MAP
+       +SEQ []
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      [
+        "a",
+        "b",
+        "c"
+      ],
+      {
+        "a": "b",
+        "c": "d",
+        "e": "f"
+      },
+      []
+    ]
+  dump: |
+    - - a
+      - b
+      - c
+    - "a": b
+      c: 'd'
+      e: "f"
+    - []

--- a/pkgs/yaml/third_party/yaml-test-suite/src/LQZ7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/LQZ7.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 7.4. Double Quoted Implicit Keys
+  from: http://www.yaml.org/spec/1.2/spec.html#id2787420
+  tags: spec scalar flow
+  yaml: |
+    "implicit block key" : [
+      "implicit flow key" : value,
+     ]
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL "implicit block key
+       +SEQ []
+        +MAP {}
+         =VAL "implicit flow key
+         =VAL :value
+        -MAP
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "implicit block key": [
+        {
+          "implicit flow key": "value"
+        }
+      ]
+    }
+  dump: |
+    "implicit block key":
+    - "implicit flow key": value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/LX3P.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/LX3P.yaml
@@ -1,0 +1,20 @@
+---
+- name: Implicit Flow Mapping Key on one line
+  from: '@perlpunk'
+  tags: complex-key mapping flow sequence 1.3-err
+  yaml: |
+    [flow]: block
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       +SEQ []
+        =VAL :flow
+       -SEQ
+       =VAL :block
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    ? - flow
+    : block

--- a/pkgs/yaml/third_party/yaml-test-suite/src/M29M.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/M29M.yaml
@@ -1,0 +1,33 @@
+---
+- name: Literal Block Scalar
+  from: NimYAML tests
+  tags: literal scalar whitespace
+  yaml: |
+    a: |
+     ab
+    ␣
+     cd
+     ef
+    ␣
+
+    ...
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL |ab\n\ncd\nef\n
+      -MAP
+     -DOC ...
+    -STR
+  json: |
+    {
+      "a": "ab\n\ncd\nef\n"
+    }
+  dump: |
+    a: |
+      ab
+
+      cd
+      ef
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/M2N8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/M2N8.yaml
@@ -1,0 +1,42 @@
+---
+- name: Question mark edge cases
+  from: '@ingydotnet'
+  tags: edge empty-key
+  yaml: |
+    - ? : x
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        +MAP
+         =VAL :
+         =VAL :x
+        -MAP
+        =VAL :
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  dump: |
+    - ? : x
+      :
+
+- yaml: |
+    ? []: x
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       +MAP
+        +SEQ []
+        -SEQ
+        =VAL :x
+       -MAP
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    ? []: x
+    :

--- a/pkgs/yaml/third_party/yaml-test-suite/src/M5C3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/M5C3.yaml
@@ -1,0 +1,32 @@
+---
+- name: Spec Example 8.21. Block Scalar Nodes
+  from: http://www.yaml.org/spec/1.2/spec.html#id2799693
+  tags: indent spec literal folded tag local-tag 1.3-err
+  yaml: |
+    literal: |2
+      value
+    folded:
+       !foo
+      >1
+     value
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :literal
+       =VAL |value\n
+       =VAL :folded
+       =VAL <!foo> >value\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "literal": "value\n",
+      "folded": "value\n"
+    }
+  dump: |
+    literal: |
+      value
+    folded: !foo >
+      value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/M5DY.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/M5DY.yaml
@@ -1,0 +1,46 @@
+---
+- name: Spec Example 2.11. Mapping between Sequences
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760799
+  tags: complex-key explicit-key spec mapping sequence
+  yaml: |
+    ? - Detroit Tigers
+      - Chicago cubs
+    :
+      - 2001-07-23
+
+    ? [ New York Yankees,
+        Atlanta Braves ]
+    : [ 2001-07-02, 2001-08-12,
+        2001-08-14 ]
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       +SEQ
+        =VAL :Detroit Tigers
+        =VAL :Chicago cubs
+       -SEQ
+       +SEQ
+        =VAL :2001-07-23
+       -SEQ
+       +SEQ []
+        =VAL :New York Yankees
+        =VAL :Atlanta Braves
+       -SEQ
+       +SEQ []
+        =VAL :2001-07-02
+        =VAL :2001-08-12
+        =VAL :2001-08-14
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    ? - Detroit Tigers
+      - Chicago cubs
+    : - 2001-07-23
+    ? - New York Yankees
+      - Atlanta Braves
+    : - 2001-07-02
+      - 2001-08-12
+      - 2001-08-14

--- a/pkgs/yaml/third_party/yaml-test-suite/src/M6YH.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/M6YH.yaml
@@ -1,0 +1,41 @@
+---
+- name: Block sequence indentation
+  from: '@ingydotnet'
+  tags: indent
+  yaml: |
+    - |
+     x
+    -
+     foo: bar
+    -
+     - 42
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL |x\n
+       +MAP
+        =VAL :foo
+        =VAL :bar
+       -MAP
+       +SEQ
+        =VAL :42
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "x\n",
+      {
+        "foo" : "bar"
+      },
+      [
+        42
+      ]
+    ]
+  dump: |
+    - |
+      x
+    - foo: bar
+    - - 42

--- a/pkgs/yaml/third_party/yaml-test-suite/src/M7A3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/M7A3.yaml
@@ -1,0 +1,29 @@
+---
+- name: Spec Example 9.3. Bare Documents
+  from: http://www.yaml.org/spec/1.2/spec.html#id2801226
+  tags: spec footer 1.3-err
+  yaml: |
+    Bare
+    document
+    ...
+    # No document
+    ...
+    |
+    %!PS-Adobe-2.0 # Not the first line
+  tree: |
+    +STR
+     +DOC
+      =VAL :Bare document
+     -DOC ...
+     +DOC
+      =VAL |%!PS-Adobe-2.0 # Not the first line\n
+     -DOC
+    -STR
+  json: |
+    "Bare document"
+    "%!PS-Adobe-2.0 # Not the first line\n"
+  emit: |
+    Bare document
+    ...
+    |
+      %!PS-Adobe-2.0 # Not the first line

--- a/pkgs/yaml/third_party/yaml-test-suite/src/M7NX.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/M7NX.yaml
@@ -1,0 +1,53 @@
+---
+- name: Nested flow collections
+  from: '@perlpunk'
+  tags: flow mapping sequence
+  yaml: |
+    ---
+    {
+     a: [
+      b, c, {
+       d: [e, f]
+      }
+     ]
+    }
+  tree: |
+    +STR
+     +DOC ---
+      +MAP {}
+       =VAL :a
+       +SEQ []
+        =VAL :b
+        =VAL :c
+        +MAP {}
+         =VAL :d
+         +SEQ []
+          =VAL :e
+          =VAL :f
+         -SEQ
+        -MAP
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": [
+        "b",
+        "c",
+        {
+          "d": [
+            "e",
+            "f"
+          ]
+        }
+      ]
+    }
+  dump: |
+    ---
+    a:
+    - b
+    - c
+    - d:
+      - e
+      - f

--- a/pkgs/yaml/third_party/yaml-test-suite/src/M9B4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/M9B4.yaml
@@ -1,0 +1,22 @@
+---
+- name: Spec Example 8.7. Literal Scalar
+  from: http://www.yaml.org/spec/1.2/spec.html#id2795789
+  tags: spec literal scalar whitespace 1.3-err
+  yaml: |
+    |
+     literal
+     ——»text
+    ↵
+    ↵
+  tree: |
+    +STR
+     +DOC
+      =VAL |literal\n\ttext\n
+     -DOC
+    -STR
+  json: |
+    "literal\n\ttext\n"
+  dump: |
+    |
+      literal
+      —»text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/MJS9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/MJS9.yaml
@@ -1,0 +1,21 @@
+---
+- name: Spec Example 6.7. Block Folding
+  from: http://www.yaml.org/spec/1.2/spec.html#id2779603
+  tags: folded spec scalar whitespace 1.3-err
+  yaml: |
+    >
+      foo␣
+    ␣
+      —» bar
+
+      baz
+  tree: |
+    +STR
+     +DOC
+      =VAL >foo \n\n\t bar\n\nbaz\n
+     -DOC
+    -STR
+  json: |
+    "foo \n\n\t bar\n\nbaz\n"
+  dump: |
+    "foo \n\n\t bar\n\nbaz\n"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/MUS6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/MUS6.yaml
@@ -1,0 +1,49 @@
+- name: Directive variants
+  from: '@ingydotnet'
+  tags: directive
+  also: ZYU8
+  fail: true
+  yaml: |
+    %YAML 1.1#...
+    ---
+  tree: |
+    +STR
+
+- fail: true
+  yaml: |
+    %YAML 1.2
+    ---
+    %YAML 1.2
+    ---
+  dump: null
+
+- yaml: |
+    %YAML  1.1
+    ---
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :
+     -DOC
+    -STR
+  json: |
+    null
+  dump: |
+    ---
+
+- yaml: |
+    %YAML ——» 1.1
+    ---
+
+- yaml: |
+    %YAML 1.1  # comment
+    ---
+
+- note: These 2 are reserved directives
+  yaml: |
+    %YAM 1.1
+    ---
+
+- yaml: |
+    %YAMLL 1.1
+    ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/MXS3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/MXS3.yaml
@@ -1,0 +1,25 @@
+---
+- name: Flow Mapping in Block Sequence
+  from: NimYAML tests
+  tags: mapping sequence flow
+  yaml: |
+    - {a: b}
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP {}
+        =VAL :a
+        =VAL :b
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "a": "b"
+      }
+    ]
+  dump: |
+    - a: b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/MYW6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/MYW6.yaml
@@ -1,0 +1,22 @@
+---
+- name: Block Scalar Strip
+  from: NimYAML tests
+  tags: literal scalar whitespace 1.3-err
+  yaml: |
+    |-
+     ab
+    ␣
+    ␣
+    ...
+  tree: |
+    +STR
+     +DOC
+      =VAL |ab
+     -DOC ...
+    -STR
+  json: |
+    "ab"
+  dump: |
+    |-
+      ab
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/MZX3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/MZX3.yaml
@@ -1,0 +1,31 @@
+---
+- name: Non-Specific Tags on Scalars
+  from: NimYAML tests
+  tags: folded scalar
+  yaml: |
+    - plain
+    - "double quoted"
+    - 'single quoted'
+    - >
+      block
+    - plain again
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :plain
+       =VAL "double quoted
+       =VAL 'single quoted
+       =VAL >block\n
+       =VAL :plain again
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "plain",
+      "double quoted",
+      "single quoted",
+      "block\n",
+      "plain again"
+    ]

--- a/pkgs/yaml/third_party/yaml-test-suite/src/N4JP.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/N4JP.yaml
@@ -1,0 +1,18 @@
+---
+- name: Bad indentation in mapping
+  from: '@perlpunk'
+  tags: error mapping indent double
+  fail: true
+  yaml: |
+    map:
+      key1: "quoted1"
+     key2: "bad indentation"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :map
+       +MAP
+        =VAL :key1
+        =VAL "quoted1
+       -MAP

--- a/pkgs/yaml/third_party/yaml-test-suite/src/N782.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/N782.yaml
@@ -1,0 +1,14 @@
+---
+- name: Invalid document markers in flow style
+  from: NimYAML tests
+  tags: flow edge header footer error
+  fail: true
+  yaml: |
+    [
+    --- ,
+    ...
+    ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []

--- a/pkgs/yaml/third_party/yaml-test-suite/src/NAT4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/NAT4.yaml
@@ -1,0 +1,77 @@
+---
+- name: Various empty or newline only quoted strings
+  from: '@perlpunk'
+  tags: double scalar single whitespace
+  yaml: |
+    ---
+    a: '
+      '
+    b: '␣␣
+      '
+    c: "
+      "
+    d: "␣␣
+      "
+    e: '
+
+      '
+    f: "
+
+      "
+    g: '
+
+
+      '
+    h: "
+
+
+      "
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :a
+       =VAL '␣
+       =VAL :b
+       =VAL '␣
+       =VAL :c
+       =VAL "␣
+       =VAL :d
+       =VAL "␣
+       =VAL :e
+       =VAL '\n
+       =VAL :f
+       =VAL "\n
+       =VAL :g
+       =VAL '\n\n
+       =VAL :h
+       =VAL "\n\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": " ",
+      "b": " ",
+      "c": " ",
+      "d": " ",
+      "e": "\n",
+      "f": "\n",
+      "g": "\n\n",
+      "h": "\n\n"
+    }
+  emit: |
+    ---
+    a: ' '
+    b: ' '
+    c: " "
+    d: " "
+    e: '
+
+      '
+    f: "\n"
+    g: '
+
+
+      '
+    h: "\n\n"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/NB6Z.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/NB6Z.yaml
@@ -1,0 +1,27 @@
+---
+- name: Multiline plain value with tabs on empty lines
+  from: '@perlpunk'
+  tags: scalar whitespace
+  yaml: |
+    key:
+      value
+      with
+      —»
+      tabs
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       =VAL :value with\ntabs
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": "value with\ntabs"
+    }
+  dump: |
+    key: 'value with
+
+      tabs'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/NHX8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/NHX8.yaml
@@ -1,0 +1,19 @@
+---
+- name: Empty Lines at End of Document
+  from: NimYAML tests
+  tags: empty-key whitespace
+  yaml: |
+    :
+    ↵
+    ↵
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  emit: |
+    :

--- a/pkgs/yaml/third_party/yaml-test-suite/src/NJ66.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/NJ66.yaml
@@ -1,0 +1,37 @@
+---
+- name: Multiline plain flow mapping key
+  from: '@perlpunk'
+  tags: flow mapping
+  yaml: |
+    ---
+    - { single line: value}
+    - { multi
+      line: value}
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       +MAP {}
+        =VAL :single line
+        =VAL :value
+       -MAP
+       +MAP {}
+        =VAL :multi line
+        =VAL :value
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "single line": "value"
+      },
+      {
+        "multi line": "value"
+      }
+    ]
+  dump: |
+    ---
+    - single line: value
+    - multi line: value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/NKF9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/NKF9.yaml
@@ -1,0 +1,60 @@
+---
+- name: Empty keys in block and flow mapping
+  from: '@perlpunk'
+  tags: empty-key mapping
+  yaml: |
+    ---
+    key: value
+    : empty key
+    ---
+    {
+     key: value, : empty key
+    }
+    ---
+    # empty key and value
+    :
+    ---
+    # empty key and value
+    { : }
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :key
+       =VAL :value
+       =VAL :
+       =VAL :empty key
+      -MAP
+     -DOC
+     +DOC ---
+      +MAP {}
+       =VAL :key
+       =VAL :value
+       =VAL :
+       =VAL :empty key
+      -MAP
+     -DOC
+     +DOC ---
+      +MAP
+       =VAL :
+       =VAL :
+      -MAP
+     -DOC
+     +DOC ---
+      +MAP {}
+       =VAL :
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  emit: |
+    ---
+    key: value
+    : empty key
+    ---
+    key: value
+    : empty key
+    ---
+    :
+    ---
+    :

--- a/pkgs/yaml/third_party/yaml-test-suite/src/NP9H.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/NP9H.yaml
@@ -1,0 +1,20 @@
+---
+- name: Spec Example 7.5. Double Quoted Line Breaks
+  from: http://www.yaml.org/spec/1.2/spec.html#id2787745
+  tags: double spec scalar whitespace upto-1.2
+  yaml: |
+    "folded␣
+    to a space,»
+    ␣
+    to a line feed, or »\
+     \ »non-content"
+  tree: |
+    +STR
+     +DOC
+      =VAL "folded to a space,\nto a line feed, or \t \tnon-content
+     -DOC
+    -STR
+  json: |
+    "folded to a space,\nto a line feed, or \t \tnon-content"
+  dump: |
+    "folded to a space,\nto a line feed, or \t \tnon-content"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/P2AD.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/P2AD.yaml
@@ -1,0 +1,42 @@
+---
+- name: Spec Example 8.1. Block Scalar Header
+  from: http://www.yaml.org/spec/1.2/spec.html#id2793888
+  tags: spec literal folded comment scalar
+  yaml: |
+    - | # Empty header↓
+     literal
+    - >1 # Indentation indicator↓
+      folded
+    - |+ # Chomping indicator↓
+     keep
+
+    - >1- # Both indicators↓
+      strip
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL |literal\n
+       =VAL > folded\n
+       =VAL |keep\n\n
+       =VAL > strip
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "literal\n",
+      " folded\n",
+      "keep\n\n",
+      " strip"
+    ]
+  dump: |
+    - |
+      literal
+    - >2
+       folded
+    - |+
+      keep
+
+    - >2-
+       strip

--- a/pkgs/yaml/third_party/yaml-test-suite/src/P2EQ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/P2EQ.yaml
@@ -1,0 +1,16 @@
+---
+- name: Invalid sequene item on same line as previous item
+  from: '@perlpunk'
+  tags: error flow mapping sequence
+  fail: true
+  yaml: |
+    ---
+    - { y: z }- invalid
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       +MAP {}
+        =VAL :y
+        =VAL :z
+       -MAP

--- a/pkgs/yaml/third_party/yaml-test-suite/src/P76L.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/P76L.yaml
@@ -1,0 +1,18 @@
+---
+- name: Spec Example 6.19. Secondary Tag Handle
+  from: http://www.yaml.org/spec/1.2/spec.html#id2782940
+  tags: spec header tag unknown-tag
+  yaml: |
+    %TAG !! tag:example.com,2000:app/
+    ---
+    !!int 1 - 3 # Interval, not integer
+  tree: |
+    +STR
+     +DOC ---
+      =VAL <tag:example.com,2000:app/int> :1 - 3
+     -DOC
+    -STR
+  json: |
+    "1 - 3"
+  dump: |
+    --- !<tag:example.com,2000:app/int> 1 - 3

--- a/pkgs/yaml/third_party/yaml-test-suite/src/P94K.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/P94K.yaml
@@ -1,0 +1,25 @@
+---
+- name: Spec Example 6.11. Multi-Line Comments
+  from: http://www.yaml.org/spec/1.2/spec.html#id2780696
+  tags: spec comment
+  yaml: |
+    key:    # Comment
+            # lines
+      value
+    ↵
+    ↵
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       =VAL :value
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": "value"
+    }
+  dump: |
+    key: value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/PBJ2.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/PBJ2.yaml
@@ -1,0 +1,54 @@
+---
+- name: Spec Example 2.3. Mapping Scalars to Sequences
+  from: http://www.yaml.org/spec/1.2/spec.html#id2759963
+  tags: spec mapping sequence
+  yaml: |
+    american:
+      - Boston Red Sox
+      - Detroit Tigers
+      - New York Yankees
+    national:
+      - New York Mets
+      - Chicago Cubs
+      - Atlanta Braves
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :american
+       +SEQ
+        =VAL :Boston Red Sox
+        =VAL :Detroit Tigers
+        =VAL :New York Yankees
+       -SEQ
+       =VAL :national
+       +SEQ
+        =VAL :New York Mets
+        =VAL :Chicago Cubs
+        =VAL :Atlanta Braves
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "american": [
+        "Boston Red Sox",
+        "Detroit Tigers",
+        "New York Yankees"
+      ],
+      "national": [
+        "New York Mets",
+        "Chicago Cubs",
+        "Atlanta Braves"
+      ]
+    }
+  dump: |
+    american:
+    - Boston Red Sox
+    - Detroit Tigers
+    - New York Yankees
+    national:
+    - New York Mets
+    - Chicago Cubs
+    - Atlanta Braves

--- a/pkgs/yaml/third_party/yaml-test-suite/src/PRH3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/PRH3.yaml
@@ -1,0 +1,25 @@
+---
+- name: Spec Example 7.9. Single Quoted Lines
+  from: http://www.yaml.org/spec/1.2/spec.html#id2788756
+  tags: single spec scalar whitespace upto-1.2
+  yaml: |
+    ' 1st non-empty
+
+     2nd non-empty␣
+    ———»3rd non-empty '
+  tree: |
+    +STR
+     +DOC
+      =VAL ' 1st non-empty\n2nd non-empty 3rd non-empty␣
+     -DOC
+    -STR
+  json: |
+    " 1st non-empty\n2nd non-empty 3rd non-empty "
+  dump: |
+    ' 1st non-empty
+
+      2nd non-empty 3rd non-empty '
+  emit: |
+    ' 1st non-empty
+
+      2nd non-empty 3rd non-empty '

--- a/pkgs/yaml/third_party/yaml-test-suite/src/PUW8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/PUW8.yaml
@@ -1,0 +1,30 @@
+---
+- name: Document start on last line
+  from: '@perlpunk'
+  tags: header
+  yaml: |
+    ---
+    a: b
+    ---
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :a
+       =VAL :b
+      -MAP
+     -DOC
+     +DOC ---
+      =VAL :
+     -DOC
+    -STR
+  json: |
+    {
+      "a": "b"
+    }
+    null
+  dump: |
+    ---
+    a: b
+    ---
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/PW8X.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/PW8X.yaml
@@ -1,0 +1,52 @@
+---
+- name: Anchors on Empty Scalars
+  from: NimYAML tests
+  tags: anchor explicit-key
+  yaml: |
+    - &a
+    - a
+    -
+      &a : a
+      b: &b
+    -
+      &c : &a
+    -
+      ? &d
+    -
+      ? &e
+      : &a
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL &a :
+       =VAL :a
+       +MAP
+        =VAL &a :
+        =VAL :a
+        =VAL :b
+        =VAL &b :
+       -MAP
+       +MAP
+        =VAL &c :
+        =VAL &a :
+       -MAP
+       +MAP
+        =VAL &d :
+        =VAL :
+       -MAP
+       +MAP
+        =VAL &e :
+        =VAL &a :
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  dump: |
+    - &a
+    - a
+    - &a : a
+      b: &b
+    - &c : &a
+    - &d :
+    - &e : &a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Q4CL.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Q4CL.yaml
@@ -1,0 +1,17 @@
+---
+- name: Trailing content after quoted value
+  from: '@perlpunk'
+  tags: error mapping double
+  fail: true
+  yaml: |
+    key1: "quoted1"
+    key2: "quoted2" trailing content
+    key3: "quoted3"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key1
+       =VAL "quoted1
+       =VAL :key2
+       =VAL "quoted2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Q5MG.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Q5MG.yaml
@@ -1,0 +1,17 @@
+---
+- name: Tab at beginning of line followed by a flow mapping
+  from: IRC
+  tags: flow whitespace
+  yaml: |
+    ———»{}
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {}
+  dump: |
+    {}

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Q88A.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Q88A.yaml
@@ -1,0 +1,48 @@
+---
+- name: Spec Example 7.23. Flow Content
+  from: http://www.yaml.org/spec/1.2/spec.html#id2793163
+  tags: spec flow sequence mapping
+  yaml: |
+    - [ a, b ]
+    - { a: b }
+    - "a"
+    - 'b'
+    - c
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ []
+        =VAL :a
+        =VAL :b
+       -SEQ
+       +MAP {}
+        =VAL :a
+        =VAL :b
+       -MAP
+       =VAL "a
+       =VAL 'b
+       =VAL :c
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      [
+        "a",
+        "b"
+      ],
+      {
+        "a": "b"
+      },
+      "a",
+      "b",
+      "c"
+    ]
+  dump: |
+    - - a
+      - b
+    - a: b
+    - "a"
+    - 'b'
+    - c

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Q8AD.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Q8AD.yaml
@@ -1,0 +1,23 @@
+---
+- name: Spec Example 7.5. Double Quoted Line Breaks [1.3]
+  from: NP9H, modified for YAML 1.3
+  tags: double spec scalar whitespace 1.3-mod
+  yaml: |
+    ---
+    "folded␣
+    to a space,
+    ␣
+    to a line feed, or »\
+     \ »non-content"
+  tree: |
+    +STR
+     +DOC ---
+      =VAL "folded to a space,\nto a line feed, or \t \tnon-content
+     -DOC
+    -STR
+  json: |
+    "folded to a space,\nto a line feed, or \t \tnon-content"
+  dump: |
+    "folded to a space,\nto a line feed, or \t \tnon-content"
+  emit: |
+    --- "folded to a space,\nto a line feed, or \t \tnon-content"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Q9WF.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Q9WF.yaml
@@ -1,0 +1,35 @@
+---
+- name: Spec Example 6.12. Separation Spaces
+  from: http://www.yaml.org/spec/1.2/spec.html#id2780989
+  tags: complex-key flow spec comment whitespace 1.3-err
+  yaml: |
+    { first: Sammy, last: Sosa }:
+    # Statistics:
+      hr:  # Home runs
+         65
+      avg: # Average
+       0.278
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       +MAP {}
+        =VAL :first
+        =VAL :Sammy
+        =VAL :last
+        =VAL :Sosa
+       -MAP
+       +MAP
+        =VAL :hr
+        =VAL :65
+        =VAL :avg
+        =VAL :0.278
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    ? first: Sammy
+      last: Sosa
+    : hr: 65
+      avg: 0.278

--- a/pkgs/yaml/third_party/yaml-test-suite/src/QB6E.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/QB6E.yaml
@@ -1,0 +1,15 @@
+---
+- name: Wrong indented multiline quoted scalar
+  from: '@perlpunk'
+  tags: double error indent
+  fail: true
+  yaml: |
+    ---
+    quoted: "a
+    b
+    c"
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :quoted

--- a/pkgs/yaml/third_party/yaml-test-suite/src/QF4Y.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/QF4Y.yaml
@@ -1,0 +1,27 @@
+---
+- name: Spec Example 7.19. Single Pair Flow Mappings
+  from: http://www.yaml.org/spec/1.2/spec.html#id2792291
+  tags: spec flow mapping
+  yaml: |
+    [
+    foo: bar
+    ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       +MAP {}
+        =VAL :foo
+        =VAL :bar
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "foo": "bar"
+      }
+    ]
+  dump: |
+    - foo: bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/QLJ7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/QLJ7.yaml
@@ -1,0 +1,22 @@
+---
+- name: Tag shorthand used in documents but only defined in the first
+  from: IRC
+  tags: error directive tag
+  fail: true
+  yaml: |
+    %TAG !prefix! tag:example.com,2011:
+    --- !prefix!A
+    a: b
+    --- !prefix!B
+    c: d
+    --- !prefix!C
+    e: f
+  tree: |
+    +STR
+     +DOC ---
+      +MAP <tag:example.com,2011:A>
+       =VAL :a
+       =VAL :b
+      -MAP
+     -DOC
+     +DOC ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/QT73.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/QT73.yaml
@@ -1,0 +1,12 @@
+---
+- name: Comment and document-end marker
+  from: '@perlpunk'
+  tags: comment footer
+  yaml: |
+    # comment
+    ...
+  tree: |
+    +STR
+    -STR
+  json: ''
+  dump: ''

--- a/pkgs/yaml/third_party/yaml-test-suite/src/R4YG.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/R4YG.yaml
@@ -1,0 +1,44 @@
+---
+- name: Spec Example 8.2. Block Indentation Indicator
+  from: http://www.yaml.org/spec/1.2/spec.html#id2794311
+  tags: spec literal folded scalar whitespace libyaml-err upto-1.2
+  yaml: |
+    - |
+     detected
+    - >
+    ␣
+    ␣␣
+      # detected
+    - |1
+      explicit
+    - >
+     ——»
+     detected
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL |detected\n
+       =VAL >\n\n# detected\n
+       =VAL | explicit\n
+       =VAL >\t\ndetected\n
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "detected\n",
+      "\n\n# detected\n",
+      " explicit\n",
+      "\t\ndetected\n"
+    ]
+  dump: |
+    - |
+      detected
+    - >2
+
+
+      # detected
+    - |2
+       explicit
+    - "\t\ndetected\n"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/R52L.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/R52L.yaml
@@ -1,0 +1,43 @@
+---
+- name: Nested flow mapping sequence and mappings
+  from: '@perlpunk'
+  tags: flow mapping sequence
+  yaml: |
+    ---
+    { top1: [item1, {key2: value2}, item3], top2: value2 }
+  tree: |
+    +STR
+     +DOC ---
+      +MAP {}
+       =VAL :top1
+       +SEQ []
+        =VAL :item1
+        +MAP {}
+         =VAL :key2
+         =VAL :value2
+        -MAP
+        =VAL :item3
+       -SEQ
+       =VAL :top2
+       =VAL :value2
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "top1": [
+        "item1",
+        {
+          "key2": "value2"
+        },
+        "item3"
+      ],
+      "top2": "value2"
+    }
+  dump: |
+    ---
+    top1:
+    - item1
+    - key2: value2
+    - item3
+    top2: value2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/RHX7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/RHX7.yaml
@@ -1,0 +1,16 @@
+---
+- name: YAML directive without document end marker
+  from: '@perlpunk'
+  tags: directive error
+  fail: true
+  yaml: |
+    ---
+    key: value
+    %YAML 1.2
+    ---
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :key
+       =VAL :value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/RLU9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/RLU9.yaml
@@ -1,0 +1,38 @@
+---
+- name: Sequence Indent
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/indent.tml
+  tags: sequence indent
+  yaml: |
+    foo:
+    - 42
+    bar:
+      - 44
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       +SEQ
+        =VAL :42
+       -SEQ
+       =VAL :bar
+       +SEQ
+        =VAL :44
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": [
+        42
+      ],
+      "bar": [
+        44
+      ]
+    }
+  dump: |
+    foo:
+    - 42
+    bar:
+    - 44

--- a/pkgs/yaml/third_party/yaml-test-suite/src/RR7F.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/RR7F.yaml
@@ -1,0 +1,27 @@
+---
+- name: Mixed Block Mapping (implicit to explicit)
+  from: NimYAML tests
+  tags: explicit-key mapping
+  yaml: |
+    a: 4.2
+    ? d
+    : 23
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL :4.2
+       =VAL :d
+       =VAL :23
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "d": 23,
+      "a": 4.2
+    }
+  dump: |
+    a: 4.2
+    d: 23

--- a/pkgs/yaml/third_party/yaml-test-suite/src/RTP8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/RTP8.yaml
@@ -1,0 +1,20 @@
+---
+- name: Spec Example 9.2. Document Markers
+  from: http://www.yaml.org/spec/1.2/spec.html#id2800866
+  tags: spec header footer
+  yaml: |
+    %YAML 1.2
+    ---
+    Document
+    ... # Suffix
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :Document
+     -DOC ...
+    -STR
+  json: |
+    "Document"
+  dump: |
+    --- Document
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/RXY3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/RXY3.yaml
@@ -1,0 +1,13 @@
+---
+- name: Invalid document-end marker in single quoted string
+  from: '@perlpunk'
+  tags: footer single error
+  fail: true
+  yaml: |
+    ---
+    '
+    ...
+    '
+  tree: |
+    +STR
+     +DOC ---

--- a/pkgs/yaml/third_party/yaml-test-suite/src/RZP5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/RZP5.yaml
@@ -1,0 +1,58 @@
+---
+- name: Various Trailing Comments [1.3]
+  from: XW4D, modified for YAML 1.3
+  tags: anchor comment folded mapping 1.3-mod
+  yaml: |
+    a: "double
+      quotes" # lala
+    b: plain
+     value  # lala
+    c  : #lala
+      d
+    ? # lala
+     - seq1
+    : # lala
+     - #lala
+      seq2
+    e: &node # lala
+     - x: y
+    block: > # lala
+      abcde
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL "double quotes
+       =VAL :b
+       =VAL :plain value
+       =VAL :c
+       =VAL :d
+       +SEQ
+        =VAL :seq1
+       -SEQ
+       +SEQ
+        =VAL :seq2
+       -SEQ
+       =VAL :e
+       +SEQ &node
+        +MAP
+         =VAL :x
+         =VAL :y
+        -MAP
+       -SEQ
+       =VAL :block
+       =VAL >abcde\n
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    a: "double quotes"
+    b: plain value
+    c: d
+    ? - seq1
+    : - seq2
+    e: &node
+    - x: y
+    block: >
+      abcde

--- a/pkgs/yaml/third_party/yaml-test-suite/src/RZT7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/RZT7.yaml
@@ -1,0 +1,133 @@
+---
+- name: Spec Example 2.28. Log File
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761866
+  tags: spec header literal mapping sequence
+  yaml: |
+    ---
+    Time: 2001-11-23 15:01:42 -5
+    User: ed
+    Warning:
+      This is an error message
+      for the log file
+    ---
+    Time: 2001-11-23 15:02:31 -5
+    User: ed
+    Warning:
+      A slightly different error
+      message.
+    ---
+    Date: 2001-11-23 15:03:17 -5
+    User: ed
+    Fatal:
+      Unknown variable "bar"
+    Stack:
+      - file: TopClass.py
+        line: 23
+        code: |
+          x = MoreObject("345\n")
+      - file: MoreClass.py
+        line: 58
+        code: |-
+          foo = bar
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :Time
+       =VAL :2001-11-23 15:01:42 -5
+       =VAL :User
+       =VAL :ed
+       =VAL :Warning
+       =VAL :This is an error message for the log file
+      -MAP
+     -DOC
+     +DOC ---
+      +MAP
+       =VAL :Time
+       =VAL :2001-11-23 15:02:31 -5
+       =VAL :User
+       =VAL :ed
+       =VAL :Warning
+       =VAL :A slightly different error message.
+      -MAP
+     -DOC
+     +DOC ---
+      +MAP
+       =VAL :Date
+       =VAL :2001-11-23 15:03:17 -5
+       =VAL :User
+       =VAL :ed
+       =VAL :Fatal
+       =VAL :Unknown variable "bar"
+       =VAL :Stack
+       +SEQ
+        +MAP
+         =VAL :file
+         =VAL :TopClass.py
+         =VAL :line
+         =VAL :23
+         =VAL :code
+         =VAL |x = MoreObject("345\\n")\n
+        -MAP
+        +MAP
+         =VAL :file
+         =VAL :MoreClass.py
+         =VAL :line
+         =VAL :58
+         =VAL :code
+         =VAL |foo = bar
+        -MAP
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "Time": "2001-11-23 15:01:42 -5",
+      "User": "ed",
+      "Warning": "This is an error message for the log file"
+    }
+    {
+      "Time": "2001-11-23 15:02:31 -5",
+      "User": "ed",
+      "Warning": "A slightly different error message."
+    }
+    {
+      "Date": "2001-11-23 15:03:17 -5",
+      "User": "ed",
+      "Fatal": "Unknown variable \"bar\"",
+      "Stack": [
+        {
+          "file": "TopClass.py",
+          "line": 23,
+          "code": "x = MoreObject(\"345\\n\")\n"
+        },
+        {
+          "file": "MoreClass.py",
+          "line": 58,
+          "code": "foo = bar"
+        }
+      ]
+    }
+  dump: |
+    ---
+    Time: 2001-11-23 15:01:42 -5
+    User: ed
+    Warning: This is an error message for the log file
+    ---
+    Time: 2001-11-23 15:02:31 -5
+    User: ed
+    Warning: A slightly different error message.
+    ---
+    Date: 2001-11-23 15:03:17 -5
+    User: ed
+    Fatal: Unknown variable "bar"
+    Stack:
+    - file: TopClass.py
+      line: 23
+      code: |
+        x = MoreObject("345\n")
+    - file: MoreClass.py
+      line: 58
+      code: |-
+        foo = bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/S3PD.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/S3PD.yaml
@@ -1,0 +1,29 @@
+---
+- name: Spec Example 8.18. Implicit Block Mapping Entries
+  from: http://www.yaml.org/spec/1.2/spec.html#id2798896
+  tags: empty-key spec mapping
+  yaml: |
+    plain key: in-line value
+    : # Both empty
+    "quoted key":
+    - entry
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :plain key
+       =VAL :in-line value
+       =VAL :
+       =VAL :
+       =VAL "quoted key
+       +SEQ
+        =VAL :entry
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  emit: |
+    plain key: in-line value
+    :
+    "quoted key":
+    - entry

--- a/pkgs/yaml/third_party/yaml-test-suite/src/S4GJ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/S4GJ.yaml
@@ -1,0 +1,14 @@
+---
+- name: Invalid text after block scalar indicator
+  from: '@perlpunk'
+  tags: error folded
+  fail: true
+  yaml: |
+    ---
+    folded: > first line
+      second line
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :folded

--- a/pkgs/yaml/third_party/yaml-test-suite/src/S4JQ.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/S4JQ.yaml
@@ -1,0 +1,29 @@
+---
+- name: Spec Example 6.28. Non-Specific Tags
+  from: http://www.yaml.org/spec/1.2/spec.html#id2785512
+  tags: spec tag
+  yaml: |
+    # Assuming conventional resolution:
+    - "12"
+    - 12
+    - ! 12
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL "12
+       =VAL :12
+       =VAL <!> :12
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "12",
+      12,
+      "12"
+    ]
+  dump: |
+    - "12"
+    - 12
+    - ! 12

--- a/pkgs/yaml/third_party/yaml-test-suite/src/S4T7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/S4T7.yaml
@@ -1,0 +1,20 @@
+---
+- name: Document with footer
+  from: https://github.com/ingydotnet/yaml-pegex-pm/blob/master/test/footer.tml
+  tags: mapping footer
+  yaml: |
+    aaa: bbb
+    ...
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :aaa
+       =VAL :bbb
+      -MAP
+     -DOC ...
+    -STR
+  json: |
+    {
+      "aaa": "bbb"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/S7BG.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/S7BG.yaml
@@ -1,0 +1,22 @@
+---
+- name: Colon followed by comma
+  from: '@perlpunk'
+  tags: scalar
+  yaml: |
+    ---
+    - :,
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       =VAL ::,
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      ":,"
+    ]
+  dump: |
+    ---
+    - :,

--- a/pkgs/yaml/third_party/yaml-test-suite/src/S98Z.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/S98Z.yaml
@@ -1,0 +1,16 @@
+---
+- name: Block scalar with more spaces than first content line
+  from: '@perlpunk'
+  tags: error folded comment scalar whitespace
+  fail: true
+  yaml: |
+    empty block scalar: >
+    ␣
+    ␣␣
+    ␣␣␣
+     # comment
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :empty block scalar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/S9E8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/S9E8.yaml
@@ -1,0 +1,49 @@
+---
+- name: Spec Example 5.3. Block Structure Indicators
+  from: http://www.yaml.org/spec/1.2/spec.html#id2772312
+  tags: explicit-key spec mapping sequence
+  yaml: |
+    sequence:
+    - one
+    - two
+    mapping:
+      ? sky
+      : blue
+      sea : green
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :sequence
+       +SEQ
+        =VAL :one
+        =VAL :two
+       -SEQ
+       =VAL :mapping
+       +MAP
+        =VAL :sky
+        =VAL :blue
+        =VAL :sea
+        =VAL :green
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "sequence": [
+        "one",
+        "two"
+      ],
+      "mapping": {
+        "sky": "blue",
+        "sea": "green"
+      }
+    }
+  dump: |
+    sequence:
+    - one
+    - two
+    mapping:
+      sky: blue
+      sea: green

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SBG9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SBG9.yaml
@@ -1,0 +1,30 @@
+---
+- name: Flow Sequence in Flow Mapping
+  from: NimYAML tests
+  tags: complex-key sequence mapping flow
+  yaml: |
+    {a: [b, c], [d, e]: f}
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :a
+       +SEQ []
+        =VAL :b
+        =VAL :c
+       -SEQ
+       +SEQ []
+        =VAL :d
+        =VAL :e
+       -SEQ
+       =VAL :f
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    a:
+    - b
+    - c
+    ? - d
+      - e
+    : f

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SF5V.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SF5V.yaml
@@ -1,0 +1,11 @@
+---
+- name: Duplicate YAML directive
+  from: '@perlpunk'
+  tags: directive error
+  fail: true
+  yaml: |
+    %YAML 1.2
+    %YAML 1.2
+    ---
+  tree: |
+    +STR

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SKE5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SKE5.yaml
@@ -1,0 +1,34 @@
+---
+- name: Anchor before zero indented sequence
+  from: '@perlpunk'
+  tags: anchor indent sequence
+  yaml: |
+    ---
+    seq:
+     &anchor
+    - a
+    - b
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :seq
+       +SEQ &anchor
+        =VAL :a
+        =VAL :b
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "seq": [
+        "a",
+        "b"
+      ]
+    }
+  dump: |
+    ---
+    seq: &anchor
+    - a
+    - b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SM9W.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SM9W.yaml
@@ -1,0 +1,34 @@
+---
+- name: Single character streams
+  from: '@ingydotnet'
+  tags: sequence
+  yaml: |
+    -∎
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [null]
+  dump: |
+    -
+
+- tags: mapping
+  yaml: |
+    :∎
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  json: null
+  dump: |
+    :

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SR86.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SR86.yaml
@@ -1,0 +1,15 @@
+---
+- name: Anchor plus Alias
+  from: '@perlpunk'
+  tags: alias error
+  fail: true
+  yaml: |
+    key1: &a value
+    key2: &b *a
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key1
+       =VAL &a :value
+       =VAL :key2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SSW6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SSW6.yaml
@@ -1,0 +1,17 @@
+---
+- name: Spec Example 7.7. Single Quoted Characters [1.3]
+  from: 4GC6, modified for YAML 1.3
+  tags: spec scalar single 1.3-mod
+  yaml: |
+    ---
+    'here''s to "quotes"'
+  tree: |
+    +STR
+     +DOC ---
+      =VAL 'here's to "quotes"
+     -DOC
+    -STR
+  json: |
+    "here's to \"quotes\""
+  dump: |
+    --- 'here''s to "quotes"'

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SU5Z.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SU5Z.yaml
@@ -1,0 +1,13 @@
+---
+- name: Comment without whitespace after doublequoted scalar
+  from: '@perlpunk'
+  tags: comment error double whitespace
+  fail: true
+  yaml: |
+    key: "value"# invalid comment
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key
+       =VAL "value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SU74.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SU74.yaml
@@ -1,0 +1,14 @@
+---
+- name: Anchor and alias as mapping key
+  from: '@perlpunk'
+  tags: error anchor alias mapping
+  fail: true
+  yaml: |
+    key1: &alias value1
+    &b *alias : value2
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :key1
+       =VAL &alias :value1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SY6V.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SY6V.yaml
@@ -1,0 +1,9 @@
+---
+- name: Anchor before sequence entry on same line
+  from: '@perlpunk'
+  tags: anchor error sequence
+  fail: true
+  yaml: |
+    &anchor - sequence entry
+  tree: |
+    +STR

--- a/pkgs/yaml/third_party/yaml-test-suite/src/SYW4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/SYW4.yaml
@@ -1,0 +1,31 @@
+---
+- name: Spec Example 2.2. Mapping Scalars to Scalars
+  from: http://www.yaml.org/spec/1.2/spec.html#id2759963
+  tags: spec scalar comment
+  yaml: |
+    hr:  65    # Home runs
+    avg: 0.278 # Batting average
+    rbi: 147   # Runs Batted In
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :hr
+       =VAL :65
+       =VAL :avg
+       =VAL :0.278
+       =VAL :rbi
+       =VAL :147
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "hr": 65,
+      "avg": 0.278,
+      "rbi": 147
+    }
+  dump: |
+    hr: 65
+    avg: 0.278
+    rbi: 147

--- a/pkgs/yaml/third_party/yaml-test-suite/src/T26H.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/T26H.yaml
@@ -1,0 +1,32 @@
+---
+- name: Spec Example 8.8. Literal Content [1.3]
+  from: DWX9, modified for YAML 1.3
+  tags: spec literal scalar comment whitespace 1.3-mod
+  yaml: |
+    --- |
+    ␣
+    ␣␣
+      literal
+    ␣␣␣
+    ␣␣
+      text
+
+     # Comment
+  tree: |
+    +STR
+     +DOC ---
+      =VAL |\n\nliteral\n \n\ntext\n
+     -DOC
+    -STR
+  json: |
+    "\n\nliteral\n \n\ntext\n"
+  dump: |
+    "\n\nliteral\n \n\ntext\n"
+  emit: |
+    --- |
+
+
+      literal
+    ␣␣␣
+
+      text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/T4YY.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/T4YY.yaml
@@ -1,0 +1,26 @@
+---
+- name: Spec Example 7.9. Single Quoted Lines [1.3]
+  from: PRH3, modified for YAML 1.3
+  tags: single spec scalar whitespace 1.3-mod
+  yaml: |
+    ---
+    ' 1st non-empty
+
+     2nd non-empty␣
+     3rd non-empty '
+  tree: |
+    +STR
+     +DOC ---
+      =VAL ' 1st non-empty\n2nd non-empty 3rd non-empty␣
+     -DOC
+    -STR
+  json: |
+    " 1st non-empty\n2nd non-empty 3rd non-empty "
+  dump: |
+    ' 1st non-empty
+
+      2nd non-empty 3rd non-empty '
+  emit: |
+    --- ' 1st non-empty
+
+      2nd non-empty 3rd non-empty '

--- a/pkgs/yaml/third_party/yaml-test-suite/src/T5N4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/T5N4.yaml
@@ -1,0 +1,24 @@
+---
+- name: Spec Example 8.7. Literal Scalar [1.3]
+  from: M9B4, modified for YAML 1.3
+  tags: spec literal scalar whitespace 1.3-mod
+  yaml: |
+    --- |
+     literal
+     ——»text
+    ↵
+    ↵
+  tree: |
+    +STR
+     +DOC ---
+      =VAL |literal\n\ttext\n
+     -DOC
+    -STR
+  json: |
+    "literal\n\ttext\n"
+  dump: |
+    "literal\n\ttext\n"
+  emit: |
+    --- |
+      literal
+      —»text

--- a/pkgs/yaml/third_party/yaml-test-suite/src/T833.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/T833.yaml
@@ -1,0 +1,15 @@
+---
+- name: Flow mapping missing a separating comma
+  from: '@perlpunk'
+  tags: error flow mapping
+  fail: true
+  yaml: |
+    ---
+    {
+     foo: 1
+     bar: 2 }
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :foo

--- a/pkgs/yaml/third_party/yaml-test-suite/src/TD5N.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/TD5N.yaml
@@ -1,0 +1,15 @@
+---
+- name: Invalid scalar after sequence
+  from: '@perlpunk'
+  tags: error sequence scalar
+  fail: true
+  yaml: |
+    - item1
+    - item2
+    invalid
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :item1
+       =VAL :item2

--- a/pkgs/yaml/third_party/yaml-test-suite/src/TE2A.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/TE2A.yaml
@@ -1,0 +1,28 @@
+---
+- name: Spec Example 8.16. Block Mappings
+  from: http://www.yaml.org/spec/1.2/spec.html#id2798147
+  tags: spec mapping
+  yaml: |
+    block mapping:
+     key: value
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :block mapping
+       +MAP
+        =VAL :key
+        =VAL :value
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "block mapping": {
+        "key": "value"
+      }
+    }
+  dump: |
+    block mapping:
+      key: value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/TL85.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/TL85.yaml
@@ -1,0 +1,22 @@
+---
+- name: Spec Example 6.8. Flow Folding
+  from: http://www.yaml.org/spec/1.2/spec.html#id2779950
+  tags: double spec whitespace scalar upto-1.2
+  yaml: |
+    "
+      foo␣
+    ␣
+      —» bar
+
+      baz
+    "
+  tree: |
+    +STR
+     +DOC
+      =VAL " foo\nbar\nbaz␣
+     -DOC
+    -STR
+  json: |
+    " foo\nbar\nbaz "
+  dump: |
+    " foo\nbar\nbaz "

--- a/pkgs/yaml/third_party/yaml-test-suite/src/TS54.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/TS54.yaml
@@ -1,0 +1,29 @@
+---
+- name: Folded Block Scalar
+  from: NimYAML tests
+  tags: folded scalar 1.3-err
+  yaml: |
+    >
+     ab
+     cd
+    ␣
+     ef
+
+
+     gh
+  tree: |
+    +STR
+     +DOC
+      =VAL >ab cd\nef\n\ngh\n
+     -DOC
+    -STR
+  json: |
+    "ab cd\nef\n\ngh\n"
+  dump: |
+    >
+      ab cd
+
+      ef
+
+
+      gh

--- a/pkgs/yaml/third_party/yaml-test-suite/src/U3C3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/U3C3.yaml
@@ -1,0 +1,18 @@
+---
+- name: Spec Example 6.16. “TAG” directive
+  from: http://www.yaml.org/spec/1.2/spec.html#id2782252
+  tags: spec header tag
+  yaml: |
+    %TAG !yaml! tag:yaml.org,2002:
+    ---
+    !yaml!str "foo"
+  tree: |
+    +STR
+     +DOC ---
+      =VAL <tag:yaml.org,2002:str> "foo
+     -DOC
+    -STR
+  json: |
+    "foo"
+  dump: |
+    --- !!str "foo"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/U3XV.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/U3XV.yaml
@@ -1,0 +1,92 @@
+---
+- name: Node and Mapping Key Anchors
+  from: '@perlpunk'
+  tags: anchor comment 1.3-err
+  yaml: |
+    ---
+    top1: &node1
+      &k1 key1: one
+    top2: &node2 # comment
+      key2: two
+    top3:
+      &k3 key3: three
+    top4:
+      &node4
+      &k4 key4: four
+    top5:
+      &node5
+      key5: five
+    top6: &val6
+      six
+    top7:
+      &val7 seven
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :top1
+       +MAP &node1
+        =VAL &k1 :key1
+        =VAL :one
+       -MAP
+       =VAL :top2
+       +MAP &node2
+        =VAL :key2
+        =VAL :two
+       -MAP
+       =VAL :top3
+       +MAP
+        =VAL &k3 :key3
+        =VAL :three
+       -MAP
+       =VAL :top4
+       +MAP &node4
+        =VAL &k4 :key4
+        =VAL :four
+       -MAP
+       =VAL :top5
+       +MAP &node5
+        =VAL :key5
+        =VAL :five
+       -MAP
+       =VAL :top6
+       =VAL &val6 :six
+       =VAL :top7
+       =VAL &val7 :seven
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "top1": {
+        "key1": "one"
+      },
+      "top2": {
+        "key2": "two"
+      },
+      "top3": {
+        "key3": "three"
+      },
+      "top4": {
+        "key4": "four"
+      },
+      "top5": {
+        "key5": "five"
+      },
+      "top6": "six",
+      "top7": "seven"
+    }
+  dump: |
+    ---
+    top1: &node1
+      &k1 key1: one
+    top2: &node2
+      key2: two
+    top3:
+      &k3 key3: three
+    top4: &node4
+      &k4 key4: four
+    top5: &node5
+      key5: five
+    top6: &val6 six
+    top7: &val7 seven

--- a/pkgs/yaml/third_party/yaml-test-suite/src/U44R.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/U44R.yaml
@@ -1,0 +1,17 @@
+---
+- name: Bad indentation in mapping (2)
+  from: '@perlpunk'
+  tags: error mapping indent double
+  fail: true
+  yaml: |
+    map:
+      key1: "quoted1"
+       key2: "bad indentation"
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :map
+       +MAP
+        =VAL :key1
+        =VAL "quoted1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/U99R.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/U99R.yaml
@@ -1,0 +1,11 @@
+---
+- name: Invalid comma in tag
+  from: '@perlpunk'
+  tags: error tag
+  fail: true
+  yaml: |
+    - !!str, xxx
+  tree: |
+    +STR
+     +DOC
+      +SEQ

--- a/pkgs/yaml/third_party/yaml-test-suite/src/U9NS.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/U9NS.yaml
@@ -1,0 +1,49 @@
+---
+- name: Spec Example 2.8. Play by Play Feed from a Game
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760519
+  tags: spec header
+  yaml: |
+    ---
+    time: 20:03:20
+    player: Sammy Sosa
+    action: strike (miss)
+    ...
+    ---
+    time: 20:03:47
+    player: Sammy Sosa
+    action: grand slam
+    ...
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :time
+       =VAL :20:03:20
+       =VAL :player
+       =VAL :Sammy Sosa
+       =VAL :action
+       =VAL :strike (miss)
+      -MAP
+     -DOC ...
+     +DOC ---
+      +MAP
+       =VAL :time
+       =VAL :20:03:47
+       =VAL :player
+       =VAL :Sammy Sosa
+       =VAL :action
+       =VAL :grand slam
+      -MAP
+     -DOC ...
+    -STR
+  json: |
+    {
+      "time": "20:03:20",
+      "player": "Sammy Sosa",
+      "action": "strike (miss)"
+    }
+    {
+      "time": "20:03:47",
+      "player": "Sammy Sosa",
+      "action": "grand slam"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/UDM2.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/UDM2.yaml
@@ -1,0 +1,25 @@
+---
+- name: Plain URL in flow mapping
+  from: https://github.com/yaml/libyaml/pull/28
+  tags: flow scalar
+  yaml: |
+    - { url: http://example.org }
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP {}
+        =VAL :url
+        =VAL :http://example.org
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      {
+        "url": "http://example.org"
+      }
+    ]
+  dump: |
+    - url: http://example.org

--- a/pkgs/yaml/third_party/yaml-test-suite/src/UDR7.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/UDR7.yaml
@@ -1,0 +1,44 @@
+---
+- name: Spec Example 5.4. Flow Collection Indicators
+  from: http://www.yaml.org/spec/1.2/spec.html#id2772813
+  tags: spec flow sequence mapping
+  yaml: |
+    sequence: [ one, two, ]
+    mapping: { sky: blue, sea: green }
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :sequence
+       +SEQ []
+        =VAL :one
+        =VAL :two
+       -SEQ
+       =VAL :mapping
+       +MAP {}
+        =VAL :sky
+        =VAL :blue
+        =VAL :sea
+        =VAL :green
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "sequence": [
+        "one",
+        "two"
+      ],
+      "mapping": {
+        "sky": "blue",
+        "sea": "green"
+      }
+    }
+  dump: |
+    sequence:
+    - one
+    - two
+    mapping:
+      sky: blue
+      sea: green

--- a/pkgs/yaml/third_party/yaml-test-suite/src/UGM3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/UGM3.yaml
@@ -1,0 +1,163 @@
+---
+- name: Spec Example 2.27. Invoice
+  from: http://www.yaml.org/spec/1.2/spec.html#id2761823
+  tags: spec tag literal mapping sequence alias unknown-tag
+  yaml: |
+    --- !<tag:clarkevans.com,2002:invoice>
+    invoice: 34843
+    date   : 2001-01-23
+    bill-to: &id001
+        given  : Chris
+        family : Dumars
+        address:
+            lines: |
+                458 Walkman Dr.
+                Suite #292
+            city    : Royal Oak
+            state   : MI
+            postal  : 48046
+    ship-to: *id001
+    product:
+        - sku         : BL394D
+          quantity    : 4
+          description : Basketball
+          price       : 450.00
+        - sku         : BL4438H
+          quantity    : 1
+          description : Super Hoop
+          price       : 2392.00
+    tax  : 251.42
+    total: 4443.52
+    comments:
+        Late afternoon is best.
+        Backup contact is Nancy
+        Billsmer @ 338-4338.
+  tree: |
+    +STR
+     +DOC ---
+      +MAP <tag:clarkevans.com,2002:invoice>
+       =VAL :invoice
+       =VAL :34843
+       =VAL :date
+       =VAL :2001-01-23
+       =VAL :bill-to
+       +MAP &id001
+        =VAL :given
+        =VAL :Chris
+        =VAL :family
+        =VAL :Dumars
+        =VAL :address
+        +MAP
+         =VAL :lines
+         =VAL |458 Walkman Dr.\nSuite #292\n
+         =VAL :city
+         =VAL :Royal Oak
+         =VAL :state
+         =VAL :MI
+         =VAL :postal
+         =VAL :48046
+        -MAP
+       -MAP
+       =VAL :ship-to
+       =ALI *id001
+       =VAL :product
+       +SEQ
+        +MAP
+         =VAL :sku
+         =VAL :BL394D
+         =VAL :quantity
+         =VAL :4
+         =VAL :description
+         =VAL :Basketball
+         =VAL :price
+         =VAL :450.00
+        -MAP
+        +MAP
+         =VAL :sku
+         =VAL :BL4438H
+         =VAL :quantity
+         =VAL :1
+         =VAL :description
+         =VAL :Super Hoop
+         =VAL :price
+         =VAL :2392.00
+        -MAP
+       -SEQ
+       =VAL :tax
+       =VAL :251.42
+       =VAL :total
+       =VAL :4443.52
+       =VAL :comments
+       =VAL :Late afternoon is best. Backup contact is Nancy Billsmer @ 338-4338.
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "invoice": 34843,
+      "date": "2001-01-23",
+      "bill-to": {
+        "given": "Chris",
+        "family": "Dumars",
+        "address": {
+          "lines": "458 Walkman Dr.\nSuite #292\n",
+          "city": "Royal Oak",
+          "state": "MI",
+          "postal": 48046
+        }
+      },
+      "ship-to": {
+        "given": "Chris",
+        "family": "Dumars",
+        "address": {
+          "lines": "458 Walkman Dr.\nSuite #292\n",
+          "city": "Royal Oak",
+          "state": "MI",
+          "postal": 48046
+        }
+      },
+      "product": [
+        {
+          "sku": "BL394D",
+          "quantity": 4,
+          "description": "Basketball",
+          "price": 450
+        },
+        {
+          "sku": "BL4438H",
+          "quantity": 1,
+          "description": "Super Hoop",
+          "price": 2392
+        }
+      ],
+      "tax": 251.42,
+      "total": 4443.52,
+      "comments": "Late afternoon is best. Backup contact is Nancy Billsmer @ 338-4338."
+    }
+  dump: |
+    --- !<tag:clarkevans.com,2002:invoice>
+    invoice: 34843
+    date: 2001-01-23
+    bill-to: &id001
+      given: Chris
+      family: Dumars
+      address:
+        lines: |
+          458 Walkman Dr.
+          Suite #292
+        city: Royal Oak
+        state: MI
+        postal: 48046
+    ship-to: *id001
+    product:
+    - sku: BL394D
+      quantity: 4
+      description: Basketball
+      price: 450.00
+    - sku: BL4438H
+      quantity: 1
+      description: Super Hoop
+      price: 2392.00
+    tax: 251.42
+    total: 4443.52
+    comments: Late afternoon is best. Backup contact is Nancy Billsmer @ 338-4338.

--- a/pkgs/yaml/third_party/yaml-test-suite/src/UKK6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/UKK6.yaml
@@ -1,0 +1,43 @@
+---
+- name: Syntax character edge cases
+  from: '@ingydotnet'
+  tags: edge empty-key
+  yaml: |
+    - :
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        =VAL :
+        =VAL :
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+
+- yaml: |
+    ::
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL ::
+       =VAL :
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      ":": null
+    }
+
+- yaml: |
+    !
+  tree: |
+    +STR
+     +DOC
+      =VAL <!> :
+     -DOC
+    -STR
+  json: null

--- a/pkgs/yaml/third_party/yaml-test-suite/src/UT92.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/UT92.yaml
@@ -1,0 +1,35 @@
+---
+- name: Spec Example 9.4. Explicit Documents
+  from: http://www.yaml.org/spec/1.2/spec.html#id2801448
+  tags: flow spec header footer comment
+  yaml: |
+    ---
+    { matches
+    % : 20 }
+    ...
+    ---
+    # Empty
+    ...
+  tree: |
+    +STR
+     +DOC ---
+      +MAP {}
+       =VAL :matches %
+       =VAL :20
+      -MAP
+     -DOC ...
+     +DOC ---
+      =VAL :
+     -DOC ...
+    -STR
+  json: |
+    {
+      "matches %": 20
+    }
+    null
+  dump: |
+    ---
+    matches %: 20
+    ...
+    ---
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/UV7Q.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/UV7Q.yaml
@@ -1,0 +1,28 @@
+---
+- name: Legal tab after indentation
+  from: '@ingydotnet'
+  tags: indent whitespace
+  yaml: |
+    x:
+     - x
+      ——»x
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :x
+       +SEQ
+        =VAL :x x
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "x": [
+        "x x"
+      ]
+    }
+  dump: |
+    x:
+    - x x

--- a/pkgs/yaml/third_party/yaml-test-suite/src/V55R.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/V55R.yaml
@@ -1,0 +1,27 @@
+---
+- name: Aliases in Block Sequence
+  from: NimYAML tests
+  tags: alias sequence
+  yaml: |
+    - &a a
+    - &b b
+    - *a
+    - *b
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL &a :a
+       =VAL &b :b
+       =ALI *a
+       =ALI *b
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "a",
+      "b",
+      "a",
+      "b"
+    ]

--- a/pkgs/yaml/third_party/yaml-test-suite/src/V9D5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/V9D5.yaml
@@ -1,0 +1,29 @@
+---
+- name: Spec Example 8.19. Compact Block Mappings
+  from: http://www.yaml.org/spec/1.2/spec.html#id2799091
+  tags: complex-key explicit-key spec mapping
+  yaml: |
+    - sun: yellow
+    - ? earth: blue
+      : moon: white
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        =VAL :sun
+        =VAL :yellow
+       -MAP
+       +MAP
+        +MAP
+         =VAL :earth
+         =VAL :blue
+        -MAP
+        +MAP
+         =VAL :moon
+         =VAL :white
+        -MAP
+       -MAP
+      -SEQ
+     -DOC
+    -STR

--- a/pkgs/yaml/third_party/yaml-test-suite/src/VJP3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/VJP3.yaml
@@ -1,0 +1,49 @@
+---
+- name: Flow collections over many lines
+  from: '@ingydotnet'
+  tags: flow indent
+  fail: true
+  yaml: |
+    k: {
+    k
+    :
+    v
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :k
+       +MAP {}
+
+- yaml: |
+    k: {
+     k
+     :
+     v
+     }
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :k
+       +MAP {}
+        =VAL :k
+        =VAL :v
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "k" : {
+        "k" : "v"
+      }
+    }
+  dump: |
+    ---
+    k:
+      k: v
+  emit: |
+    k:
+      k: v

--- a/pkgs/yaml/third_party/yaml-test-suite/src/W42U.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/W42U.yaml
@@ -1,0 +1,47 @@
+---
+- name: Spec Example 8.15. Block Sequence Entry Types
+  from: http://www.yaml.org/spec/1.2/spec.html#id2797944
+  tags: comment spec literal sequence
+  yaml: |
+    - # Empty
+    - |
+     block node
+    - - one # Compact
+      - two # sequence
+    - one: two # Compact mapping
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :
+       =VAL |block node\n
+       +SEQ
+        =VAL :one
+        =VAL :two
+       -SEQ
+       +MAP
+        =VAL :one
+        =VAL :two
+       -MAP
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      null,
+      "block node\n",
+      [
+        "one",
+        "two"
+      ],
+      {
+        "one": "two"
+      }
+    ]
+  dump: |
+    -
+    - |
+      block node
+    - - one
+      - two
+    - one: two

--- a/pkgs/yaml/third_party/yaml-test-suite/src/W4TN.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/W4TN.yaml
@@ -1,0 +1,31 @@
+---
+- name: Spec Example 9.5. Directives Documents
+  from: http://www.yaml.org/spec/1.2/spec.html#id2801606
+  tags: spec header footer 1.3-err
+  yaml: |
+    %YAML 1.2
+    --- |
+    %!PS-Adobe-2.0
+    ...
+    %YAML 1.2
+    ---
+    # Empty
+    ...
+  tree: |
+    +STR
+     +DOC ---
+      =VAL |%!PS-Adobe-2.0\n
+     -DOC ...
+     +DOC ---
+      =VAL :
+     -DOC ...
+    -STR
+  json: |
+    "%!PS-Adobe-2.0\n"
+    null
+  dump: |
+    --- |
+      %!PS-Adobe-2.0
+    ...
+    ---
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/W5VH.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/W5VH.yaml
@@ -1,0 +1,23 @@
+---
+- name: Allowed characters in alias
+  from: '@perlpunk'
+  tags: alias 1.3-err
+  yaml: |
+    a: &:@*!$"<foo>: scalar a
+    b: *:@*!$"<foo>:
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL &:@*!$"<foo>: :scalar a
+       =VAL :b
+       =ALI *:@*!$"<foo>:
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": "scalar a",
+      "b": "scalar a"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/W9L4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/W9L4.yaml
@@ -1,0 +1,16 @@
+---
+- name: Literal block scalar with more spaces in first line
+  from: '@perlpunk'
+  tags: error literal whitespace
+  fail: true
+  yaml: |
+    ---
+    block scalar: |
+    ␣␣␣␣␣
+      more spaces at the beginning
+      are invalid
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :block scalar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/WZ62.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/WZ62.yaml
@@ -1,0 +1,28 @@
+---
+- name: Spec Example 7.2. Empty Content
+  from: http://www.yaml.org/spec/1.2/spec.html#id2786720
+  tags: spec flow scalar tag
+  yaml: |
+    {
+      foo : !!str,
+      !!str : bar,
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :foo
+       =VAL <tag:yaml.org,2002:str> :
+       =VAL <tag:yaml.org,2002:str> :
+       =VAL :bar
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "",
+      "": "bar"
+    }
+  dump: |
+    foo: !!str
+    !!str : bar

--- a/pkgs/yaml/third_party/yaml-test-suite/src/X38W.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/X38W.yaml
@@ -1,0 +1,33 @@
+---
+- name: Aliases in Flow Objects
+  from: NimYAML tests
+  tags: alias complex-key flow
+  yaml: |
+    { &a [a, &b b]: *b, *a : [c, *b, d]}
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       +SEQ [] &a
+        =VAL :a
+        =VAL &b :b
+       -SEQ
+       =ALI *b
+       =ALI *a
+       +SEQ []
+        =VAL :c
+        =ALI *b
+        =VAL :d
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    ? &a
+    - a
+    - &b b
+    : *b
+    *a :
+    - c
+    - *b
+    - d

--- a/pkgs/yaml/third_party/yaml-test-suite/src/X4QW.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/X4QW.yaml
@@ -1,0 +1,13 @@
+---
+- name: Comment without whitespace after block scalar indicator
+  from: '@perlpunk'
+  tags: folded comment error whitespace
+  fail: true
+  yaml: |
+    block: ># comment
+      scalar
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :block

--- a/pkgs/yaml/third_party/yaml-test-suite/src/X8DW.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/X8DW.yaml
@@ -1,0 +1,25 @@
+---
+- name: Explicit key and value seperated by comment
+  from: '@perlpunk'
+  tags: comment explicit-key mapping
+  yaml: |
+    ---
+    ? key
+    # comment
+    : value
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :key
+       =VAL :value
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": "value"
+    }
+  dump: |
+    ---
+    key: value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/XLQ9.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/XLQ9.yaml
@@ -1,0 +1,19 @@
+---
+- name: Multiline scalar that looks like a YAML directive
+  from: '@perlpunk'
+  tags: directive scalar
+  yaml: |
+    ---
+    scalar
+    %YAML 1.2
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :scalar %YAML 1.2
+     -DOC
+    -STR
+  json: |
+    "scalar %YAML 1.2"
+  dump: |
+    --- scalar %YAML 1.2
+    ...

--- a/pkgs/yaml/third_party/yaml-test-suite/src/XV9V.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/XV9V.yaml
@@ -1,0 +1,33 @@
+---
+- name: Spec Example 6.5. Empty Lines [1.3]
+  from: 5GBF, modified for YAML 1.3
+  tags: literal spec scalar 1.3-mod
+  yaml: |
+    Folding:
+      "Empty line
+
+      as a line feed"
+    Chomping: |
+      Clipped empty lines
+    ␣
+    ↵
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :Folding
+       =VAL "Empty line\nas a line feed
+       =VAL :Chomping
+       =VAL |Clipped empty lines\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "Folding": "Empty line\nas a line feed",
+      "Chomping": "Clipped empty lines\n"
+    }
+  dump: |
+    Folding: "Empty line\nas a line feed"
+    Chomping: |
+      Clipped empty lines

--- a/pkgs/yaml/third_party/yaml-test-suite/src/XW4D.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/XW4D.yaml
@@ -1,0 +1,59 @@
+---
+- name: Various Trailing Comments
+  from: '@perlpunk'
+  tags: comment explicit-key folded 1.3-err
+  yaml: |
+    a: "double
+      quotes" # lala
+    b: plain
+     value  # lala
+    c  : #lala
+      d
+    ? # lala
+     - seq1
+    : # lala
+     - #lala
+      seq2
+    e:
+     &node # lala
+     - x: y
+    block: > # lala
+      abcde
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a
+       =VAL "double quotes
+       =VAL :b
+       =VAL :plain value
+       =VAL :c
+       =VAL :d
+       +SEQ
+        =VAL :seq1
+       -SEQ
+       +SEQ
+        =VAL :seq2
+       -SEQ
+       =VAL :e
+       +SEQ &node
+        +MAP
+         =VAL :x
+         =VAL :y
+        -MAP
+       -SEQ
+       =VAL :block
+       =VAL >abcde\n
+      -MAP
+     -DOC
+    -STR
+  dump: |
+    a: "double quotes"
+    b: plain value
+    c: d
+    ? - seq1
+    : - seq2
+    e: &node
+    - x: y
+    block: >
+      abcde

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Y2GN.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Y2GN.yaml
@@ -1,0 +1,23 @@
+---
+- name: Anchor with colon in the middle
+  from: '@perlpunk'
+  tags: anchor
+  yaml: |
+    ---
+    key: &an:chor value
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :key
+       =VAL &an:chor :value
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": "value"
+    }
+  dump: |
+    ---
+    key: &an:chor value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Y79Y.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Y79Y.yaml
@@ -1,0 +1,119 @@
+---
+- name: Tabs in various contexts
+  from: '@ingydotnet'
+  tags: whitespace
+  fail: true
+  yaml: |
+    foo: |
+    ————»
+    bar: 1
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+
+- yaml: |
+    foo: |
+     ———»
+    bar: 1
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :foo
+       =VAL |\t\n
+       =VAL :bar
+       =VAL :1
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "foo": "\t\n",
+      "bar": 1
+    }
+  dump: |
+    foo: |
+      ———»
+    bar: 1
+
+- yaml: |
+    - [
+    ————»
+     foo
+     ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ []
+        =VAL :foo
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      [
+        "foo"
+      ]
+    ]
+  dump: |
+    - - foo
+
+- fail: true
+  yaml: |
+    - [
+    ————»foo,
+     foo
+     ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ []
+  json: null
+
+- fail: true
+  yaml: |
+    -———»-
+
+- fail: true
+  yaml: |
+    - ——»-
+
+- fail: true
+  yaml: |
+    ?———»-
+
+- fail: true
+  yaml: |
+    ? -
+    :———»-
+
+- fail: true
+  yaml: |
+    ?———»key:
+
+- fail: true
+  yaml: |
+    ? key:
+    :———»key:
+
+- yaml: |
+    -———»-1
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       =VAL :-1
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      -1
+    ]
+  dump: |
+    - -1

--- a/pkgs/yaml/third_party/yaml-test-suite/src/YD5X.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/YD5X.yaml
@@ -1,0 +1,58 @@
+---
+- name: Spec Example 2.5. Sequence of Sequences
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760351
+  tags: spec sequence
+  yaml: |
+    - [name        , hr, avg  ]
+    - [Mark McGwire, 65, 0.278]
+    - [Sammy Sosa  , 63, 0.288]
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +SEQ []
+        =VAL :name
+        =VAL :hr
+        =VAL :avg
+       -SEQ
+       +SEQ []
+        =VAL :Mark McGwire
+        =VAL :65
+        =VAL :0.278
+       -SEQ
+       +SEQ []
+        =VAL :Sammy Sosa
+        =VAL :63
+        =VAL :0.288
+       -SEQ
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      [
+        "name",
+        "hr",
+        "avg"
+      ],
+      [
+        "Mark McGwire",
+        65,
+        0.278
+      ],
+      [
+        "Sammy Sosa",
+        63,
+        0.288
+      ]
+    ]
+  dump: |
+    - - name
+      - hr
+      - avg
+    - - Mark McGwire
+      - 65
+      - 0.278
+    - - Sammy Sosa
+      - 63
+      - 0.288

--- a/pkgs/yaml/third_party/yaml-test-suite/src/YJV2.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/YJV2.yaml
@@ -1,0 +1,11 @@
+---
+- name: Dash in flow sequence
+  from: '@ingydotnet'
+  tags: flow sequence
+  fail: true
+  yaml: |
+    [-]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Z67P.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Z67P.yaml
@@ -1,0 +1,30 @@
+---
+- name: Spec Example 8.21. Block Scalar Nodes [1.3]
+  from: M5C3, modified for YAML 1.3
+  tags: indent spec literal folded tag local-tag 1.3-mod
+  yaml: |
+    literal: |2
+      value
+    folded: !foo >1
+     value
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :literal
+       =VAL |value\n
+       =VAL :folded
+       =VAL <!foo> >value\n
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "literal": "value\n",
+      "folded": "value\n"
+    }
+  dump: |
+    literal: |
+      value
+    folded: !foo >
+      value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/Z9M4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/Z9M4.yaml
@@ -1,0 +1,23 @@
+---
+- name: Spec Example 6.22. Global Tag Prefix
+  from: http://www.yaml.org/spec/1.2/spec.html#id2783726
+  tags: spec header tag unknown-tag
+  yaml: |
+    %TAG !e! tag:example.com,2000:app/
+    ---
+    - !e!foo "bar"
+  tree: |
+    +STR
+     +DOC ---
+      +SEQ
+       =VAL <tag:example.com,2000:app/foo> "bar
+      -SEQ
+     -DOC
+    -STR
+  json: |
+    [
+      "bar"
+    ]
+  dump: |
+    ---
+    - !<tag:example.com,2000:app/foo> "bar"

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZCZ6.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZCZ6.yaml
@@ -1,0 +1,12 @@
+---
+- name: Invalid mapping in plain single line value
+  from: https://gist.github.com/anonymous/0c8db51d151baf8113205ba3ce71d1b4 via @ingydotnet
+  tags: error mapping scalar
+  fail: true
+  yaml: |
+    a: b: c: d
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :a

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZF4X.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZF4X.yaml
@@ -1,0 +1,49 @@
+---
+- name: Spec Example 2.6. Mapping of Mappings
+  from: http://www.yaml.org/spec/1.2/spec.html#id2760372
+  tags: flow spec mapping
+  yaml: |
+    Mark McGwire: {hr: 65, avg: 0.278}
+    Sammy Sosa: {
+        hr: 63,
+        avg: 0.288
+      }
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL :Mark McGwire
+       +MAP {}
+        =VAL :hr
+        =VAL :65
+        =VAL :avg
+        =VAL :0.278
+       -MAP
+       =VAL :Sammy Sosa
+       +MAP {}
+        =VAL :hr
+        =VAL :63
+        =VAL :avg
+        =VAL :0.288
+       -MAP
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "Mark McGwire": {
+        "hr": 65,
+        "avg": 0.278
+      },
+      "Sammy Sosa": {
+        "hr": 63,
+        "avg": 0.288
+      }
+    }
+  dump: |
+    Mark McGwire:
+      hr: 65
+      avg: 0.278
+    Sammy Sosa:
+      hr: 63
+      avg: 0.288

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZH7C.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZH7C.yaml
@@ -1,0 +1,23 @@
+---
+- name: Anchors in Mapping
+  from: NimYAML tests
+  tags: anchor mapping
+  yaml: |
+    &a a: b
+    c: &d d
+  tree: |
+    +STR
+     +DOC
+      +MAP
+       =VAL &a :a
+       =VAL :b
+       =VAL :c
+       =VAL &d :d
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": "b",
+      "c": "d"
+    }

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZK9H.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZK9H.yaml
@@ -1,0 +1,37 @@
+---
+- name: Nested top level flow mapping
+  from: '@perlpunk'
+  tags: flow indent mapping sequence
+  yaml: |
+    { key: [[[
+      value
+     ]]]
+    }
+  tree: |
+    +STR
+     +DOC
+      +MAP {}
+       =VAL :key
+       +SEQ []
+        +SEQ []
+         +SEQ []
+          =VAL :value
+         -SEQ
+        -SEQ
+       -SEQ
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "key": [
+        [
+          [
+            "value"
+          ]
+        ]
+      ]
+    }
+  dump: |
+    key:
+    - - - value

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZL4Z.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZL4Z.yaml
@@ -1,0 +1,14 @@
+---
+- name: Invalid nested mapping
+  from: '@perlpunk'
+  tags: error mapping
+  fail: true
+  yaml: |
+    ---
+    a: 'b': c
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :a
+       =VAL 'b

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZVH3.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZVH3.yaml
@@ -1,0 +1,16 @@
+---
+- name: Wrong indented sequence item
+  from: '@perlpunk'
+  tags: error sequence indent
+  fail: true
+  yaml: |
+    - key: value
+     - item1
+  tree: |
+    +STR
+     +DOC
+      +SEQ
+       +MAP
+        =VAL :key
+        =VAL :value
+       -MAP

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZWK4.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZWK4.yaml
@@ -1,0 +1,33 @@
+---
+- name: Key with anchor after missing explicit mapping value
+  from: '@perlpunk'
+  tags: anchor explicit-key mapping
+  yaml: |
+    ---
+    a: 1
+    ? b
+    &anchor c: 3
+  tree: |
+    +STR
+     +DOC ---
+      +MAP
+       =VAL :a
+       =VAL :1
+       =VAL :b
+       =VAL :
+       =VAL &anchor :c
+       =VAL :3
+      -MAP
+     -DOC
+    -STR
+  json: |
+    {
+      "a": 1,
+      "b": null,
+      "c": 3
+    }
+  dump: |
+    ---
+    a: 1
+    b:
+    &anchor c: 3

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZXT5.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZXT5.yaml
@@ -1,0 +1,13 @@
+---
+- name: Implicit key followed by newline and adjacent value
+  from: '@perlpunk'
+  tags: error flow mapping sequence
+  fail: true
+  yaml: |
+    [ "key"
+      :value ]
+  tree: |
+    +STR
+     +DOC
+      +SEQ []
+       =VAL "key

--- a/pkgs/yaml/third_party/yaml-test-suite/src/ZYU8.yaml
+++ b/pkgs/yaml/third_party/yaml-test-suite/src/ZYU8.yaml
@@ -1,0 +1,32 @@
+---
+- skip: true
+  note: The following cases are valid YAML according to the 1.2 productions but
+    not at all usefully valid. We don't want to encourage parsers to support
+    them when we'll likely make them invalid later.
+  also: MU58
+  name: Directive variants
+  from: '@ingydotnet'
+  tags: directive
+  yaml: |
+    %YAML1.1
+    ---
+  tree: |
+    +STR
+     +DOC ---
+      =VAL :
+     -DOC
+    -STR
+  json: |
+    null
+
+- yaml: |
+    %***
+    ---
+
+- yaml: |
+    %YAML 1.1 1.2
+    ---
+
+- yaml: |
+    %YAML 1.12345
+    ---

--- a/pkgs/yaml/tool/update-yaml-test-suite.sh
+++ b/pkgs/yaml/tool/update-yaml-test-suite.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Go to the pkgs/yaml directory
+cd "$(dirname "$0")/.."
+
+TARGET_DIR="third_party/yaml-test-suite"
+
+echo "Updating yaml-test-suite..."
+
+# Remove the old directory if it exists
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+
+# Clone the repository to a temporary directory
+TMP_DIR=$(mktemp -d)
+git clone https://github.com/yaml/yaml-test-suite.git "$TMP_DIR"
+
+# Copy the required files and directories
+cp -r "$TMP_DIR/src" "$TARGET_DIR/"
+cp "$TMP_DIR/License" "$TARGET_DIR/LICENSE"
+
+# Copy README
+if [ -f "$TMP_DIR/ReadMe.md" ]; then
+    cp "$TMP_DIR/ReadMe.md" "$TARGET_DIR/README.md"
+elif [ -f "$TMP_DIR/README.md" ]; then
+    cp "$TMP_DIR/README.md" "$TARGET_DIR/README.md"
+fi
+
+# Clean up
+rm -rf "$TMP_DIR"
+
+echo "yaml-test-suite updated successfully."

--- a/pkgs/yaml/tool/yaml_test_suite_summary.dart
+++ b/pkgs/yaml/tool/yaml_test_suite_summary.dart
@@ -1,0 +1,106 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'package:test/test.dart';
+import '../test/yaml_test_suite.dart';
+
+void main(List<String> args) {
+  final cases = loadYamlTestSuite();
+
+  if (args.isNotEmpty) {
+    final targetId = args.first;
+    final testCase = cases.cast<YamlTestCase?>().firstWhere(
+          (c) => c?.id == targetId,
+          orElse: () => null,
+        );
+
+    if (testCase == null) {
+      print('Test case $targetId not found.');
+      exit(1);
+    }
+
+    print('Test Case: ${testCase.id} - ${testCase.name}');
+    print('Tags: ${testCase.tags.join(', ')}');
+    print('Fail expected: ${testCase.fail}');
+    print('--- YAML ---');
+    print(testCase.yaml);
+    print('------------');
+
+    try {
+      testCase.runTest();
+      print('Status: PASSED');
+    } on TestFailure catch (e) {
+      print('Status: FAILED (TestFailure)');
+      print(e.message);
+    } catch (e) {
+      print('Status: FAILED (Unexpected Exception)');
+      print(e.toString());
+    }
+    return;
+  }
+
+  final tagFailures = <String, List<String>>{};
+  final expectedParsingFailIds = <String>[];
+  final mismatchingJsonIds = <String>[];
+  final unexpectedErrorIds = <String>[];
+
+  for (final c in cases) {
+    try {
+      c.runTest();
+    } on TestFailure catch (e) {
+      for (final tag in c.tags) {
+        tagFailures.putIfAbsent(tag, () => []).add(c.id);
+      }
+
+      if (e.message?.contains('Expected parsing to fail') == true) {
+        expectedParsingFailIds.add(c.id);
+      } else if (e.message?.contains('JSON mismatch') == true) {
+        mismatchingJsonIds.add(c.id);
+      } else {
+        unexpectedErrorIds.add(c.id);
+      }
+    } catch (e) {
+      // Any other exception from parser
+      for (final tag in c.tags) {
+        tagFailures.putIfAbsent(tag, () => []).add(c.id);
+      }
+      unexpectedErrorIds.add(c.id);
+    }
+  }
+
+  print('Failures by Tag:');
+  final sortedTags = tagFailures.entries.toList()
+    ..sort((a, b) => b.value.length.compareTo(a.value.length));
+
+  // Calculate max length of tag for alignment
+  final maxTagLen = tagFailures.keys
+      .fold<int>(0, (max, tag) => tag.length > max ? tag.length : max);
+
+  for (final entry in sortedTags) {
+    final countStr = entry.value.length.toString().padLeft(4);
+    final tagPadded = entry.key.padRight(maxTagLen);
+    final samples = entry.value.take(5).join(' ');
+    print('  $tagPadded: $countStr          $samples');
+  }
+
+  print('');
+  print('Total Failures:');
+
+  final categories = [
+    ('Expected parsing to fail', expectedParsingFailIds),
+    ('Mismatching JSON', mismatchingJsonIds),
+    ('Unexpected errors', unexpectedErrorIds),
+  ];
+
+  final maxCatLen = categories.fold<int>(
+      0, (max, cat) => cat.$1.length > max ? cat.$1.length : max);
+
+  for (final cat in categories) {
+    final namePadded = cat.$1.padRight(maxCatLen);
+    final countStr = cat.$2.length.toString().padLeft(4);
+    final samples = cat.$2.take(5).join(' ');
+    print('  $namePadded: $countStr          $samples');
+  }
+}


### PR DESCRIPTION
Integrates [yaml-test-suite](https://github.com/yaml/yaml-test-suite) to test `package:yaml` against standard YAML specifications. Out of 402 comprehensive tests, 357 pass flawlessly, and exactly 45 expected failures are cleanly isolated.

Having reviewed some (not all) of the 45 failures, I think it's plausible that they are discrepancies between `package:yaml` and the specification.
This does not mean that they are bugs we should fix without considering the implication on consumers of `package:yaml`.

**Please review commit-by-commit:**
* **Commit 1: Add script to fetch yaml-test-suite**
  * Adds `tool/update-yaml-test-suite.sh` to download and vendor the upstream suite.
* **Commit 2: Fetch yaml-test-suite data using script**
  * Adds the raw, vendored test suite data into `third_party/` (mostly data, safe to skim).
* **Commit 3: Add yaml-test-suite harness and test cases**
  * Adds `test/yaml_test_suite.dart` harness to parse multi-JSON descriptors and assert equality.
  * Adds `test/yaml_test_suite_test.dart` to run the suite and track the 45 `expectedFailures`.
  * Adds `tool/yaml_test_suite_summary.dart` CLI tool to categorize parsing bugs by spec tags.