### PR TITLE
[glob] Limit expansion during option flattening

### DIFF
--- a/pkgs/glob/CHANGELOG.md
+++ b/pkgs/glob/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.4-wip
+
+- Limit option expansion during glob listing (`list()` and `listSync()`) to a
+  maximum of 10,000 branches. Globs with combinatorial option expansions
+  exceeding 10,000 will now throw a `FormatException` to prevent out-of-memory
+  exhaustion. `Glob.matches()` uses regular expressions and is unaffected.
+
 ## 2.1.3
 
 - Require Dart 3.3.

--- a/pkgs/glob/lib/src/ast.dart
+++ b/pkgs/glob/lib/src/ast.dart
@@ -56,6 +56,21 @@ class SequenceNode extends AstNode {
   /// The nodes in the sequence.
   final List<AstNode> nodes;
 
+  /// The maximum number of branches that [flattenOptions] will materialize.
+  ///
+  /// Each `{a,b}` group multiplies the number of expanded sequences, so a
+  /// pattern like `{a,b}{a,b}...` produces `2^k` [SequenceNode]s. Bounding the
+  /// product prevents tiny hostile patterns from exhausting memory when the
+  /// glob is listed.
+  static const _maxFlattenedOptions = 10000;
+
+  static void _checkFlattenedSize(int product) {
+    if (product > _maxFlattenedOptions) {
+      throw const FormatException(
+          'Glob pattern expands to more than $_maxFlattenedOptions options');
+    }
+  }
+
   @override
   bool get canMatchAbsolute => nodes.first.canMatchAbsolute;
 
@@ -72,12 +87,16 @@ class SequenceNode extends AstNode {
       return OptionsNode([this], caseSensitive: caseSensitive);
     }
 
-    var sequences =
-        nodes.first.flattenOptions().options.map((sequence) => sequence.nodes);
+    var firstOptions = nodes.first.flattenOptions().options;
+    var product = firstOptions.length;
+    _checkFlattenedSize(product);
+    var sequences = firstOptions.map((sequence) => sequence.nodes);
     for (var node in nodes.skip(1)) {
       // Concatenate all sequences in the next options node ([nextSequences])
       // onto all previous sequences ([sequences]).
       var nextSequences = node.flattenOptions().options;
+      product *= nextSequences.length;
+      _checkFlattenedSize(product);
       sequences = sequences.expand((sequence) {
         return nextSequences.map((nextSequence) {
           return sequence.toList()..addAll(nextSequence.nodes);

--- a/pkgs/glob/lib/src/ast.dart
+++ b/pkgs/glob/lib/src/ast.dart
@@ -64,10 +64,11 @@ class SequenceNode extends AstNode {
   /// glob is listed.
   static const _maxFlattenedOptions = 10000;
 
-  static void _checkFlattenedSize(int product) {
+  void _checkFlattenedSize(int product) {
     if (product > _maxFlattenedOptions) {
-      throw const FormatException(
-          'Glob pattern expands to more than $_maxFlattenedOptions options');
+      throw FormatException(
+          'Glob pattern expands to more than $_maxFlattenedOptions options',
+          toString());
     }
   }
 

--- a/pkgs/glob/pubspec.yaml
+++ b/pkgs/glob/pubspec.yaml
@@ -1,5 +1,5 @@
 name: glob
-version: 2.1.3
+version: 2.1.4-wip
 description: A library to perform Bash-style file and directory globbing.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/glob
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aglob

--- a/pkgs/glob/test/list_test.dart
+++ b/pkgs/glob/test/list_test.dart
@@ -314,6 +314,12 @@ void main() {
             equals([p.join('foo', 'baz', 'qux')]));
       });
     });
+
+    group('options expansion limit', () {
+      test('throws FormatException when options expansion exceeds limit', () {
+        expect(() => list('{a,b}' * 14), throwsFormatException);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Bounded the number of option branches materialized in
`SequenceNode.flattenOptions()` to 10,000. Throw a FormatException if an
option product exceeds this limit to prevent unbounded memory allocation
and OOM crashes when listing globs with combinatorial options.

BUG=b/528621962
