### PR TITLE
Add skip-changelog-check label to dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,7 @@ updates:
       default-days: 7
     labels:
       - autosubmit
+      - skip-changelog-check
     groups:
       github-actions:
         patterns:
@@ -27,4 +28,5 @@ updates:
       default-days: 7
     labels:
       - autosubmit
+      - skip-changelog-check
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Dependabot PRs don't include CHANGELOG updates, causing the PR health changelog check to fail. Adding `skip-changelog-check` to the labels applied by dependabot ensures these PRs can pass health checks and auto-submit.