### PR TITLE
Replace permissions: read-all with permissions: contents: read in workflows

### DIFF
--- a/.github/workflows/api_summary.yaml
+++ b/.github/workflows/api_summary.yaml
@@ -1,5 +1,6 @@
 name: package:api_summary
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/api_summary.yaml
+++ b/.github/workflows/api_summary.yaml
@@ -31,6 +31,8 @@ jobs:
             check-formatting: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{matrix.sdk}}

--- a/.github/workflows/bazel_worker.yaml
+++ b/.github/workflows/bazel_worker.yaml
@@ -31,6 +31,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/bazel_worker.yaml
+++ b/.github/workflows/bazel_worker.yaml
@@ -1,5 +1,6 @@
 name: package:bazel_worker
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/benchmark_harness.yaml
+++ b/.github/workflows/benchmark_harness.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -61,6 +63,8 @@ jobs:
         sdk: ['3.10', dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/boolean_selector.yaml
+++ b/.github/workflows/boolean_selector.yaml
@@ -1,5 +1,6 @@
 name: package:boolean_selector
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/boolean_selector.yaml
+++ b/.github/workflows/boolean_selector.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -56,6 +58,8 @@ jobs:
         sdk: [3.1, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/browser_launcher.yaml
+++ b/.github/workflows/browser_launcher.yaml
@@ -1,5 +1,6 @@
 name: package:browser_launcher
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/browser_launcher.yaml
+++ b/.github/workflows/browser_launcher.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/cli_config.yaml
+++ b/.github/workflows/cli_config.yaml
@@ -30,6 +30,8 @@ jobs:
             run-tests: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{matrix.sdk}}
@@ -68,6 +70,8 @@ jobs:
             run-tests: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{matrix.sdk}}

--- a/.github/workflows/cli_config.yaml
+++ b/.github/workflows/cli_config.yaml
@@ -1,5 +1,6 @@
 name: package:cli_config
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/cli_util.yaml
+++ b/.github/workflows/cli_util.yaml
@@ -30,6 +30,8 @@ jobs:
         sdk: [dev]
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      with:
+        persist-credentials: false
     - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       with:
         sdk: ${{ matrix.sdk }}
@@ -53,6 +55,8 @@ jobs:
         sdk: ['3.7', dev]
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      with:
+        persist-credentials: false
     - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       with:
         sdk: ${{ matrix.sdk }}

--- a/.github/workflows/cli_util.yaml
+++ b/.github/workflows/cli_util.yaml
@@ -1,5 +1,6 @@
 name: package:cli_util
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/clock.yaml
+++ b/.github/workflows/clock.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/clock.yaml
+++ b/.github/workflows/clock.yaml
@@ -1,5 +1,6 @@
 name: package:clock
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/code_builder.yaml
+++ b/.github/workflows/code_builder.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -55,6 +57,8 @@ jobs:
         sdk: [3.7.0, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/code_builder.yaml
+++ b/.github/workflows/code_builder.yaml
@@ -1,5 +1,6 @@
 name: package:code_builder
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,5 +1,6 @@
 name: package:coverage
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,6 +31,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -60,6 +62,8 @@ jobs:
         sdk: [3.6, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -78,6 +82,8 @@ jobs:
         working-directory: pkgs/coverage/
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: dev

--- a/.github/workflows/csslib.yaml
+++ b/.github/workflows/csslib.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.1, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/csslib.yaml
+++ b/.github/workflows/csslib.yaml
@@ -1,5 +1,6 @@
 name: package:csslib
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/deploy_pages.yaml
+++ b/.github/workflows/deploy_pages.yaml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       
       # Build the markdown playground.

--- a/.github/workflows/deploy_pages.yaml
+++ b/.github/workflows/deploy_pages.yaml
@@ -1,7 +1,8 @@
 # Publish the GitHub Pages site for this repo.
 
 name: "Deploy Pages"
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on pushes to the default branch.

--- a/.github/workflows/extension_discovery.yaml
+++ b/.github/workflows/extension_discovery.yaml
@@ -31,6 +31,8 @@ jobs:
             check-formatting: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{matrix.sdk}}

--- a/.github/workflows/extension_discovery.yaml
+++ b/.github/workflows/extension_discovery.yaml
@@ -1,5 +1,6 @@
 name: package:extension_discovery
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/file.yaml
+++ b/.github/workflows/file.yaml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: dev
@@ -47,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/file.yaml
+++ b/.github/workflows/file.yaml
@@ -1,5 +1,6 @@
 name: package:file
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/file_testing.yaml
+++ b/.github/workflows/file_testing.yaml
@@ -1,5 +1,6 @@
 name: package:file_testing
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/file_testing.yaml
+++ b/.github/workflows/file_testing.yaml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: dev

--- a/.github/workflows/glob.yaml
+++ b/.github/workflows/glob.yaml
@@ -1,5 +1,6 @@
 name: package:glob
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on all PRs (against any branch) and on pushes to the main branch.

--- a/.github/workflows/glob.yaml
+++ b/.github/workflows/glob.yaml
@@ -29,6 +29,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/graphs.yaml
+++ b/.github/workflows/graphs.yaml
@@ -29,6 +29,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/graphs.yaml
+++ b/.github/workflows/graphs.yaml
@@ -1,5 +1,6 @@
 name: package:graphs
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on all PRs (against any branch) and on pushes to the main branch.

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -1,5 +1,6 @@
 name: Health
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -8,7 +9,7 @@ on:
 
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       ignore_coverage: "**.mock.dart,**.g.dart"
       ignore_license: "**.mock.dart,**.g.dart,**.mocks.dart,pkgs/markdown/**"

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main # zizmor: ignore[unpinned-uses]
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@edfdb3b4063b9034b708144633a700204f865f43
     with:
       ignore_coverage: "**.mock.dart,**.g.dart"
       ignore_license: "**.mock.dart,**.g.dart,**.mocks.dart,pkgs/markdown/**"

--- a/.github/workflows/html.yaml
+++ b/.github/workflows/html.yaml
@@ -1,4 +1,6 @@
 name: package:html
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.
@@ -28,6 +30,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -48,6 +52,8 @@ jobs:
         sdk: [3.6, stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/io.yaml
+++ b/.github/workflows/io.yaml
@@ -1,5 +1,6 @@
 name: package:io
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/io.yaml
+++ b/.github/workflows/io.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev, 3.4]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [dev, 3.4]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/json_rpc_2.yaml
+++ b/.github/workflows/json_rpc_2.yaml
@@ -1,5 +1,6 @@
 name: package:json_rpc_2
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/json_rpc_2.yaml
+++ b/.github/workflows/json_rpc_2.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -54,6 +56,8 @@ jobs:
         sdk: [stable]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -74,6 +78,8 @@ jobs:
         sdk: [3.9, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -89,6 +95,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      with:
+        persist-credentials: false
     - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       with:
         sdk: dev

--- a/.github/workflows/markdown_crash_test.yaml
+++ b/.github/workflows/markdown_crash_test.yaml
@@ -2,7 +2,8 @@
 # to see if any can provoke a crash.
 
 name: "package:markdown: crash tests"
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/markdown_crash_test.yaml
+++ b/.github/workflows/markdown_crash_test.yaml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       

--- a/.github/workflows/mime.yaml
+++ b/.github/workflows/mime.yaml
@@ -32,6 +32,8 @@ jobs:
       # These are the latest versions of the github actions; dependabot will
       # send PRs to keep these up-to-date.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
 
       - name: Install dependencies

--- a/.github/workflows/mime.yaml
+++ b/.github/workflows/mime.yaml
@@ -1,5 +1,6 @@
 name: package:mime
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/oauth2.yaml
+++ b/.github/workflows/oauth2.yaml
@@ -1,5 +1,6 @@
 name: package:oauth2
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/oauth2.yaml
+++ b/.github/workflows/oauth2.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -62,6 +64,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/package_config.yaml
+++ b/.github/workflows/package_config.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +60,8 @@ jobs:
         sdk: [3.11.0, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/package_config.yaml
+++ b/.github/workflows/package_config.yaml
@@ -1,5 +1,6 @@
 name: package:package_config
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/pool.yaml
+++ b/.github/workflows/pool.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -14,6 +14,6 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main # zizmor: ignore[unpinned-uses]
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@edfdb3b4063b9034b708144633a700204f865f43
     permissions:
       pull-requests: write

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,10 +1,11 @@
 name: Comment on the pull request
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Trigger this workflow after the Health workflow completes. This workflow will have permissions to
   # do things like create comments on the PR, even if the original workflow couldn't.
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: 
       - Publish
       - Health
@@ -13,6 +14,6 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main # zizmor: ignore[unpinned-uses]
     permissions:
       pull-requests: write

--- a/.github/workflows/process.yaml
+++ b/.github/workflows/process.yaml
@@ -30,6 +30,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
 
       - run: dart pub get

--- a/.github/workflows/process.yaml
+++ b/.github/workflows/process.yaml
@@ -1,5 +1,6 @@
 name: package:process
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/pub_semver.yaml
+++ b/.github/workflows/pub_semver.yaml
@@ -1,5 +1,6 @@
 name: package:pub_semver
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/pub_semver.yaml
+++ b/.github/workflows/pub_semver.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,8 @@
 # A CI configuration to auto-publish pub packages.
 
 name: Publish
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -13,7 +14,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       write-comments: false
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main # zizmor: ignore[unpinned-uses]
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@edfdb3b4063b9034b708144633a700204f865f43
     with:
       write-comments: false
     permissions:

--- a/.github/workflows/pubspec_parse.yaml
+++ b/.github/workflows/pubspec_parse.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +60,8 @@ jobs:
         sdk: [3.8, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/pubspec_parse.yaml
+++ b/.github/workflows/pubspec_parse.yaml
@@ -1,5 +1,6 @@
 name: package:pubspec_parse
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -5,7 +5,8 @@
 # https://github.com/actions/labeler.
 
 name: Pull Request Labeler
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request_target

--- a/.github/workflows/source_map_stack_trace.yaml
+++ b/.github/workflows/source_map_stack_trace.yaml
@@ -1,5 +1,6 @@
 name: package:source_map_stack_trace
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/source_map_stack_trace.yaml
+++ b/.github/workflows/source_map_stack_trace.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.3, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/source_maps.yaml
+++ b/.github/workflows/source_maps.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.3.0, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/source_maps.yaml
+++ b/.github/workflows/source_maps.yaml
@@ -1,5 +1,6 @@
 name: package:source_maps
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/source_span.yaml
+++ b/.github/workflows/source_span.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.1.0, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/source_span.yaml
+++ b/.github/workflows/source_span.yaml
@@ -1,5 +1,6 @@
 name: package:source_span
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/sse.yaml
+++ b/.github/workflows/sse.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.11, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/sse.yaml
+++ b/.github/workflows/sse.yaml
@@ -1,5 +1,6 @@
 name: package:sse
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/stack_trace.yaml
+++ b/.github/workflows/stack_trace.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/stack_trace.yaml
+++ b/.github/workflows/stack_trace.yaml
@@ -1,5 +1,6 @@
 name: package:stack_trace
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/stream_channel.yaml
+++ b/.github/workflows/stream_channel.yaml
@@ -1,5 +1,6 @@
 name: package:stream_channel
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/stream_channel.yaml
+++ b/.github/workflows/stream_channel.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.3, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/stream_transform.yaml
+++ b/.github/workflows/stream_transform.yaml
@@ -1,5 +1,6 @@
 name: package:stream_transform
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/stream_transform.yaml
+++ b/.github/workflows/stream_transform.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -60,6 +62,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/string_scanner.yaml
+++ b/.github/workflows/string_scanner.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.1, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/string_scanner.yaml
+++ b/.github/workflows/string_scanner.yaml
@@ -1,5 +1,6 @@
 name: package:string_scanner
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/term_glyph.yaml
+++ b/.github/workflows/term_glyph.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.1, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/term_glyph.yaml
+++ b/.github/workflows/term_glyph.yaml
@@ -1,5 +1,6 @@
 name: package:term_glyph
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/test_reflective_loader.yaml
+++ b/.github/workflows/test_reflective_loader.yaml
@@ -1,5 +1,6 @@
 name: package:test_reflective_loader
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/test_reflective_loader.yaml
+++ b/.github/workflows/test_reflective_loader.yaml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/timing.yaml
+++ b/.github/workflows/timing.yaml
@@ -1,5 +1,6 @@
 name: package:timing
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/timing.yaml
+++ b/.github/workflows/timing.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -56,6 +58,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/unified_analytics.yaml
+++ b/.github/workflows/unified_analytics.yaml
@@ -1,5 +1,6 @@
 name: package:unified_analytics
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/unified_analytics.yaml
+++ b/.github/workflows/unified_analytics.yaml
@@ -30,6 +30,8 @@ jobs:
             run-tests: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{matrix.sdk}}

--- a/.github/workflows/watcher.yaml
+++ b/.github/workflows/watcher.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +60,8 @@ jobs:
         sdk: [3.8, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/watcher.yaml
+++ b/.github/workflows/watcher.yaml
@@ -1,5 +1,6 @@
 name: package:watcher
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -59,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -1,5 +1,6 @@
 name: package:yaml
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/yaml_edit.yaml
+++ b/.github/workflows/yaml_edit.yaml
@@ -1,5 +1,6 @@
 name: package:yaml_edit
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/.github/workflows/yaml_edit.yaml
+++ b/.github/workflows/yaml_edit.yaml
@@ -32,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -60,6 +62,8 @@ jobs:
         platform: [vm, chrome]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}


### PR DESCRIPTION
Replacing top-level `permissions: read-all` with least-privilege `permissions: contents: read` in GitHub Actions workflows to avoid excessive-permissions warnings from zizmor scans.