### PR TITLE
[browser_launcher] Add `additionalArguments` for Chrome

### DIFF
--- a/pkgs/browser_launcher/CHANGELOG.md
+++ b/pkgs/browser_launcher/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `--test-type` and `--disable-session-crashed-bubble` flags when launching
   chrome to prevent some warnings.
+- Allow passing arbitrary command line arguments when starting Chrome.
 
 ## 1.1.3
 

--- a/pkgs/browser_launcher/lib/src/chrome.dart
+++ b/pkgs/browser_launcher/lib/src/chrome.dart
@@ -80,12 +80,16 @@ class Chrome {
   /// as a user data directory. Chrome will start signed into
   /// the default profile with extensions enabled if [signIn]
   /// is also true.
+  ///
+  /// When launging, all [additionalArguments] will be passed directly to Chrome
+  /// as command line arguments.
   static Future<Chrome> startWithDebugPort(
     List<String> urls, {
     int debugPort = 0,
     bool headless = false,
     String? userDataDir,
     bool signIn = false,
+    List<String> additionalArguments = const [],
   }) async {
     Directory dataDir;
     if (userDataDir == null) {
@@ -124,6 +128,7 @@ class Chrome {
       // Dev runs of the browser should be considered independent of one
       // another, don't announce when the previous session crashed.
       '--disable-session-crashed-bubble',
+      ...additionalArguments,
     ];
     if (headless) {
       args.add('--headless');

--- a/pkgs/browser_launcher/lib/src/chrome.dart
+++ b/pkgs/browser_launcher/lib/src/chrome.dart
@@ -81,8 +81,8 @@ class Chrome {
   /// the default profile with extensions enabled if [signIn]
   /// is also true.
   ///
-  /// When launging, all [additionalArguments] will be passed directly to Chrome
-  /// as command line arguments.
+  /// When launching, all [additionalArguments] will be passed directly to
+  /// Chrome as command line arguments.
   static Future<Chrome> startWithDebugPort(
     List<String> urls, {
     int debugPort = 0,

--- a/pkgs/browser_launcher/test/chrome_test.dart
+++ b/pkgs/browser_launcher/test/chrome_test.dart
@@ -54,6 +54,7 @@ void main() {
     String? userDataDir,
     bool signIn = false,
     bool headless = false,
+    List<String> additionalArguments = const [],
   }) async {
     chrome = await Chrome.startWithDebugPort(
       [_googleUrl],
@@ -61,6 +62,7 @@ void main() {
       userDataDir: userDataDir,
       signIn: signIn,
       headless: headless,
+      additionalArguments: additionalArguments,
     );
   }
 
@@ -89,6 +91,21 @@ void main() {
         test('can launch chrome with debug port', () async {
           await launchChromeWithDebugPort(headless: headless);
           expect(chrome, isNotNull);
+        });
+
+        test('can launch with additional arguments', () async {
+          await launchChromeWithDebugPort(
+            headless: headless,
+            additionalArguments: ['--user-agent=CustomTestAgent'],
+          );
+          expect(chrome, isNotNull);
+          // Validate that the additional argument was applied.
+          final wipConnection = await connectToTab(_googleUrl);
+          await wipConnection.debugger.enable();
+          await wipConnection.runtime.enable();
+          final userAgent =
+              await _evaluate(wipConnection.page, 'navigator.userAgent');
+          expect(userAgent, contains('CustomTestAgent'));
         });
 
         test('has a working debugger', () async {


### PR DESCRIPTION
Allows passing arbitrary command line arguments when starting Chrome.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
