### PR TITLE
[markdown] Do not double-encode percent-encoded sequences in autolinks

### DIFF
--- a/pkgs/markdown/CHANGELOG.md
+++ b/pkgs/markdown/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Optimize email autolink regex parsing in `AutolinkExtensionSyntax` by bounding
   quantifiers to RFC limits, improving performance on inputs with long sequences
   of dots or alphanumeric characters.
+* Fix `AutolinkExtensionSyntax` double-encoding percent-encoded sequences in
+  the destination, for example `https://example.com/%40foo` no longer turns
+  into `https://example.com/%2540foo`.
 
 ## 7.3.1
 

--- a/pkgs/markdown/lib/src/inline_syntaxes/autolink_extension_syntax.dart
+++ b/pkgs/markdown/lib/src/inline_syntaxes/autolink_extension_syntax.dart
@@ -101,7 +101,7 @@ class AutolinkExtensionSyntax extends InlineSyntax {
     }
 
     final anchor = Element.text('a', text)
-      ..attributes['href'] = Uri.encodeFull(destination);
+      ..attributes['href'] = _encodeDestination(destination);
 
     parser
       ..addNode(anchor)
@@ -109,6 +109,21 @@ class AutolinkExtensionSyntax extends InlineSyntax {
 
     return true;
   }
+
+  static final _percentEncodedSequences = RegExp('%[0-9A-Fa-f]{2}');
+
+  /// Percent-encodes [destination], preserving pre-existing percent-encoded
+  /// sequences so that they do not get encoded a second time, for example a
+  /// destination containing `%40` keeps it instead of producing `%2540`.
+  ///
+  /// This matches how [normalizeLinkDestination] treats the destination of
+  /// inline links, see https://spec.commonmark.org/0.30/#example-502.
+  static String _encodeDestination(String destination) =>
+      destination.splitMapJoin(
+        _percentEncodedSequences,
+        onMatch: (match) => match.match,
+        onNonMatch: Uri.encodeFull,
+      );
 
   int _getConsumeLength(String text) {
     var excludedLength = 0;

--- a/pkgs/markdown/test/extensions/autolink_extension.unit
+++ b/pkgs/markdown/test/extensions/autolink_extension.unit
@@ -8,3 +8,15 @@ http://www.foo.com
 <<<
 <p>m
 <a href="http://www.foo.com">http://www.foo.com</a></p>
+>>> percent-encoded characters are not double-encoded
+http://example.com/%40foo
+<<<
+<p><a href="http://example.com/%40foo">http://example.com/%40foo</a></p>
+>>> characters requiring encoding are percent-encoded
+http://example.com/fü
+<<<
+<p><a href="http://example.com/f%C3%BC">http://example.com/fü</a></p>
+>>> invalid percent-encoding is still percent-encoded
+http://example.com/50%off
+<<<
+<p><a href="http://example.com/50%25off">http://example.com/50%off</a></p>


### PR DESCRIPTION
Fixes #2479

`AutolinkExtensionSyntax` built the `href` with `Uri.encodeFull`, which escapes `%` itself, so an already percent-encoded destination like `https://example.com/%40foo` became `https://example.com/%2540foo`.

This PR preserves pre-existing `%XX` sequences and percent-encodes only the rest, matching how `normalizeLinkDestination` treats inline link destinations (https://spec.commonmark.org/0.30/#example-502). Note it deliberately does not reuse `normalizeLinkDestination` itself, since that would additionally decode HTML character references and change behavior for destinations containing e.g. `&amp;`.

- Added three cases to `test/extensions/autolink_extension.unit` (pre-encoded sequences preserved, non-ASCII characters still encoded, invalid `%` still escaped to `%25`)
- Added a CHANGELOG entry under the unreleased 7.4.0 section
