### PR TITLE
[test_reflective_loader] Ignore unreachable_from_main in test files

### DIFF
--- a/pkgs/test_reflective_loader/test/set_up_tear_down_test.data.dart
+++ b/pkgs/test_reflective_loader/test/set_up_tear_down_test.data.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unreachable_from_main
 
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';

--- a/pkgs/test_reflective_loader/test/test_reflective_loader_test.dart
+++ b/pkgs/test_reflective_loader/test/test_reflective_loader_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unreachable_from_main
 
 import 'dart:async';
 


### PR DESCRIPTION
Fixes `dart analyze --fatal-infos` failure on Dart 3.5 in CI: https://github.com/dart-lang/tools/actions/runs/30725753561/job/91437018521

In Dart 3.5, `unreachable_from_main` is reported for reflective test methods such as `setUpClass` and `tearDownClass` when a `main()` function is present in an executable library. Added `unreachable_from_main` to `ignore_for_file:` in `set_up_tear_down_test.data.dart` and `test_reflective_loader_test.dart`.

Created with AI