### PR TITLE
fix: add missing license headers

### DIFF
--- a/pkgs/bazel_worker/benchmark/benchmark.dart
+++ b/pkgs/bazel_worker/benchmark/benchmark.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:math';
 import 'dart:typed_data';
 

--- a/pkgs/coverage/lib/src/coverage_options.dart
+++ b/pkgs/coverage/lib/src/coverage_options.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'package:cli_config/cli_config.dart';
 import 'package:path/path.dart' as path;

--- a/pkgs/html/example/main.dart
+++ b/pkgs/html/example/main.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:html/dom.dart';
 import 'package:html/dom_parsing.dart';
 import 'package:html/parser.dart';

--- a/pkgs/pubspec_parse/test/git_uri_test.dart
+++ b/pkgs/pubspec_parse/test/git_uri_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:pubspec_parse/src/dependency.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/watcher/test/custom_watcher_factory_test.dart
+++ b/pkgs/watcher/test/custom_watcher_factory_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:test/test.dart';


### PR DESCRIPTION
Add missing BSD license headers to source and test files flagged by PR license check:

- `pkgs/bazel_worker/benchmark/benchmark.dart`
- `pkgs/coverage/lib/src/coverage_options.dart`
- `pkgs/html/example/main.dart`
- `pkgs/pubspec_parse/test/git_uri_test.dart`
- `pkgs/watcher/test/custom_watcher_factory_test.dart`