### PR TITLE
Use -- to separate chrome URLs

### DIFF
--- a/pkgs/browser_launcher/CHANGELOG.md
+++ b/pkgs/browser_launcher/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `--test-type` and `--disable-session-crashed-bubble` flags when launching
   chrome to prevent some warnings.
 - Allow passing arbitrary command line arguments when starting Chrome.
+- Separate CLI arguments from URLs with a `--` when launching Chrome.
 
 ## 1.1.3
 

--- a/pkgs/browser_launcher/lib/src/chrome.dart
+++ b/pkgs/browser_launcher/lib/src/chrome.dart
@@ -178,7 +178,7 @@ class Chrome {
     List<String> urls, {
     List<String> args = const [],
   }) =>
-      Process.start(_executable, [...args, '--', ...urls]);
+      Process.start(_executable, [...args, if (urls.isNotEmpty) '--', ...urls]);
 
   static Future<Chrome> _connect(Chrome chrome) async {
     // The connection is lazy. Try a simple call to make sure the provided

--- a/pkgs/browser_launcher/lib/src/chrome.dart
+++ b/pkgs/browser_launcher/lib/src/chrome.dart
@@ -177,8 +177,11 @@ class Chrome {
   static Future<Process> start(
     List<String> urls, {
     List<String> args = const [],
-  }) =>
-      Process.start(_executable, [...args, if (urls.isNotEmpty) '--', ...urls]);
+  }) {
+    assert(!args.contains('--'));
+    assert(!urls.contains('--'));
+    return Process.start(_executable, [...args, '--', ...urls]);
+  }
 
   static Future<Chrome> _connect(Chrome chrome) async {
     // The connection is lazy. Try a simple call to make sure the provided

--- a/pkgs/browser_launcher/lib/src/chrome.dart
+++ b/pkgs/browser_launcher/lib/src/chrome.dart
@@ -134,7 +134,7 @@ class Chrome {
       args.add('--headless');
     }
 
-    final process = await _startProcess(urls, args: args);
+    final process = await start(urls, args: args);
 
     // Wait until the DevTools are listening before trying to connect.
     final errorLines = <String>[];
@@ -177,16 +177,8 @@ class Chrome {
   static Future<Process> start(
     List<String> urls, {
     List<String> args = const [],
-  }) async =>
-      await _startProcess(urls, args: args);
-
-  static Future<Process> _startProcess(
-    List<String> urls, {
-    List<String> args = const [],
-  }) async {
-    final processArgs = args.toList()..addAll(urls);
-    return await Process.start(_executable, processArgs);
-  }
+  }) =>
+      Process.start(_executable, [...args, '--', ...urls]);
 
   static Future<Chrome> _connect(Chrome chrome) async {
     // The connection is lazy. Try a simple call to make sure the provided

--- a/pkgs/browser_launcher/lib/src/chrome.dart
+++ b/pkgs/browser_launcher/lib/src/chrome.dart
@@ -129,10 +129,8 @@ class Chrome {
       // another, don't announce when the previous session crashed.
       '--disable-session-crashed-bubble',
       ...additionalArguments,
+      if (headless) '--headless',
     ];
-    if (headless) {
-      args.add('--headless');
-    }
 
     final process = await start(urls, args: args);
 


### PR DESCRIPTION
If any URLs are passed with leading `--` characters they may be
interpreted as arguments instead. Any arguments which follow a bare `--`
are explicitly treated as URLs not arguments. Avoid the need for callers
to sanitize arguments with this explicit divider.

Drop an unnecessary private implementation since it's small enough for a
direct public implementation that's as small as the forwarder anyway.

BUG=b/536185918
