### PR TITLE
Change owner of `unified_analytics` to `analyzer-team`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@ pkgs/string_scanner             @dart-lang/dart-ecosystem-team
 pkgs/term_glyph                 @dart-lang/dart-bat
 pkgs/test_reflective_loader     @scheglov
 pkgs/timing                     @dart-lang/dart-bat
-pkgs/unified_analytics          @bkonyi @dart-lang/dash-developer-services
+pkgs/unified_analytics          @dart-lang/analyzer-team
 pkgs/watcher                    @davidmorgan @dart-lang/dart-model-team
 pkgs/yaml                       @dart-lang/dart-pub-team
 pkgs/yaml_edit                  @dart-lang/dart-pub-team


### PR DESCRIPTION
Updated `CODEOWNERS` to change ownership of `unified_analytics` to the Dash DevExp team.