### PR TITLE
Add pub.dev validation toolkit

### DIFF
--- a/pkgs/yaml/pubspec.yaml
+++ b/pkgs/yaml/pubspec.yaml
@@ -17,6 +17,11 @@ dependencies:
   string_scanner: ^1.2.0
 
 dev_dependencies:
+  args: ^2.7.0
+  crypto: ^3.0.7
   dart_flutter_team_lints: ^3.0.0
+  http: ^1.6.0
   path: ^1.8.0
+  pool: ^1.5.2
+  tar: ^2.0.2
   test: ^1.16.6

--- a/pkgs/yaml/tool/pub-validation/README.md
+++ b/pkgs/yaml/tool/pub-validation/README.md
@@ -1,0 +1,28 @@
+# Pub.dev YAML validation tools
+
+A brute force mechanism to assess implications `package:yaml` changes.
+
+1. Fetch and extract all `.yaml` files from all packages on pub.dev:
+   ```sh
+   dart run tool/pub-validation/fetch_yamls_from_pub_dev.dart
+   ```
+2. Compare `main` branch against `HEAD` (requires clean git working tree):
+   ```sh
+   dart run tool/pub-validation/compare_parsers.dart
+   ```   
+
+Step (1) will fetch > 80k packages, parse and extract all YAML files, storing
+them in `.dart_tool/yaml/pub-dev-yaml-files/<package>.jsonl.gz` (~400 MB).
+
+Step (2) will compile `_jsonl_bulk_parser.dart` from current branch and `main`,
+running both on each of the `.jsonl.gz` files comparing the output; writing
+differences to `.dart_tool/yaml/comparison/<package_name>.jsonl.gz`, and
+printing a summary.
+
+With good internet and decent CPU, step (1) takes 4-5 hours, step (2) 1-2 hours.
+
+------------------------------
+
+If the scripts in this folder breaks horribly in the future, it's fair to simply
+delete them.
+This is not a super important test, nor one we should run regularly.

--- a/pkgs/yaml/tool/pub-validation/_jsonl_bulk_parser.dart
+++ b/pkgs/yaml/tool/pub-validation/_jsonl_bulk_parser.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty) {
+    stderr.writeln('Usage: dart _jsonl_bulk_parser.dart <file.jsonl.gz>');
+    exit(1);
+  }
+
+  final file = File(args[0]);
+  if (!file.existsSync()) {
+    stderr.writeln('File not found: ${args[0]}');
+    exit(1);
+  }
+
+  final lines = file
+      .openRead()
+      .transform(gzip.decoder)
+      .transform(utf8.decoder)
+      .transform(const LineSplitter());
+
+  await for (final line in lines) {
+    if (line.trim().isEmpty) continue;
+
+    Map<String, dynamic> data;
+    try {
+      data = jsonDecode(line) as Map<String, dynamic>;
+    } catch (e) {
+      stderr.writeln('Failed to decode line: $e');
+      continue;
+    }
+
+    final yamlString = data['contents'] as String?;
+    if (yamlString == null) continue;
+
+    Object? parsedJson;
+    String? exception;
+
+    try {
+      // Parse YAML. We convert to JSON-compatible structures
+      // so it can be serialized back to JSON.
+      final doc = loadYamlNode(yamlString);
+      parsedJson = _toJson(doc);
+    } catch (e) {
+      exception = e.toString();
+    }
+
+    final result = {
+      'package': data['package'],
+      'version': data['version'],
+      'file': data['file'],
+      'yaml': yamlString,
+      'json': parsedJson,
+      'exception': exception,
+    };
+
+    stdout.writeln(jsonEncode(result));
+  }
+}
+
+Object? _toJson(YamlNode node) {
+  if (node is YamlMap) {
+    final map = <String, Object?>{};
+    for (final entry in node.nodes.entries) {
+      final keyNode = entry.key;
+      final key = keyNode is YamlNode ? _toJson(keyNode) : keyNode;
+      final keyStr = key is String ? key : jsonEncode(key);
+      map[keyStr] = _toJson(entry.value);
+    }
+    return map;
+  } else if (node is YamlList) {
+    return node.nodes.map(_toJson).toList();
+  } else if (node is YamlScalar) {
+    final val = node.value;
+    if (val is double) {
+      if (val.isNaN) return '.nan';
+      if (val.isInfinite) return val < 0 ? '-.inf' : '.inf';
+    }
+    if (val is String || val is num || val is bool || val == null) {
+      return val;
+    }
+    return val.toString();
+  }
+  return null;
+}

--- a/pkgs/yaml/tool/pub-validation/compare_parsers.dart
+++ b/pkgs/yaml/tool/pub-validation/compare_parsers.dart
@@ -1,0 +1,344 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:args/args.dart';
+import 'package:pool/pool.dart';
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()
+    ..addOption('max-packages',
+        help: 'Maximum number of packages to process', valueHelp: 'N');
+
+  final parsedArgs = parser.parse(args);
+  final maxPackagesStr = parsedArgs['max-packages'] as String?;
+  final maxPackages = maxPackagesStr != null ? int.parse(maxPackagesStr) : null;
+
+  // 1. Verify git is clean
+  final gitStatus = await Process.run('git', ['status', '--porcelain']);
+  if (gitStatus.stdout.toString().trim().isNotEmpty) {
+    print('Please commit or stash your changes before running this script.');
+    print(gitStatus.stdout);
+    exit(1);
+  }
+
+  final currentBranchResult =
+      await Process.run('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+  final currentBranch = currentBranchResult.stdout.toString().trim();
+
+  // 2. Setup paths
+  final dataDir = Directory('.dart_tool/yaml/pub-dev-yaml-files');
+  if (!dataDir.existsSync()) {
+    print('Data directory not found. Run fetch_yamls_from_pub_dev.dart first.');
+    exit(1);
+  }
+
+  final outDir = Directory('.dart_tool/yaml');
+  final binNew = File('${outDir.path}/_jsonl_bulk_parser_new');
+  final binOld = File('${outDir.path}/_jsonl_bulk_parser_old');
+  final compareDir = Directory('${outDir.path}/comparison');
+
+  if (compareDir.existsSync()) {
+    compareDir.deleteSync(recursive: true);
+  }
+  compareDir.createSync(recursive: true);
+
+  // Copy the parser script so it survives git checkout
+  final tempParser = File('.dart_tool/yaml/_jsonl_bulk_parser.dart');
+  File('tool/pub-validation/_jsonl_bulk_parser.dart').copySync(tempParser.path);
+
+  try {
+    print('Compiling parser for current branch ($currentBranch)...');
+    final compileNew = await Process.run(Platform.executable,
+        ['compile', 'exe', tempParser.path, '-o', binNew.path]);
+    if (compileNew.exitCode != 0) {
+      throw StateError(
+          'Compilation failed:\n${compileNew.stdout}\n${compileNew.stderr}');
+    }
+
+    print('Checking out main...');
+    final checkoutMain = await Process.run('git', ['checkout', 'main']);
+    if (checkoutMain.exitCode != 0) {
+      throw StateError(
+          'Failed to checkout main branch:\n${checkoutMain.stderr}');
+    }
+
+    print('Compiling parser for main branch...');
+    final compileOld = await Process.run(Platform.executable,
+        ['compile', 'exe', tempParser.path, '-o', binOld.path]);
+    if (compileOld.exitCode != 0) {
+      throw StateError(
+          'Compilation failed:\n${compileOld.stdout}\n${compileOld.stderr}');
+    }
+  } finally {
+    print('Restoring original branch ($currentBranch)...');
+    await Process.run('git', ['checkout', currentBranch]);
+    if (tempParser.existsSync()) {
+      tempParser.deleteSync();
+    }
+  }
+
+  print('Compilation successful. Beginning comparison.');
+
+  final files = dataDir
+      .listSync()
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.jsonl.gz'))
+      .toList();
+  files.sort((a, b) => a.path.compareTo(b.path));
+
+  final filesToProcess =
+      maxPackages != null ? files.take(maxPackages).toList() : files;
+
+  int totalChecks = 0;
+  int differences = 0;
+  int newExceptions = 0;
+  int resolvedExceptions = 0;
+  int jsonDiffers = 0;
+
+  int processedCount = 0;
+  print(
+      'Processing ${filesToProcess.length} packages with ${Platform.numberOfProcessors} concurrent workers...');
+
+  // Process files concurrently using a Pool
+  final pool = Pool(Platform.numberOfProcessors);
+
+  var lastPrint = DateTime.now();
+
+  await Future.wait(filesToProcess.map((file) {
+    return pool.withResource(() async {
+      final result = await _runIsolateFor(
+        filePath: file.path,
+        binOldPath: binOld.path,
+        binNewPath: binNew.path,
+        compareDirPath: compareDir.path,
+      );
+
+      totalChecks += result.checks;
+      differences += result.diffs;
+      newExceptions += result.newEx;
+      resolvedExceptions += result.resEx;
+      jsonDiffers += result.jsonDiffs;
+
+      processedCount++;
+      final now = DateTime.now();
+      if (now.difference(lastPrint).inMinutes >= 1 ||
+          processedCount == filesToProcess.length) {
+        print(
+            'Processed $processedCount / ${filesToProcess.length} (${(processedCount / filesToProcess.length * 100).toStringAsFixed(1)}%)');
+        lastPrint = now;
+      }
+    });
+  }));
+
+  print('\n--- Comparison Report ---');
+  print('Total YAML files checked: $totalChecks');
+  print('Total differences found: $differences');
+  print('New exceptions (did not fail before, fails now): $newExceptions');
+  print('Resolved exceptions (failed before, passes now): $resolvedExceptions');
+  print('Cases where parsed JSON differs: $jsonDiffers');
+  print('-------------------------');
+}
+
+typedef DiffResult = ({
+  int checks,
+  int diffs,
+  int newEx,
+  int resEx,
+  int jsonDiffs
+});
+
+Future<DiffResult> _runIsolateFor({
+  required String filePath,
+  required String binOldPath,
+  required String binNewPath,
+  required String compareDirPath,
+}) {
+  return Isolate.run(() => processFileInIsolate(
+        filePath: filePath,
+        binOldPath: binOldPath,
+        binNewPath: binNewPath,
+        compareDirPath: compareDirPath,
+      ));
+}
+
+Future<DiffResult> processFileInIsolate({
+  required String filePath,
+  required String binOldPath,
+  required String binNewPath,
+  required String compareDirPath,
+}) async {
+  final results = await Future.wait([
+    Process.run(binOldPath, [filePath]),
+    Process.run(binNewPath, [filePath]),
+  ]);
+  final oldProc = results[0];
+  final newProc = results[1];
+
+  if (oldProc.stderr.toString().isNotEmpty) {
+    stderr.write('[OLD $filePath] ${oldProc.stderr}');
+  }
+  if (newProc.stderr.toString().isNotEmpty) {
+    stderr.write('[NEW $filePath] ${newProc.stderr}');
+  }
+
+  if (oldProc.exitCode != 0 || newProc.exitCode != 0) {
+    stderr.writeln(
+        'Process crashed on $filePath: old=${oldProc.exitCode} new=${newProc.exitCode}');
+    final package =
+        Uri.file(filePath).pathSegments.last.replaceAll('.jsonl.gz', '');
+    final diffFile = File('$compareDirPath/$package.jsonl.gz');
+    final sink = diffFile.openWrite();
+    final gzipSink = gzip.encoder.startChunkedConversion(sink);
+    gzipSink.add(utf8.encode(jsonEncode({
+          'file': filePath,
+          'error': 'Process crashed',
+          'old_exit_code': oldProc.exitCode,
+          'new_exit_code': newProc.exitCode,
+          'old_stderr': oldProc.stderr.toString(),
+          'new_stderr': newProc.stderr.toString(),
+        }) +
+        '\n'));
+    gzipSink.close();
+    await sink.done;
+
+    return (
+      checks: 0,
+      diffs: 1,
+      newEx: oldProc.exitCode == 0 && newProc.exitCode != 0 ? 1 : 0,
+      resEx: oldProc.exitCode != 0 && newProc.exitCode == 0 ? 1 : 0,
+      jsonDiffs: 0,
+    );
+  }
+
+  final oldLines = oldProc.stdout
+      .toString()
+      .split('\n')
+      .map((l) => l.trim())
+      .where((l) => l.isNotEmpty)
+      .toList();
+  final newLines = newProc.stdout
+      .toString()
+      .split('\n')
+      .map((l) => l.trim())
+      .where((l) => l.isNotEmpty)
+      .toList();
+
+  int checks = 0;
+  int diffs = 0;
+  int newExCount = 0;
+  int resExCount = 0;
+  int jsonDiffs = 0;
+
+  List<String> diffOutput = [];
+
+  if (oldLines.length != newLines.length) {
+    stderr.writeln(
+        'Line count mismatch on $filePath: old=${oldLines.length} new=${newLines.length}');
+    diffs++;
+    diffOutput.add(jsonEncode({
+      'error': 'Line count mismatch',
+      'old_count': oldLines.length,
+      'new_count': newLines.length,
+    }));
+  }
+
+  final minLength =
+      oldLines.length < newLines.length ? oldLines.length : newLines.length;
+
+  for (int i = 0; i < minLength; i++) {
+    final oldLine = oldLines[i];
+    final newLine = newLines[i];
+
+    checks++;
+
+    // Fast path: if the JSON lines are identical, they are the same!
+    if (oldLine == newLine) {
+      continue;
+    }
+
+    final oldData = jsonDecode(oldLine);
+    final newData = jsonDecode(newLine);
+
+    final oldEx = oldData['exception'];
+    final newEx = newData['exception'];
+    final oldJson = jsonEncode(oldData['json']);
+    final newJson = jsonEncode(newData['json']);
+
+    bool lineDiffers = false;
+
+    if (oldEx != newEx) {
+      lineDiffers = true;
+      if (oldEx == null && newEx != null) {
+        newExCount++;
+      } else if (oldEx != null && newEx == null) {
+        resExCount++;
+      }
+    }
+
+    if (oldJson != newJson) {
+      lineDiffers = true;
+      jsonDiffs++;
+    }
+
+    if (lineDiffers) {
+      diffs++;
+
+      String? jsonDiffStr;
+      if (oldJson != newJson) {
+        final encoder = const JsonEncoder.withIndent('  ');
+        final oldPretty = encoder.convert(oldData['json']);
+        final newPretty = encoder.convert(newData['json']);
+
+        final tempDir = Directory.systemTemp.createTempSync('yaml_diff_');
+        final oldFile = File('${tempDir.path}/old.json')
+          ..writeAsStringSync(oldPretty);
+        final newFile = File('${tempDir.path}/new.json')
+          ..writeAsStringSync(newPretty);
+
+        final diffProc = await Process.run('diff',
+            ['-y', '--color=always', '-W', '180', oldFile.path, newFile.path]);
+        jsonDiffStr =
+            '${oldData['package']}-${oldData['version']}.tar.gz ${oldData['file']}\n'
+            '${diffProc.stdout}\n'
+            '---------';
+
+        tempDir.deleteSync(recursive: true);
+      }
+
+      diffOutput.add(jsonEncode({
+        'package': oldData['package'],
+        'version': oldData['version'],
+        'file': oldData['file'],
+        'yaml': oldData['yaml'],
+        'old_exception': oldEx,
+        'new_exception': newEx,
+        'old_json': oldData['json'],
+        'new_json': newData['json'],
+        if (jsonDiffStr != null) 'json_diff': jsonDiffStr,
+      }));
+    }
+  }
+
+  if (diffOutput.isNotEmpty) {
+    final package =
+        Uri.file(filePath).pathSegments.last.replaceAll('.jsonl.gz', '');
+    final diffFile = File('$compareDirPath/$package.jsonl.gz');
+    final sink = diffFile.openWrite();
+    final gzipSink = gzip.encoder.startChunkedConversion(sink);
+    for (final diffLine in diffOutput) {
+      gzipSink.add(utf8.encode('$diffLine\n'));
+    }
+    gzipSink.close();
+    await sink.done;
+  }
+
+  return (
+    checks: checks,
+    diffs: diffs,
+    newEx: newExCount,
+    resEx: resExCount,
+    jsonDiffs: jsonDiffs,
+  );
+}

--- a/pkgs/yaml/tool/pub-validation/fetch_yamls_from_pub_dev.dart
+++ b/pkgs/yaml/tool/pub-validation/fetch_yamls_from_pub_dev.dart
@@ -1,0 +1,227 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:args/args.dart';
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/retry.dart';
+import 'package:pool/pool.dart';
+import 'package:tar/tar.dart';
+
+typedef PackageStats = ({
+  int fetchedVersions,
+  int failedVersions,
+  int uniqueYamlFiles,
+  bool failedVersionListing,
+});
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()
+    ..addOption('max-packages',
+        abbr: 'm', help: 'Maximum number of packages to fetch')
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Show this help');
+
+  final results = parser.parse(args);
+
+  if (results['help'] == true) {
+    print(parser.usage);
+    return;
+  }
+
+  int? maxPackages;
+  if (results['max-packages'] != null) {
+    maxPackages = int.tryParse(results['max-packages'] as String);
+  }
+
+  print('Fetching package list from pub.dev...');
+  final namesResponse =
+      await http.get(Uri.parse('https://pub.dev/api/package-names'));
+  if (namesResponse.statusCode != 200) {
+    print('Error: Failed to fetch package list '
+        '(HTTP ${namesResponse.statusCode})');
+    return;
+  }
+
+  final namesJson = jsonDecode(namesResponse.body) as Map<String, dynamic>;
+  final packages = (namesJson['packages'] as List<dynamic>).cast<String>();
+  print('Found ${packages.length} packages on pub.dev.');
+
+  final packagesToProcess = maxPackages != null
+      ? packages.take(maxPackages).toList()
+      : packages.toList();
+
+  print('Processing ${packagesToProcess.length} packages...');
+
+  final packageConfig = Isolate.packageConfigSync;
+  final Directory dartToolDir;
+  if (packageConfig != null) {
+    dartToolDir = Directory.fromUri(packageConfig.resolve('.'));
+  } else {
+    dartToolDir = Directory('.dart_tool');
+  }
+
+  final outDir = Directory('${dartToolDir.path}/yaml/pub-dev-yaml-files');
+  outDir.createSync(recursive: true);
+
+  final pool = Pool(50);
+  var completed = 0;
+
+  var totalFetchedVersions = 0;
+  var totalFailedVersions = 0;
+  var totalUniqueYamlFiles = 0;
+  var totalFailedVersionListing = 0;
+  var totalPackagesDownloaded = 0;
+
+  await Future.wait(
+      packagesToProcess.map((package) async => pool.withResource(() async {
+            final outFile = File('${outDir.path}/$package.jsonl.gz');
+            if (outFile.existsSync()) {
+              completed++;
+              print('[$completed/${packagesToProcess.length}] '
+                  'Skipped $package (already exists)');
+              return;
+            }
+
+            try {
+              final path = outFile.path;
+              final stats = await _runIsolate(package, path);
+
+              totalFetchedVersions += stats.fetchedVersions;
+              totalFailedVersions += stats.failedVersions;
+              totalUniqueYamlFiles += stats.uniqueYamlFiles;
+              if (stats.failedVersionListing) {
+                totalFailedVersionListing++;
+              }
+              totalPackagesDownloaded++;
+
+              completed++;
+              print('[$completed/${packagesToProcess.length}] '
+                  'Processed $package (${stats.uniqueYamlFiles} yamls, '
+                  '${stats.fetchedVersions} versions, '
+                  '${stats.failedVersions} failed versions)');
+            } catch (e) {
+              completed++;
+              print('[$completed/${packagesToProcess.length}] '
+                  'Failed to process $package: $e');
+            }
+          })));
+
+  await pool.close();
+
+  print('\n=== SUMMARY ===');
+  print('Packages downloaded: $totalPackagesDownloaded');
+  print('Packages failed to list versions: $totalFailedVersionListing');
+  print('Total versions fetched successfully: $totalFetchedVersions');
+  print('Total versions failed fetching/extracting: $totalFailedVersions');
+  print('Total unique YAML files: $totalUniqueYamlFiles');
+}
+
+Future<PackageStats> _runIsolate(String package, String outPath) =>
+    Isolate.run(() => _processPackage(package, outPath));
+
+Future<PackageStats> _processPackage(String package, String outPath) async {
+  final client = RetryClient(http.Client());
+  final results = <String>[];
+  var fetchedVersions = 0;
+  var failedVersions = 0;
+  var uniqueYamlFiles = 0;
+  var failedVersionListing = false;
+
+  try {
+    final apiUrl = Uri.parse('https://pub.dev/api/packages/$package');
+    final apiResponse = await client.get(apiUrl);
+
+    if (apiResponse.statusCode != 200) {
+      return (
+        fetchedVersions: fetchedVersions,
+        failedVersions: failedVersions,
+        uniqueYamlFiles: uniqueYamlFiles,
+        failedVersionListing: true,
+      );
+    }
+
+    final metadata = jsonDecode(apiResponse.body) as Map<String, dynamic>;
+    final versionsList = metadata['versions'] as List<dynamic>? ?? [];
+
+    // Process from newest to oldest
+    final versions = versionsList.reversed.toList();
+    final seenHashes = <String>{};
+
+    for (final versionInfo in versions) {
+      if (versionInfo is! Map) continue;
+
+      final version = versionInfo['version'] as String;
+      final archiveUrl = versionInfo['archive_url'] as String?;
+
+      if (archiveUrl == null) continue;
+
+      try {
+        final request = http.Request('GET', Uri.parse(archiveUrl));
+        final response = await client.send(request);
+
+        if (response.statusCode != 200) {
+          failedVersions++;
+          continue;
+        }
+
+        final tarStream = response.stream.transform(gzip.decoder);
+        final reader = TarReader(tarStream);
+
+        try {
+          while (await reader.moveNext()) {
+            final entry = reader.current;
+            if (entry.type == TypeFlag.reg &&
+                (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml'))) {
+              final bytesBuilder = BytesBuilder();
+              await for (final chunk in entry.contents) {
+                bytesBuilder.add(chunk);
+              }
+              final bytes = bytesBuilder.takeBytes();
+
+              final fileHash = base64Encode(sha256.convert(bytes).bytes);
+
+              if (!seenHashes.contains(fileHash)) {
+                seenHashes.add(fileHash);
+                final contentString = utf8.decode(bytes, allowMalformed: true);
+
+                final jsonLine = jsonEncode({
+                  'package': package,
+                  'version': version,
+                  'file': entry.name,
+                  'contents': contentString,
+                });
+                results.add(jsonLine);
+                uniqueYamlFiles++;
+              }
+            }
+          }
+        } finally {
+          await reader.cancel();
+        }
+        fetchedVersions++;
+      } catch (e) {
+        failedVersions++;
+      }
+    }
+  } finally {
+    client.close();
+  }
+
+  final outFile = File(outPath);
+  if (results.isNotEmpty) {
+    final gzipBytes = gzip.encode(utf8.encode('${results.join('\n')}\n'));
+    await outFile.writeAsBytes(gzipBytes);
+  } else {
+    await outFile.writeAsBytes(gzip.encode([]));
+  }
+
+  return (
+    fetchedVersions: fetchedVersions,
+    failedVersions: failedVersions,
+    uniqueYamlFiles: uniqueYamlFiles,
+    failedVersionListing: failedVersionListing,
+  );
+}


### PR DESCRIPTION
Adds a set of tools in `tool/pub-validation/` to test `package:yaml` changes against the entire pub.dev ecosystem (1M+ YAML files) to ensure zero unintended regressions.

*   `fetch_yamls_from_pub_dev.dart`: Downloads and compresses all YAML files from pub.dev packages into a local dataset.
*   `compare_parsers.dart`: Cross-compiles the parser on your current branch against `main`, streams the dataset concurrently to both, and diffs the AST outputs at high speed.
*   `_jsonl_bulk_parser.dart`: The standalone test binary that parses the YAML and converts it into strict JSON for comparison.


