### PR TITLE
Parse hosted URLs as URLs

### DIFF
--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.6.0-wip
 
 - Added `toJson` method to `Pubspec` to serialize the object back to a `Map`.
+- Parse `HostedDetails.url` as a non-git URI.
 - Require Dart 3.8
 - Fix analysis issues caused by new lints.
 

--- a/pkgs/pubspec_parse/lib/src/dependency.dart
+++ b/pkgs/pubspec_parse/lib/src/dependency.dart
@@ -164,8 +164,7 @@ class GitDependency extends Dependency {
   };
 }
 
-Uri? _parseUriOrNull(String? value) =>
-    value == null ? null : Uri.parse(value);
+Uri? _parseUriOrNull(String? value) => value == null ? null : Uri.parse(value);
 
 Uri parseGitUri(String value) => _tryParseScpUri(value) ?? Uri.parse(value);
 

--- a/pkgs/pubspec_parse/lib/src/dependency.dart
+++ b/pkgs/pubspec_parse/lib/src/dependency.dart
@@ -164,8 +164,8 @@ class GitDependency extends Dependency {
   };
 }
 
-Uri? parseGitUriOrNull(String? value) =>
-    value == null ? null : parseGitUri(value);
+Uri? _parseUriOrNull(String? value) =>
+    value == null ? null : Uri.parse(value);
 
 Uri parseGitUri(String value) => _tryParseScpUri(value) ?? Uri.parse(value);
 
@@ -265,7 +265,7 @@ class HostedDetails {
   @JsonKey(name: 'name')
   final String? declaredName;
 
-  @JsonKey(fromJson: parseGitUriOrNull, disallowNullValue: true)
+  @JsonKey(fromJson: _parseUriOrNull, disallowNullValue: true)
   final Uri? url;
 
   @JsonKey(includeFromJson: false, includeToJson: false)

--- a/pkgs/pubspec_parse/lib/src/dependency.g.dart
+++ b/pkgs/pubspec_parse/lib/src/dependency.g.dart
@@ -59,7 +59,7 @@ HostedDetails _$HostedDetailsFromJson(Map json) =>
       );
       final val = HostedDetails(
         $checkedConvert('name', (v) => v as String?),
-        $checkedConvert('url', (v) => parseGitUriOrNull(v as String?)),
+        $checkedConvert('url', (v) => _parseUriOrNull(v as String?)),
       );
       return val;
     }, fieldKeyMap: const {'declaredName': 'name'});

--- a/pkgs/pubspec_parse/test/dependency_test.dart
+++ b/pkgs/pubspec_parse/test/dependency_test.dart
@@ -126,6 +126,18 @@ line 4, column 10: Unsupported value for "dep". Could not parse version "not a v
     expect(dep.toString(), 'HostedDependency: ^1.0.0');
   });
 
+  test('map w/ hosted url parsed as non-git URI', () async {
+    final dep = await _dependency<HostedDependency>(
+      {
+        'version': '^1.0.0',
+        'hosted': {'name': 'hosted_name', 'url': 'pub.example.com:8080'},
+      },
+      skipTryPub: true,
+    );
+    expect(dep.hosted!.url, Uri.parse('pub.example.com:8080'));
+    expect(dep.hosted!.url!.scheme, 'pub.example.com');
+  });
+
   test('map w/ bad version value', () {
     _expectThrows(
       {

--- a/pkgs/pubspec_parse/test/dependency_test.dart
+++ b/pkgs/pubspec_parse/test/dependency_test.dart
@@ -127,13 +127,10 @@ line 4, column 10: Unsupported value for "dep". Could not parse version "not a v
   });
 
   test('map w/ hosted url parsed as non-git URI', () async {
-    final dep = await _dependency<HostedDependency>(
-      {
-        'version': '^1.0.0',
-        'hosted': {'name': 'hosted_name', 'url': 'pub.example.com:8080'},
-      },
-      skipTryPub: true,
-    );
+    final dep = await _dependency<HostedDependency>({
+      'version': '^1.0.0',
+      'hosted': {'name': 'hosted_name', 'url': 'pub.example.com:8080'},
+    }, skipTryPub: true);
     expect(dep.hosted!.url, Uri.parse('pub.example.com:8080'));
     expect(dep.hosted!.url!.scheme, 'pub.example.com');
   });


### PR DESCRIPTION
Fix a bug where a "hosted" pub dependency URL is parsed as a Git URL
which can have observable effects when the URL has no scheme and gets
filled in with an `ssh` scheme. Typically this won't surface because
pubspec with hosted details will use full form URLs with a scheme.
