### PR TITLE
Fix MultiChannel inner channel type constraint documentation

### DIFF
--- a/pkgs/stream_channel/example/example.dart
+++ b/pkgs/stream_channel/example/example.dart
@@ -62,7 +62,7 @@ Future<void> main() async {
   //
   // A MultiChannel<T> splits events into numbered channels, which are
   // instances of VirtualChannel<T>.
-  var dummyCtrl1 = StreamChannelController<String>();
+  var dummyCtrl1 = StreamChannelController<dynamic>();
   var multiChannel = MultiChannel<String>(dummyCtrl1.foreign);
   var channel1 = multiChannel.virtualChannel();
   await multiChannel.sink.close();
@@ -71,7 +71,7 @@ Future<void> main() async {
   // the underlying transport, use the corresponding ID's to handle events in
   // their respective channels. It is up to you how to communicate channel ID's
   // across different endpoints.
-  var dummyCtrl2 = StreamChannelController<String>();
+  var dummyCtrl2 = StreamChannelController<dynamic>();
   var multiChannel2 = MultiChannel<String>(dummyCtrl2.foreign);
   var channel2 = multiChannel2.virtualChannel(channel1.id);
   await channel2.sink.close();

--- a/pkgs/stream_channel/example/example.dart
+++ b/pkgs/stream_channel/example/example.dart
@@ -62,7 +62,7 @@ Future<void> main() async {
   //
   // A MultiChannel<T> splits events into numbered channels, which are
   // instances of VirtualChannel<T>.
-  var dummyCtrl1 = StreamChannelController<dynamic>();
+  var dummyCtrl1 = StreamChannelController<Object>();
   var multiChannel = MultiChannel<String>(dummyCtrl1.foreign);
   var channel1 = multiChannel.virtualChannel();
   await multiChannel.sink.close();

--- a/pkgs/stream_channel/example/example.dart
+++ b/pkgs/stream_channel/example/example.dart
@@ -71,7 +71,7 @@ Future<void> main() async {
   // the underlying transport, use the corresponding ID's to handle events in
   // their respective channels. It is up to you how to communicate channel ID's
   // across different endpoints.
-  var dummyCtrl2 = StreamChannelController<dynamic>();
+  var dummyCtrl2 = StreamChannelController<Object>();
   var multiChannel2 = MultiChannel<String>(dummyCtrl2.foreign);
   var channel2 = multiChannel2.virtualChannel(channel1.id);
   await channel2.sink.close();

--- a/pkgs/stream_channel/lib/src/multi_channel.dart
+++ b/pkgs/stream_channel/lib/src/multi_channel.dart
@@ -57,12 +57,10 @@ abstract class MultiChannel<T> implements StreamChannel<T> {
   /// Creates a new [MultiChannel] that sends and receives messages over
   /// [inner].
   ///
-  /// The inner channel must take JSON-like objects (e.g. `List`s).
-  ///
-  /// Note: The underlying [inner] channel must be capable of transmitting `List`
+  /// The [inner] channel must be capable of transmitting `List`
   /// envelopes. Even if you intend to use a strictly typed [MultiChannel]
-  /// (e.g. `MultiChannel<String>`), the [inner] channel MUST be typed to
-  /// accept `List` or `dynamic`, otherwise a runtime `TypeError` will occur.
+  /// (for example `MultiChannel<String>`), the [inner] channel MUST be typed to
+  /// accept `List` or a supertype, otherwise a runtime `TypeError` will occur.
   factory MultiChannel(StreamChannel<dynamic> inner) => _MultiChannel<T>(inner);
 
   /// Creates a new virtual channel.

--- a/pkgs/stream_channel/lib/src/multi_channel.dart
+++ b/pkgs/stream_channel/lib/src/multi_channel.dart
@@ -24,13 +24,11 @@ import '../stream_channel.dart';
 /// ```dart
 /// // First endpoint
 /// var virtual = multiChannel.virtualChannel();
-/// multiChannel.sink.add({
-///   "channel": virtual.id
-/// });
+/// multiChannel.sink.add(virtual.id);
 ///
 /// // Second endpoint
 /// multiChannel.stream.listen((message) {
-///   var virtual = multiChannel.virtualChannel(message["channel"]);
+///   var virtual = multiChannel.virtualChannel(message);
 ///   // ...
 /// });
 /// ```
@@ -59,7 +57,12 @@ abstract class MultiChannel<T> implements StreamChannel<T> {
   /// Creates a new [MultiChannel] that sends and receives messages over
   /// [inner].
   ///
-  /// The inner channel must take JSON-like objects.
+  /// The inner channel must take JSON-like objects (e.g. `List`s).
+  ///
+  /// Note: The underlying [inner] channel must be capable of transmitting `List`
+  /// envelopes. Even if you intend to use a strictly typed [MultiChannel]
+  /// (e.g. `MultiChannel<String>`), the [inner] channel MUST be typed to
+  /// accept `List` or `dynamic`, otherwise a runtime `TypeError` will occur.
   factory MultiChannel(StreamChannel<dynamic> inner) => _MultiChannel<T>(inner);
 
   /// Creates a new virtual channel.

--- a/pkgs/stream_channel/lib/src/multi_channel.dart
+++ b/pkgs/stream_channel/lib/src/multi_channel.dart
@@ -28,7 +28,7 @@ import '../stream_channel.dart';
 ///
 /// // Second endpoint
 /// multiChannel.stream.listen((message) {
-///   var virtual = multiChannel.virtualChannel(message);
+///   var virtual = multiChannel.virtualChannel(message as int);
 ///   // ...
 /// });
 /// ```


### PR DESCRIPTION
Fixes #2401

This PR addresses a runtime type mismatch issue when using `MultiChannel` with strictly typed channels. 

**What this PR changes:**
- **`example.dart`**: Changes the underlying `StreamChannelController` type to `<dynamic>`, as `MultiChannel` requires a transport channel capable of receiving `List` envelopes.
- **`multi_channel.dart`**: Clarifies the `MultiChannel` documentation and updates the code snippet to correctly transmit the channel ID without causing type conflicts.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
