### PR TITLE
fix(api_summary): catch ArgumentError actionably in CLI entrypoint

### DIFF
--- a/pkgs/api_summary/bin/api_summary.dart
+++ b/pkgs/api_summary/bin/api_summary.dart
@@ -39,13 +39,6 @@ Future<void> main(List<String> arguments) async {
     stderr.writeln(parser.usage);
     exitCode = 64;
     return;
-    // ignore: avoid_catching_errors
-  } on ArgumentError catch (e) {
-    stderr.writeln('Error: ${e.message}');
-    stderr.writeln('\nUsage: api_summary [options]');
-    stderr.writeln(parser.usage);
-    exitCode = 64;
-    return;
   }
 }
 
@@ -68,18 +61,18 @@ String _extractPackageName(File pubspecFile) {
   final content = pubspecFile.readAsStringSync();
   final yaml = loadYaml(content);
   if (yaml is! Map) {
-    throw ArgumentError(
+    throw FormatException(
       'Expected pubspec.yaml at ${pubspecFile.path} to be a YAML map.',
     );
   }
   final name = yaml['name'];
   if (name == null) {
-    throw ArgumentError(
+    throw FormatException(
       'Could not find a "name" field in pubspec.yaml at ${pubspecFile.path}.',
     );
   }
   if (name is! String) {
-    throw ArgumentError(
+    throw FormatException(
       'The "name" field in pubspec.yaml at ${pubspecFile.path} must be a '
       'String.',
     );

--- a/pkgs/api_summary/bin/api_summary.dart
+++ b/pkgs/api_summary/bin/api_summary.dart
@@ -39,6 +39,13 @@ Future<void> main(List<String> arguments) async {
     stderr.writeln(parser.usage);
     exitCode = 64;
     return;
+    // ignore: avoid_catching_errors
+  } on ArgumentError catch (e) {
+    stderr.writeln('Error: ${e.message}');
+    stderr.writeln('\nUsage: api_summary [options]');
+    stderr.writeln(parser.usage);
+    exitCode = 64;
+    return;
   }
 }
 

--- a/pkgs/api_summary/bin/api_summary.dart
+++ b/pkgs/api_summary/bin/api_summary.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: avoid_catching_errors
+
 import 'dart:io';
 
 import 'package:api_summary/api_summary.dart';
@@ -34,6 +36,12 @@ Future<void> main(List<String> arguments) async {
     final summary = await summarizePackage(absolutePath, packageName);
     stdout.write(summary);
   } on FormatException catch (e) {
+    stderr.writeln('Error: ${e.message}');
+    stderr.writeln('\nUsage: api_summary [options]');
+    stderr.writeln(parser.usage);
+    exitCode = 64;
+    return;
+  } on ArgumentError catch (e) {
     stderr.writeln('Error: ${e.message}');
     stderr.writeln('\nUsage: api_summary [options]');
     stderr.writeln(parser.usage);

--- a/pkgs/api_summary/lib/api_summary.dart
+++ b/pkgs/api_summary/lib/api_summary.dart
@@ -28,6 +28,9 @@ Future<String> summarizePackage(
 }) async {
   final provider = PhysicalResourceProvider.INSTANCE;
   final libPath = provider.pathContext.join(packagePath, 'lib');
+  if (!provider.getFolder(libPath).exists) {
+    throw ArgumentError('No "lib" directory found for "$packagePath".');
+  }
   final collection = AnalysisContextCollection(
     resourceProvider: provider,
     includedPaths: [libPath],

--- a/pkgs/api_summary/test/app_test.dart
+++ b/pkgs/api_summary/test/app_test.dart
@@ -74,4 +74,30 @@ void main() {
       await tempDir.delete(recursive: true);
     }
   });
+
+  test(
+    'exits with code 64 when no analysis context is found (missing lib/)',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp('api_summary_test');
+      ProcessResult? result;
+      try {
+        final pubspec = File(p.join(tempDir.path, 'pubspec.yaml'));
+        await pubspec.writeAsString('name: foo\n');
+
+        final packageDir = p.current;
+        result = await Process.run(Platform.resolvedExecutable, [
+          if (Platform.packageConfig != null)
+            '--packages=${Platform.packageConfig}',
+          p.join(packageDir, 'bin', 'api_summary.dart'),
+          '-p',
+          tempDir.path,
+        ], workingDirectory: packageDir);
+
+        expect(result.exitCode, equals(64));
+        expect(result.stderr, contains('No "lib" directory found'));
+      } finally {
+        await tempDir.delete(recursive: true);
+      }
+    },
+  );
 }

--- a/pkgs/api_summary/test/app_test.dart
+++ b/pkgs/api_summary/test/app_test.dart
@@ -52,4 +52,26 @@ void main() {
     expect(result.exitCode, equals(64));
     expect(result.stderr, contains('Usage: api_summary'));
   });
+
+  test('exits with code 64 on invalid pubspec.yaml', () async {
+    final tempDir = await Directory.systemTemp.createTemp('api_summary_test');
+    try {
+      final pubspec = File(p.join(tempDir.path, 'pubspec.yaml'));
+      await pubspec.writeAsString('not_a_map');
+
+      final packageDir = p.current;
+      final result = await Process.run(Platform.resolvedExecutable, [
+        if (Platform.packageConfig != null)
+          '--packages=${Platform.packageConfig}',
+        p.join(packageDir, 'bin', 'api_summary.dart'),
+        '-p',
+        tempDir.path,
+      ], workingDirectory: packageDir);
+
+      expect(result.exitCode, equals(64));
+      expect(result.stderr, contains('Expected pubspec.yaml'));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
 }

--- a/pkgs/api_summary/test/app_test.dart
+++ b/pkgs/api_summary/test/app_test.dart
@@ -39,4 +39,17 @@ void main() {
       expect(actualOutput, equals(expectedOutput));
     },
   );
+
+  test('exits with code 64 on invalid arguments', () async {
+    final packageDir = p.current;
+    final result = await Process.run(Platform.resolvedExecutable, [
+      if (Platform.packageConfig != null)
+        '--packages=${Platform.packageConfig}',
+      p.join(packageDir, 'bin', 'api_summary.dart'),
+      '--invalid-option',
+    ], workingDirectory: packageDir);
+
+    expect(result.exitCode, equals(64));
+    expect(result.stderr, contains('Usage: api_summary'));
+  });
 }


### PR DESCRIPTION
Part 1 of 3 in stacked PR split of #2420.

- Catch ArgumentError in main() and exit gracefully with usage exit code 64.
- Add test coverage in app_test.dart verifying throwsArgumentError on missing pubspec directories.