### PR TITLE
add an event type for events coming from package:skills

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 8.0.16-wip
+## 8.0.16
 
+- Added `Event.packageSkillsEvent` to track events from package:skills.
 - Run `dart format`.
 
 ## 8.0.15
@@ -15,7 +16,7 @@
 
 ## 8.0.12
 - Require Dart 3.10
-- Added `success` indicator and `label` to `Event.flutterTrackAndroidDependencies` 
+- Added `success` indicator and `label` to `Event.flutterTrackAndroidDependencies`
 
 ## 8.0.11
 - Added `Event.flutterTrackAndroidDependencies` to track android dependencies.

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '8.0.16-wip';
+const String kPackageVersion = '8.0.16';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/enums.dart
+++ b/pkgs/unified_analytics/lib/src/enums.dart
@@ -66,6 +66,10 @@ enum DashEvent {
     description: 'Information for a Dart MCP server event',
     toolOwner: DashTool.dartTool,
   ),
+  packageSkillsEvent(
+    label: 'package_skills',
+    description: 'Information for a package:skills event',
+  ),
 
   // Events for Flutter devtools
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -1105,6 +1105,28 @@ final class Event {
          },
        );
 
+  /// An event that is sent from package:skills.
+  ///
+  /// The [version] is the version of the skills package.
+  ///
+  /// The [type] identifies the kind of event this is, and [additionalData] is
+  /// the actual data for the event.
+  ///
+  /// See https://github.com/dart-lang/ai/tree/main/pkgs/skills for the actual
+  /// events sent by this package.
+  Event.packageSkillsEvent({
+    required String version,
+    required String type,
+    CustomMetrics? additionalData,
+  }) : this._(
+         eventName: DashEvent.packageSkillsEvent,
+         eventData: {
+           'version': version,
+           'type': type,
+           ...?additionalData?.toMap(),
+         },
+       );
+
   @override
   int get hashCode => Object.hash(eventName, jsonEncode(eventData));
 

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 8.0.16-wip
+version: 8.0.16
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aunified_analytics

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -955,7 +955,7 @@ void main() {
 
     // Change this integer below if your PR either adds or removes
     // an Event constructor
-    final eventsAccountedForInTests = 34;
+    final eventsAccountedForInTests = 35;
     expect(
       eventsAccountedForInTests,
       constructorCount,

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -921,6 +921,28 @@ void main() {
     );
   });
 
+  test('Event.packageSkillsEvent constructed', () {
+    final event = Event.packageSkillsEvent(
+      version: '1.1.1',
+      type: 'some_event',
+      additionalData: _TestMetrics(
+        boolField: true,
+        stringField: 'hello',
+        intField: 1,
+      ),
+    );
+    expect(
+      event.eventData,
+      equals({
+        'version': '1.1.1',
+        'type': 'some_event',
+        'boolField': true,
+        'stringField': 'hello',
+        'intField': 1,
+      }),
+    );
+  });
+
   test('Confirm all constructors were checked', () {
     var constructorCount = 0;
     for (final declaration in reflectClass(Event).declarations.keys) {


### PR DESCRIPTION
Adds a custom event type for events coming from package:skills.

First part of https://github.com/dart-lang/ai/issues/467.