### PR TITLE
source_maps: check bounds earlier.

### DIFF
--- a/pkgs/source_maps/CHANGELOG.md
+++ b/pkgs/source_maps/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.10.14-wip
+## 0.10.14
 
 * Fix `SingleMapping.spanFor` to use the entry from a previous line as specified
   by the sourcemap specification
-  (https://tc39.es/ecma426/#sec-GetOriginalPositions),
+  (https://tc39.es/ecma426/#sec-GetOriginalPositions).
+* Throw `StateError` when parsing mappings with negative source URL or source name IDs.
 
 ## 0.10.13
 

--- a/pkgs/source_maps/lib/parser.dart
+++ b/pkgs/source_maps/lib/parser.dart
@@ -399,7 +399,7 @@ class SingleMapping extends Mapping {
         entries.add(TargetEntry(column));
       } else {
         srcUrlId += tokenizer._consumeValue();
-        if (srcUrlId >= urls.length) {
+        if (srcUrlId < 0 || srcUrlId >= urls.length) {
           throw StateError(
               'Invalid source url id. $targetUrl, $line, $srcUrlId');
         }
@@ -411,7 +411,7 @@ class SingleMapping extends Mapping {
           entries.add(TargetEntry(column, srcUrlId, srcLine, srcColumn));
         } else {
           srcNameId += tokenizer._consumeValue();
-          if (srcNameId >= names.length) {
+          if (srcNameId < 0 || srcNameId >= names.length) {
             throw StateError('Invalid name id: $targetUrl, $line, $srcNameId');
           }
           entries.add(

--- a/pkgs/source_maps/pubspec.yaml
+++ b/pkgs/source_maps/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_maps
-version: 0.10.14-wip
+version: 0.10.14
 description: A library to programmatically manipulate source map files.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/source_maps
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Asource_maps

--- a/pkgs/source_maps/test/parser_test.dart
+++ b/pkgs/source_maps/test/parser_test.dart
@@ -187,6 +187,28 @@ void main() {
         Uri.parse('file:///path/to/pkg/input.dart'));
   });
 
+  test('parse throws StateError on negative source url id', () {
+    expect(
+        () => parse(jsonEncode({
+              'version': 3,
+              'sources': ['a.dart'],
+              'names': ['x'],
+              'mappings': 'AAAAA,ADAAA'
+            })),
+        throwsA(isA<StateError>()));
+  });
+
+  test('parse throws StateError on negative source name id', () {
+    expect(
+        () => parse(jsonEncode({
+              'version': 3,
+              'sources': ['a.dart'],
+              'names': ['x'],
+              'mappings': 'AAAAA,AAAAD'
+            })),
+        throwsA(isA<StateError>()));
+  });
+
   group('parse with bundle', () {
     var mapping =
         parseJsonExtended(_sourceMapBundle, mapUrl: 'file:///path/to/map');


### PR DESCRIPTION
Fail earlier if a source map is invalid.

Prepare to release.