### PR TITLE
Add 'AiAgent.detectAgentNames' to return a set of all matched agents

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 8.0.16-wip
+## 8.0.16
 
+- Added `AiAgent.detectAgentNames` to return the `Set<String>` of all matched agents.
 - Run `dart format`.
 
 ## 8.0.15

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -427,7 +427,7 @@ class AnalyticsImpl implements Analytics {
          ),
          locale: io.Platform.localeName,
          clientIde: clientIde,
-         aiAgent: agent != null ? truncateStringToLength(agent, 36) : null,
+         aiAgent: truncateJoinedString(agent, ',', 36),
        ),
        _enabledFeatures = enabledFeatures,
        _configHandler = ConfigHandler(

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '8.0.16-wip';
+const String kPackageVersion = '8.0.16';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -373,7 +373,9 @@ enum AiAgent {
       if (agent == '1') {
         agents.add(genericAiAgentLabel);
       } else {
-        agents.addAll(agent.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty));
+        agents.addAll(
+          agent.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty),
+        );
       }
     }
     final aiAgent = environment['AI_AGENT'];
@@ -381,7 +383,9 @@ enum AiAgent {
       if (aiAgent == '1') {
         agents.add(genericAiAgentLabel);
       } else {
-        agents.addAll(aiAgent.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty));
+        agents.addAll(
+          aiAgent.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty),
+        );
       }
     }
     if (environment.containsKey('SWE_AGENT')) {

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -370,11 +370,19 @@ enum AiAgent {
 
     final agent = environment['AGENT'];
     if (agent != null && agent.isNotEmpty) {
-      agents.add(agent == '1' ? genericAiAgentLabel : agent);
+      if (agent == '1') {
+        agents.add(genericAiAgentLabel);
+      } else {
+        agents.addAll(agent.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty));
+      }
     }
     final aiAgent = environment['AI_AGENT'];
     if (aiAgent != null && aiAgent.isNotEmpty) {
-      agents.add(aiAgent == '1' ? genericAiAgentLabel : aiAgent);
+      if (aiAgent == '1') {
+        agents.add(genericAiAgentLabel);
+      } else {
+        agents.addAll(aiAgent.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty));
+      }
     }
     if (environment.containsKey('SWE_AGENT')) {
       agents.add(genericAiAgentLabel);

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -298,89 +298,100 @@ enum AiAgent {
 
   const AiAgent(this.label);
 
-  /// Returns the name of the AI agent executing the tool, if any,
+  /// Returns a set of the names of the AI agents executing the tool, if any,
   /// by parsing the environment variables.
-  ///
-  /// Returns `null` if no AI agent is detected.
-  static String? detectAgentName(Map<String, String> environment) {
+  static Set<String> detectAgentNames(Map<String, String> environment) {
+    final agents = <String>{};
     const genericAiAgentLabel = 'Generic AI Agent';
 
     if (environment.containsKey('CLAUDECODE') ||
         environment.containsKey('CLAUDE_CODE') ||
         environment.containsKey('CLAUDE_CODE_IS_COWORK')) {
-      return claudeCode.label;
+      agents.add(claudeCode.label);
     }
 
     if (environment.containsKey('ANTIGRAVITY_AGENT')) {
-      return antigravity.label;
+      agents.add(antigravity.label);
     }
 
     if (environment.containsKey('GEMINI_AGENT') ||
         environment.containsKey('GEMINI_CLI')) {
-      return gemini.label;
+      agents.add(gemini.label);
     }
 
     if (environment['TERM_PROGRAM'] == 'cursor' ||
         environment.keys.any((String key) => key.startsWith('CURSOR_'))) {
-      return cursor.label;
+      agents.add(cursor.label);
     }
 
     if (environment.keys.any(
       (String key) =>
           key.startsWith('COPILOT_') || key.startsWith('GITHUB_COPILOT'),
     )) {
-      return copilot.label;
+      agents.add(copilot.label);
     }
 
     if (environment.containsKey('AIDER') ||
         environment.keys.any((String key) => key.startsWith('AIDER_'))) {
-      return aider.label;
+      agents.add(aider.label);
     }
 
     if (environment.containsKey('DEVIN') ||
         environment.containsKey('DEVIN_WORKSPACE_ID')) {
-      return devin.label;
+      agents.add(devin.label);
     }
 
     if (environment.containsKey('AMP_CURRENT_THREAD_ID')) {
-      return amp.label;
+      agents.add(amp.label);
     }
 
     if (environment.containsKey('AUGMENT_AGENT')) {
-      return augment.label;
+      agents.add(augment.label);
     }
 
     if (environment.containsKey('CODEX_CI') ||
         environment.containsKey('CODEX_SANDBOX') ||
         environment.containsKey('CODEX_THREAD_ID')) {
-      return codex.label;
+      agents.add(codex.label);
     }
 
     if (environment.containsKey('OPENCODE') ||
         environment.containsKey('OPENCODE_CLIENT')) {
-      return openCode.label;
+      agents.add(openCode.label);
     }
 
     if (environment.containsKey('PI_CODING_AGENT')) {
-      return pi.label;
+      agents.add(pi.label);
     }
 
     if (environment.containsKey('REPL_ID')) {
-      return replit.label;
+      agents.add(replit.label);
     }
 
-    var agent = environment['AGENT'];
+    final agent = environment['AGENT'];
     if (agent != null && agent.isNotEmpty) {
-      return agent == '1' ? genericAiAgentLabel : agent;
+      agents.add(agent == '1' ? genericAiAgentLabel : agent);
     }
-    agent = environment['AI_AGENT'];
-    if (agent != null && agent.isNotEmpty) {
-      return agent == '1' ? genericAiAgentLabel : agent;
+    final aiAgent = environment['AI_AGENT'];
+    if (aiAgent != null && aiAgent.isNotEmpty) {
+      agents.add(aiAgent == '1' ? genericAiAgentLabel : aiAgent);
     }
     if (environment.containsKey('SWE_AGENT')) {
-      return genericAiAgentLabel;
+      agents.add(genericAiAgentLabel);
     }
 
-    return null;
+    return agents;
+  }
+
+  /// Returns the name of the AI agent executing the tool, if any,
+  /// by parsing the environment variables.
+  ///
+  /// Returns `null` if no AI agent is detected.
+  ///
+  /// If multiple AI agents are detected, they are returned as a
+  /// comma-separated string.
+  static String? detectAgentName(Map<String, String> environment) {
+    final agents = detectAgentNames(environment);
+    return agents.isEmpty ? null : agents.join(',');
   }
 }

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -346,6 +346,30 @@ String truncateStringToLength(String str, int maxLength) {
   return str.substring(0, maxLength);
 }
 
+/// Truncates a joined [input] string (separated by [separator]) to a
+/// maximum length by discarding entire elements from the end if they would
+/// exceed [maxLength].
+///
+/// If even the first element exceeds [maxLength], it will be truncated.
+String? truncateJoinedString(String? input, String separator, int maxLength) {
+  if (input == null || input.isEmpty) return null;
+
+  final elements = input.split(separator);
+  final result = <String>[];
+
+  for (final element in elements) {
+    final candidate = <String>[...result, element].join(separator);
+    if (candidate.length > maxLength) break;
+    result.add(element);
+  }
+
+  // Fallback to truncating the first element if even it didn't fit.
+  if (result.isEmpty) {
+    return truncateStringToLength(elements.first, maxLength);
+  }
+  return result.join(separator);
+}
+
 /// Writes the JSON string payload to the provided [sessionFile].
 ///
 /// The `last_ping` key:value pair has been deprecated, it remains included

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 8.0.16-wip
+version: 8.0.16
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aunified_analytics

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -1032,6 +1032,12 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
         }),
         <String>{'Claude Code', 'Copilot', 'MyCustomAgent'},
       );
+      expect(
+        AiAgent.detectAgentNames(<String, String>{
+          'AGENT': ' Aider , Cursor , Aider ',
+        }),
+        <String>{'Aider', 'Cursor'},
+      );
     },
   );
 

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -882,6 +882,36 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     },
   );
 
+  test(
+    'The UserProperty class truncates the ai_agent list by discarding entire agent strings from the end if they exceed 36 characters',
+    () {
+      // "Aider" (5), "Antigravity" (11), "Claude Code" (11), "Generic AI Agent" (16)
+      // "Aider,Antigravity,Claude Code" -> 5 + 1 + 11 + 1 + 11 = 29 chars
+      // Adding "Generic AI Agent" would make it 29 + 1 + 16 = 46 chars, which exceeds 36.
+      // So "Generic AI Agent" should be discarded completely, resulting in "Aider,Antigravity,Claude Code".
+      final longListAnalytics = Analytics.fake(
+        tool: initialTool,
+        homeDirectory: home,
+        flutterChannel: flutterChannel,
+        toolsMessageVersion: toolsMessageVersion,
+        toolsMessage: toolsMessage,
+        flutterVersion: flutterVersion,
+        dartVersion: dartVersion,
+        fs: fs,
+        platform: platform,
+        clientIde: 'CursorIDE',
+        agent: 'Aider,Antigravity,Claude Code,Generic AI Agent',
+      );
+
+      expect(
+        longListAnalytics.userPropertyMap['ai_agent']?['value'],
+        'Aider,Antigravity,Claude Code',
+        reason:
+            'The ai_agent user property should omit Generic AI Agent to fit within 36 characters',
+      );
+    },
+  );
+
   test('AiAgent.detectAgentName detects AI agents based on environment', () {
     expect(AiAgent.detectAgentName(<String, String>{}), isNull);
 
@@ -973,7 +1003,37 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       AiAgent.detectAgentName(<String, String>{'AI_AGENT': 'MyCustomAgent'}),
       'MyCustomAgent',
     );
+
+    // Multiple agents detected (comma separated)
+    expect(
+      AiAgent.detectAgentName(<String, String>{
+        'CLAUDECODE': '1',
+        'GITHUB_COPILOT': '1',
+        'AGENT': 'MyCustomAgent',
+      }),
+      'Claude Code,Copilot,MyCustomAgent',
+    );
   });
+
+  test(
+    'AiAgent.detectAgentNames detects multiple AI agents based on environment',
+    () {
+      expect(AiAgent.detectAgentNames(<String, String>{}), isEmpty);
+
+      expect(
+        AiAgent.detectAgentNames(<String, String>{'CLAUDECODE': '1'}),
+        <String>{'Claude Code'},
+      );
+      expect(
+        AiAgent.detectAgentNames(<String, String>{
+          'CLAUDECODE': '1',
+          'GITHUB_COPILOT': '1',
+          'AGENT': 'MyCustomAgent',
+        }),
+        <String>{'Claude Code', 'Copilot', 'MyCustomAgent'},
+      );
+    },
+  );
 
   test('The minimum session duration should be at least 30 minutes', () {
     expect(
@@ -1717,6 +1777,36 @@ Privacy Policy (https://policies.google.com/privacy).
 
     expect(eventList.contains(eventToMatch), true);
     expect(eventList.where((element) => element == eventToMatch).length, 1);
+  });
+
+  group('Unit tests for util truncateJoinedString', () {
+    test('returns null for null or empty input', () {
+      expect(truncateJoinedString(null, ',', 10), isNull);
+      expect(truncateJoinedString('', ',', 10), isNull);
+    });
+
+    test('returns whole elements if they fit', () {
+      expect(truncateJoinedString('one,two,three', ',', 15), 'one,two,three');
+    });
+
+    test('omits elements from the end that exceed maxLength', () {
+      // 'one,two' is 7 chars.
+      // 'one,two,three' is 13 chars.
+      // With maxLength 10, 'three' should be omitted completely, returning 'one,two'.
+      expect(truncateJoinedString('one,two,three', ',', 10), 'one,two');
+    });
+
+    test('truncates the first element if it is longer than maxLength', () {
+      expect(
+        truncateJoinedString('extremely_long_element', ',', 10),
+        'extremely_',
+      );
+    });
+
+    test('works with different separators', () {
+      expect(truncateJoinedString('one;two;three', ';', 10), 'one;two');
+      expect(truncateJoinedString('one two three', ' ', 10), 'one two');
+    });
   });
 
   group('Unit tests for util dartSDKVersion', () {


### PR DESCRIPTION
Follow up to comment https://github.com/dart-lang/tools/pull/2423#discussion_r3373855915 to add multi-agent detection.

Note GA4 user_properties don't support lists as map values, so it needs to be a comma-delineated string. We can split it apart on the query side. This happily also prevents a breaking change.

Truncate the agent string to 36 characters by removing full agent names, instead of truncating in the middle of the name.

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
