### PR TITLE
Add pub dependabot support

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,6 @@
 # Dependabot configuration file.
 version: 2
+enable-beta-ecosystems: true
 
 updates:
   - package-ecosystem: github-actions
@@ -12,3 +13,12 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "pub"
+    directories:
+      - "/pkgs/*"
+    schedule:
+      interval: monthly
+    labels:
+      - autosubmit
+    versioning-strategy: increase-if-necessary

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,6 +19,8 @@ updates:
       - "/pkgs/*"
     schedule:
       interval: monthly
+    allow:
+      - update-types: ["version-update:semver-major"]
     cooldown:
       default-days: 7
     labels:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     labels:
       - autosubmit
     groups:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,6 +19,8 @@ updates:
       - "/pkgs/*"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     labels:
       - autosubmit
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Configures Dependabot to check pub dependencies in `/pkgs/*` on a monthly schedule, with `autosubmit` label and `increase-if-necessary` versioning strategy.