### PR TITLE
Fix UKK6-1 from yaml-test-suite

### DIFF
--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.4-wip
 
+* Fix parsing of plain scalars starting with indicator characters (`?`, `:`, and `-`).
 * Throw a `FormatException` when parsing self-referential collections instead of
   a `StackOverflow`. Yaml definitions with collections nested within themselves
   are unsupported.

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -417,14 +417,14 @@ class Scanner {
 
       // These characters may sometimes begin plain scalars.
       case HYPHEN:
-        if (_isPlainCharAt(1)) {
+        if (_isPlainSafeAt(1)) {
           _fetchPlainScalar();
         } else {
           _fetchBlockEntry();
         }
         return;
       case QUESTION:
-        if (_isPlainCharAt(1)) {
+        if (_isPlainSafeAt(1)) {
           _fetchPlainScalar();
         } else {
           _fetchKey();
@@ -445,7 +445,7 @@ class Scanner {
           }
         }
 
-        if (_isPlainCharAt(1)) {
+        if (_isPlainSafeAt(1)) {
           _fetchPlainScalar();
         } else {
           _fetchValue();

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -613,6 +613,12 @@ void main() {
   // encoding.
 
   group('5.3: Indicator Characters', () {
+    test('can start a plain scalar if followed by a plain-safe character', () {
+      expectYamlLoads({':': null}, '::');
+      expectYamlLoads({'-': null}, '-:');
+      expectYamlLoads([':a', '-b', '?c'], '[ :a, -b, ?c ]');
+    });
+
     test('[Example 5.3]', () {
       expectYamlLoads({
         'sequence': ['one', 'two'],

--- a/pkgs/yaml/test/yaml_test_suite_test.dart
+++ b/pkgs/yaml/test/yaml_test_suite_test.dart
@@ -72,7 +72,6 @@ const _expectedFailures = <String>[
   'X38W-0',
   'ZYU8-2',
   'RHX7-0',
-  'UKK6-1',
   '2XXW-0',
   '9HCY-0',
   'KS4U-0',


### PR DESCRIPTION
This PR fixes a bug where plain scalars starting with an indicator character (`?`, `:`, or `-`) followed immediately by a colon were incorrectly parsed, causing syntax errors. 

Under the YAML 1.2 `ns-plain-first` rule, an indicator character can begin a plain scalar as long as the immediately following character is "plain-safe". The scanner was incorrectly checking the character *after* the colon (a double-lookahead) due to how `_isPlainCharAt` handles colons internally. 

By swapping the lookahead check from `_isPlainCharAt(1)` to `_isPlainSafeAt(1)`, the scanner correctly validates the colon as plain-safe and successfully starts parsing the scalar.

### Examples of what this fixes

**Input YAML:**
```yaml
::
```

* **Before:** Threw a syntax error (the scanner emitted two consecutive `VALUE` indicators without keys).
* **After:** Successfully parses as a map with the string key `":"` and a `null` value (`{":": null}`).

**Input YAML:**
```yaml
-:
```

* **Before:** Threw a syntax error.
* **After:** Successfully parses as a map with the string key `"-"` and a `null` value (`{"-": null}`).

This fixes `UKK6-1` from the `yaml-test-suite`.