### PR TITLE
ci: pin unpinned GitHub Actions references to commit SHAs

### DIFF
--- a/.github/workflows/benchmark_harness.yaml
+++ b/.github/workflows/benchmark_harness.yaml
@@ -65,7 +65,7 @@ jobs:
           sdk: ${{ matrix.sdk }}
       # Node 22 has wasmGC enabled, which allows the wasm tests to run!
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
       - id: install

--- a/.github/workflows/benchmark_harness.yaml
+++ b/.github/workflows/benchmark_harness.yaml
@@ -1,5 +1,6 @@
 name: package:benchmark_harness
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/deploy_pages.yaml
+++ b/.github/workflows/deploy_pages.yaml
@@ -37,8 +37,8 @@ jobs:
       - run: cp -r pkgs/markdown/build _site/markdown
 
       # Deploy to GitHub Pages.
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: _site
-      - uses: actions/deploy-pages@v5
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,5 +1,6 @@
 name: package:markdown
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -98,7 +98,7 @@ jobs:
     - name: Collect and report coverage
       run: dart pub global run coverage:test_with_coverage
     - name: Upload coverage
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: pkgs/markdown/coverage/lcov.info

--- a/.github/workflows/pool.yaml
+++ b/.github/workflows/pool.yaml
@@ -63,7 +63,7 @@ jobs:
           sdk: ${{ matrix.sdk }}
       # Node 22 has wasmGC enabled, which allows the wasm tests to run!
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
       - id: install

--- a/.github/workflows/pool.yaml
+++ b/.github/workflows/pool.yaml
@@ -1,5 +1,6 @@
 name: package:pool
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.


### PR DESCRIPTION
Fixes `zizmor/unpinned-uses` warnings across CI workflows:
- `.github/workflows/pool.yaml#L66` (`actions/setup-node`)
- `.github/workflows/markdown.yaml#L101` (`coverallsapp/github-action`)
- `.github/workflows/deploy_pages.yaml#L40` (`actions/configure-pages`)
- `.github/workflows/deploy_pages.yaml#L41` (`actions/upload-pages-artifact`)
- `.github/workflows/deploy_pages.yaml#L44` (`actions/deploy-pages`)
- `.github/workflows/benchmark_harness.yaml#L68` (`actions/setup-node`)

Also narrows workflow permissions from `read-all` to `contents: read`:
- `.github/workflows/pool.yaml`
- `.github/workflows/benchmark_harness.yaml`
- `.github/workflows/markdown.yaml`