### PR TITLE
[api_summary] Track pubspec.yaml environment constraints and executables

### DIFF
--- a/pkgs/api_summary/api.json
+++ b/pkgs/api_summary/api.json
@@ -4030,28 +4030,6 @@
             }
           ],
           "isStatic": true
-        },
-        {
-          "name": "canonicalizeConstraint",
-          "locationUri": "package:api_summary/api_summary.dart",
-          "kind": "function",
-          "returnType": {
-            "kind": "interface",
-            "name": "String",
-            "libraryUri": "dart:core"
-          },
-          "parameters": [
-            {
-              "name": "rawConstraint",
-              "type": {
-                "kind": "interface",
-                "name": "String",
-                "libraryUri": "dart:core"
-              },
-              "isRequired": true
-            }
-          ],
-          "isStatic": true
         }
       ]
     }

--- a/pkgs/api_summary/api.json
+++ b/pkgs/api_summary/api.json
@@ -1,5 +1,11 @@
 {
   "name": "api_summary",
+  "environment": {
+    "sdk": "^3.12.0"
+  },
+  "executables": {
+    "api_summary": null
+  },
   "libraries": [
     {
       "uri": "package:api_summary/api_summary.dart",
@@ -2752,6 +2758,51 @@
               },
               "parameters": [
                 {
+                  "name": "environment",
+                  "type": {
+                    "kind": "interface",
+                    "name": "Map",
+                    "libraryUri": "dart:core",
+                    "typeArguments": [
+                      {
+                        "kind": "interface",
+                        "name": "String",
+                        "libraryUri": "dart:core"
+                      },
+                      {
+                        "kind": "interface",
+                        "name": "String",
+                        "libraryUri": "dart:core"
+                      }
+                    ],
+                    "isNullable": true
+                  },
+                  "isNamed": true
+                },
+                {
+                  "name": "executables",
+                  "type": {
+                    "kind": "interface",
+                    "name": "Map",
+                    "libraryUri": "dart:core",
+                    "typeArguments": [
+                      {
+                        "kind": "interface",
+                        "name": "String",
+                        "libraryUri": "dart:core"
+                      },
+                      {
+                        "kind": "interface",
+                        "name": "String",
+                        "libraryUri": "dart:core",
+                        "isNullable": true
+                      }
+                    ],
+                    "isNullable": true
+                  },
+                  "isNamed": true
+                },
+                {
                   "name": "libraries",
                   "type": {
                     "kind": "interface",
@@ -2782,6 +2833,51 @@
             }
           ],
           "methods": [
+            {
+              "name": "environment",
+              "locationUri": "package:api_summary/src/api_declaration.dart",
+              "kind": "getter",
+              "returnType": {
+                "kind": "interface",
+                "name": "Map",
+                "libraryUri": "dart:core",
+                "typeArguments": [
+                  {
+                    "kind": "interface",
+                    "name": "String",
+                    "libraryUri": "dart:core"
+                  },
+                  {
+                    "kind": "interface",
+                    "name": "String",
+                    "libraryUri": "dart:core"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "executables",
+              "locationUri": "package:api_summary/src/api_declaration.dart",
+              "kind": "getter",
+              "returnType": {
+                "kind": "interface",
+                "name": "Map",
+                "libraryUri": "dart:core",
+                "typeArguments": [
+                  {
+                    "kind": "interface",
+                    "name": "String",
+                    "libraryUri": "dart:core"
+                  },
+                  {
+                    "kind": "interface",
+                    "name": "String",
+                    "libraryUri": "dart:core",
+                    "isNullable": true
+                  }
+                ]
+              }
+            },
             {
               "name": "libraries",
               "locationUri": "package:api_summary/src/api_declaration.dart",
@@ -3931,6 +4027,28 @@
                 "isNullable": true
               },
               "isNamed": true
+            }
+          ],
+          "isStatic": true
+        },
+        {
+          "name": "canonicalizeConstraint",
+          "locationUri": "package:api_summary/api_summary.dart",
+          "kind": "function",
+          "returnType": {
+            "kind": "interface",
+            "name": "String",
+            "libraryUri": "dart:core"
+          },
+          "parameters": [
+            {
+              "name": "rawConstraint",
+              "type": {
+                "kind": "interface",
+                "name": "String",
+                "libraryUri": "dart:core"
+              },
+              "isRequired": true
             }
           ],
           "isStatic": true

--- a/pkgs/api_summary/api.txt
+++ b/pkgs/api_summary/api.txt
@@ -1,5 +1,10 @@
+environment:
+  sdk: ^3.12.0
+executables:
+  api_summary
 package:api_summary/api_summary.dart:
   apiSummary (function: Future<ApiSummary> Function(String, {ApiSummaryCustomizer? customizer, String? packageName}))
+  canonicalizeConstraint (function: String Function(String))
   ApiClass (class extends ApiDeclaration, final):
     new (constructor: ApiClass Function({required List<ApiExecutable> constructors, required List<String> immediateSubtypes, required List<ApiType> interfaces, bool isDeprecated, bool isExperimental, bool isVisibleForTesting, String? locationUri, required List<ApiExecutable> methods, required List<ApiType> mixins, required List<ApiClassModifier> modifiers, required String name, ApiDeclarationStatus status, List<ApiType> superclassConstraints, ApiType? supertype, required Map<String, ApiType?> typeParameters}))
     fromJson (constructor: ApiClass Function(Map<String, dynamic>))
@@ -126,8 +131,10 @@ package:api_summary/api_summary.dart:
     positionalFields (getter: List<ApiType>)
     toJson (method: Map<String, dynamic> Function())
   ApiSummary (class extends Object, final):
-    new (constructor: ApiSummary Function({required List<ApiLibrary> libraries, required String name}))
+    new (constructor: ApiSummary Function({Map<String, String>? environment, Map<String, String?>? executables, required List<ApiLibrary> libraries, required String name}))
     fromJson (constructor: ApiSummary Function(Map<String, dynamic>))
+    environment (getter: Map<String, String>)
+    executables (getter: Map<String, String?>)
     libraries (getter: List<ApiLibrary>)
     name (getter: String)
     toJson (method: Map<String, dynamic> Function())

--- a/pkgs/api_summary/api.txt
+++ b/pkgs/api_summary/api.txt
@@ -4,7 +4,6 @@ executables:
   api_summary
 package:api_summary/api_summary.dart:
   apiSummary (function: Future<ApiSummary> Function(String, {ApiSummaryCustomizer? customizer, String? packageName}))
-  canonicalizeConstraint (function: String Function(String))
   ApiClass (class extends ApiDeclaration, final):
     new (constructor: ApiClass Function({required List<ApiExecutable> constructors, required List<String> immediateSubtypes, required List<ApiType> interfaces, bool isDeprecated, bool isExperimental, bool isVisibleForTesting, String? locationUri, required List<ApiExecutable> methods, required List<ApiType> mixins, required List<ApiClassModifier> modifiers, required String name, ApiDeclarationStatus status, List<ApiType> superclassConstraints, ApiType? supertype, required Map<String, ApiType?> typeParameters}))
     fromJson (constructor: ApiClass Function(Map<String, dynamic>))

--- a/pkgs/api_summary/api.yaml
+++ b/pkgs/api_summary/api.yaml
@@ -1,4 +1,8 @@
 name: api_summary
+environment:
+  sdk: ^3.12.0
+executables:
+  api_summary: null
 libraries:
   - uri: package:api_summary/api_summary.dart
     isPublicEntryPoint: true
@@ -1795,6 +1799,35 @@ libraries:
               name: ApiSummary
               libraryUri: package:api_summary/src/api_declaration.dart
             parameters:
+              - name: environment
+                type:
+                  kind: interface
+                  name: Map
+                  libraryUri: dart:core
+                  typeArguments:
+                    - kind: interface
+                      name: String
+                      libraryUri: dart:core
+                    - kind: interface
+                      name: String
+                      libraryUri: dart:core
+                  isNullable: true
+                isNamed: true
+              - name: executables
+                type:
+                  kind: interface
+                  name: Map
+                  libraryUri: dart:core
+                  typeArguments:
+                    - kind: interface
+                      name: String
+                      libraryUri: dart:core
+                    - kind: interface
+                      name: String
+                      libraryUri: dart:core
+                      isNullable: true
+                  isNullable: true
+                isNamed: true
               - name: libraries
                 type:
                   kind: interface
@@ -1814,6 +1847,35 @@ libraries:
                 isRequired: true
                 isNamed: true
         methods:
+          - name: environment
+            locationUri: package:api_summary/src/api_declaration.dart
+            kind: getter
+            returnType:
+              kind: interface
+              name: Map
+              libraryUri: dart:core
+              typeArguments:
+                - kind: interface
+                  name: String
+                  libraryUri: dart:core
+                - kind: interface
+                  name: String
+                  libraryUri: dart:core
+          - name: executables
+            locationUri: package:api_summary/src/api_declaration.dart
+            kind: getter
+            returnType:
+              kind: interface
+              name: Map
+              libraryUri: dart:core
+              typeArguments:
+                - kind: interface
+                  name: String
+                  libraryUri: dart:core
+                - kind: interface
+                  name: String
+                  libraryUri: dart:core
+                  isNullable: true
           - name: libraries
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2582,4 +2644,19 @@ libraries:
               libraryUri: dart:core
               isNullable: true
             isNamed: true
+        isStatic: true
+      - name: canonicalizeConstraint
+        locationUri: package:api_summary/api_summary.dart
+        kind: function
+        returnType:
+          kind: interface
+          name: String
+          libraryUri: dart:core
+        parameters:
+          - name: rawConstraint
+            type:
+              kind: interface
+              name: String
+              libraryUri: dart:core
+            isRequired: true
         isStatic: true

--- a/pkgs/api_summary/api.yaml
+++ b/pkgs/api_summary/api.yaml
@@ -2645,18 +2645,3 @@ libraries:
               isNullable: true
             isNamed: true
         isStatic: true
-      - name: canonicalizeConstraint
-        locationUri: package:api_summary/api_summary.dart
-        kind: function
-        returnType:
-          kind: interface
-          name: String
-          libraryUri: dart:core
-        parameters:
-          - name: rawConstraint
-            type:
-              kind: interface
-              name: String
-              libraryUri: dart:core
-            isRequired: true
-        isStatic: true

--- a/pkgs/api_summary/bin/api_summary.dart
+++ b/pkgs/api_summary/bin/api_summary.dart
@@ -28,7 +28,7 @@ Future<void> main(List<String> arguments) async {
 
     final format = results.option('format');
     final package = await apiSummary(absolutePath);
-    print(_format(package, format!));
+    stdout.write(_format(package, format!));
   } on FormatException catch (e) {
     stderr.writeln('Error: ${e.message}');
     stderr.writeln('\nUsage: api_summary [options]');

--- a/pkgs/api_summary/lib/api_summary.dart
+++ b/pkgs/api_summary/lib/api_summary.dart
@@ -7,8 +7,7 @@ import 'dart:io';
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
-import 'package:yaml/yaml.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'src/api_builder.dart';
 import 'src/api_declaration.dart';
@@ -54,36 +53,6 @@ Future<ApiSummary> apiSummary(
   );
 }
 
-/// Canonicalizes a version constraint string.
-///
-/// If [rawConstraint] represents a range equivalent to `^version` (such as
-/// `>=1.2.3 <2.0.0`, `>=1.2.3 <2.0.0-0`, or `>=0.1.2 <0.2.0`), it is formatted
-/// in canonical `^` syntax.
-String canonicalizeConstraint(String rawConstraint) {
-  final VersionConstraint constraint;
-  try {
-    constraint = VersionConstraint.parse(rawConstraint);
-  } on FormatException catch (e) {
-    throw ArgumentError(
-      'Invalid version constraint "$rawConstraint": ${e.message}',
-    );
-  }
-
-  if (constraint is VersionRange) {
-    final min = constraint.min;
-    final max = constraint.max;
-    if (constraint.includeMin &&
-        !constraint.includeMax &&
-        min != null &&
-        max != null) {
-      if (max == min.nextBreaking || max == min.nextBreaking.firstPreRelease) {
-        return '^$min';
-      }
-    }
-  }
-  return constraint.toString();
-}
-
 typedef _PubspecDetails = ({
   String name,
   Map<String, String> environment,
@@ -96,80 +65,23 @@ _PubspecDetails _extractPubspecDetails(String packagePath) {
     throw ArgumentError('No pubspec.yaml found at "$packagePath".');
   }
   final content = pubspecFile.readAsStringSync();
-  final yaml = loadYaml(content);
-  if (yaml is! Map) {
+  final Pubspec pubspec;
+  try {
+    pubspec = Pubspec.parse(content, sourceUrl: pubspecFile.uri);
+  } on Exception catch (e) {
     throw ArgumentError(
-      'Expected pubspec.yaml at ${pubspecFile.path} to be a YAML map.',
-    );
-  }
-  final name = yaml['name'];
-  if (name == null) {
-    throw ArgumentError(
-      'Could not find a "name" field in pubspec.yaml at ${pubspecFile.path}.',
-    );
-  }
-  if (name is! String) {
-    throw ArgumentError(
-      'The "name" field in pubspec.yaml at ${pubspecFile.path} must be a '
-      'string.',
+      'Failed to parse pubspec.yaml at ${pubspecFile.path}: $e',
     );
   }
 
-  final environment = <String, String>{};
-  if (yaml.containsKey('environment')) {
-    final envNode = yaml['environment'];
-    if (envNode is! Map) {
-      throw ArgumentError(
-        'The "environment" field in pubspec.yaml at ${pubspecFile.path} must '
-        'be a map.',
-      );
-    }
-    for (final entry in envNode.entries) {
-      final key = entry.key;
-      final val = entry.value;
-      if (key is! String) {
-        throw ArgumentError(
-          'Keys in "environment" field in pubspec.yaml at ${pubspecFile.path} '
-          'must be strings.',
-        );
-      }
-      if (val is! String) {
-        throw ArgumentError(
-          'Constraint value for "$key" in "environment" field in pubspec.yaml '
-          'at ${pubspecFile.path} must be a string.',
-        );
-      }
-      environment[key] = canonicalizeConstraint(val);
-    }
-  }
+  final environment = <String, String>{
+    for (final entry in pubspec.environment.entries)
+      if (entry.value case final constraint?) entry.key: constraint.toString(),
+  };
 
-  final executables = <String, String?>{};
-  if (yaml.containsKey('executables')) {
-    final execNode = yaml['executables'];
-    if (execNode is! Map) {
-      throw ArgumentError(
-        'The "executables" field in pubspec.yaml at ${pubspecFile.path} must '
-        'be a map.',
-      );
-    }
-    for (final entry in execNode.entries) {
-      final key = entry.key;
-      final val = entry.value;
-      if (key is! String) {
-        throw ArgumentError(
-          'Keys in "executables" field in pubspec.yaml at ${pubspecFile.path} '
-          'must be strings.',
-        );
-      }
-      if (val != null && val is! String) {
-        throw ArgumentError(
-          'Target value for executable "$key" in pubspec.yaml at '
-          '${pubspecFile.path} must be a string or null.',
-        );
-      }
-      executables[key] = val as String?;
-    }
-  }
-
-  return (name: name, environment: environment, executables: executables);
+  return (
+    name: pubspec.name,
+    environment: environment,
+    executables: pubspec.executables,
+  );
 }

--- a/pkgs/api_summary/lib/api_summary.dart
+++ b/pkgs/api_summary/lib/api_summary.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
 import 'src/api_builder.dart';
@@ -32,7 +33,8 @@ Future<ApiSummary> apiSummary(
   String? packageName,
   ApiSummaryCustomizer? customizer,
 }) async {
-  final resolvedPackageName = packageName ?? _extractPackageName(packagePath);
+  final pubspec = _extractPubspecDetails(packagePath);
+  final resolvedPackageName = packageName ?? pubspec.name;
   final provider = PhysicalResourceProvider.INSTANCE;
   final libPath = provider.pathContext.join(packagePath, 'lib');
   if (!provider.getFolder(libPath).exists) {
@@ -47,31 +49,127 @@ Future<ApiSummary> apiSummary(
     resolvedPackageName,
     context,
     customizer ?? const ApiSummaryCustomizer(),
+    environment: pubspec.environment,
+    executables: pubspec.executables,
   );
 }
 
-String _extractPackageName(String packagePath) {
+/// Canonicalizes a version constraint string.
+///
+/// If [rawConstraint] represents a range equivalent to `^version` (such as
+/// `>=1.2.3 <2.0.0`, `>=1.2.3 <2.0.0-0`, or `>=0.1.2 <0.2.0`), it is formatted
+/// in canonical `^` syntax.
+String canonicalizeConstraint(String rawConstraint) {
+  final VersionConstraint constraint;
+  try {
+    constraint = VersionConstraint.parse(rawConstraint);
+  } on FormatException catch (e) {
+    throw ArgumentError(
+      'Invalid version constraint "$rawConstraint": ${e.message}',
+    );
+  }
+
+  if (constraint is VersionRange) {
+    final min = constraint.min;
+    final max = constraint.max;
+    if (constraint.includeMin &&
+        !constraint.includeMax &&
+        min != null &&
+        max != null) {
+      if (max == min.nextBreaking || max == min.nextBreaking.firstPreRelease) {
+        return '^$min';
+      }
+    }
+  }
+  return constraint.toString();
+}
+
+typedef _PubspecDetails = ({
+  String name,
+  Map<String, String> environment,
+  Map<String, String?> executables,
+});
+
+_PubspecDetails _extractPubspecDetails(String packagePath) {
   final pubspecFile = File(p.join(packagePath, 'pubspec.yaml'));
   if (!pubspecFile.existsSync()) {
     throw ArgumentError('No pubspec.yaml found at "$packagePath".');
   }
   final content = pubspecFile.readAsStringSync();
   final yaml = loadYaml(content);
-  if (yaml case {'name': final String name}) {
-    return name;
-  }
   if (yaml is! Map) {
     throw ArgumentError(
       'Expected pubspec.yaml at ${pubspecFile.path} to be a YAML map.',
     );
   }
-  if (yaml['name'] == null) {
+  final name = yaml['name'];
+  if (name == null) {
     throw ArgumentError(
       'Could not find a "name" field in pubspec.yaml at ${pubspecFile.path}.',
     );
   }
-  throw ArgumentError(
-    'The "name" field in pubspec.yaml at ${pubspecFile.path} must be a '
-    'string.',
-  );
+  if (name is! String) {
+    throw ArgumentError(
+      'The "name" field in pubspec.yaml at ${pubspecFile.path} must be a '
+      'string.',
+    );
+  }
+
+  final environment = <String, String>{};
+  if (yaml.containsKey('environment')) {
+    final envNode = yaml['environment'];
+    if (envNode is! Map) {
+      throw ArgumentError(
+        'The "environment" field in pubspec.yaml at ${pubspecFile.path} must '
+        'be a map.',
+      );
+    }
+    for (final entry in envNode.entries) {
+      final key = entry.key;
+      final val = entry.value;
+      if (key is! String) {
+        throw ArgumentError(
+          'Keys in "environment" field in pubspec.yaml at ${pubspecFile.path} '
+          'must be strings.',
+        );
+      }
+      if (val is! String) {
+        throw ArgumentError(
+          'Constraint value for "$key" in "environment" field in pubspec.yaml '
+          'at ${pubspecFile.path} must be a string.',
+        );
+      }
+      environment[key] = canonicalizeConstraint(val);
+    }
+  }
+
+  final executables = <String, String?>{};
+  if (yaml.containsKey('executables')) {
+    final execNode = yaml['executables'];
+    if (execNode is! Map) {
+      throw ArgumentError(
+        'The "executables" field in pubspec.yaml at ${pubspecFile.path} must '
+        'be a map.',
+      );
+    }
+    for (final entry in execNode.entries) {
+      final key = entry.key;
+      final val = entry.value;
+      if (key is! String) {
+        throw ArgumentError(
+          'Keys in "executables" field in pubspec.yaml at ${pubspecFile.path} '
+          'must be strings.',
+        );
+      }
+      if (val != null && val is! String) {
+        throw ArgumentError(
+          'Target value for executable "$key" in pubspec.yaml at '
+          '${pubspecFile.path} must be a string or null.',
+        );
+      }
+      executables[key] = val as String?;
+    }
+  }
+
+  return (name: name, environment: environment, executables: executables);
 }

--- a/pkgs/api_summary/lib/src/api_builder.dart
+++ b/pkgs/api_summary/lib/src/api_builder.dart
@@ -24,14 +24,23 @@ import 'extensions.dart';
 Future<ApiSummary> buildApiPackage(
   String packageName,
   AnalysisContext context,
-  ApiSummaryCustomizer customizer,
-) => _ApiBuilder(packageName, customizer).build(context);
+  ApiSummaryCustomizer customizer, {
+  Map<String, String> environment = const {},
+  Map<String, String?> executables = const {},
+}) => _ApiBuilder(
+  packageName,
+  customizer,
+  environment: environment,
+  executables: executables,
+).build(context);
 
 /// Internal builder traversing analysis results to build structured API
 /// summaries.
 final class _ApiBuilder {
   final ApiSummaryCustomizer _customizer;
   final String _pkgName;
+  final Map<String, String> _environment;
+  final Map<String, String?> _executables;
 
   final _immediateSubinterfaceCache =
       <LibraryElement, Map<ClassElement, Set<InterfaceElement>>>{};
@@ -41,7 +50,12 @@ final class _ApiBuilder {
   final _libraryBuilders = <String, _ApiLibraryBuilder>{};
   final _elementToLibraries = <Element, List<LibraryElement>>{};
 
-  _ApiBuilder(this._pkgName, this._customizer);
+  _ApiBuilder(
+    this._pkgName,
+    this._customizer, {
+    this._environment = const {},
+    this._executables = const {},
+  });
 
   Future<ApiSummary> build(AnalysisContext context) async {
     final publicApiLibraries = <LibraryElement>[];
@@ -155,7 +169,12 @@ final class _ApiBuilder {
 
     final libraries = _libraryBuilders.values.map((e) => e.build()).toList();
 
-    return ApiSummary(name: _pkgName, libraries: libraries);
+    return ApiSummary(
+      name: _pkgName,
+      environment: _environment,
+      executables: _executables,
+      libraries: libraries,
+    );
   }
 
   Future<void> _scanPublicApiLibraries(

--- a/pkgs/api_summary/lib/src/api_builder.dart
+++ b/pkgs/api_summary/lib/src/api_builder.dart
@@ -21,6 +21,12 @@ import 'extensions.dart';
 /// a canonical [ApiSummary] representation.
 ///
 /// Filtering and discovery behaviors are customized using [customizer].
+///
+/// [environment] defines the SDK and platform environment constraints of the
+/// package (such as 'sdk' or 'flutter').
+///
+/// [executables] defines the executables exposed by the package, mapping
+/// executable names to their target script paths within `bin/`.
 Future<ApiSummary> buildApiPackage(
   String packageName,
   AnalysisContext context,

--- a/pkgs/api_summary/lib/src/api_declaration.dart
+++ b/pkgs/api_summary/lib/src/api_declaration.dart
@@ -46,8 +46,16 @@ enum ApiClassModifier {
 /// and the collection of [libraries] that make up its public API surface.
 final class ApiSummary {
   final String name;
+
+  /// The SDK and platform environment constraints of the package, mapping
+  /// environment names (such as 'sdk' or 'flutter') to their version
+  /// constraints.
   final Map<String, String> environment;
+
+  /// The executables exposed by the package, mapping executable names to
+  /// their target script paths within `bin/`.
   final Map<String, String?> executables;
+
   final List<ApiLibrary> libraries;
 
   ApiSummary({
@@ -55,7 +63,7 @@ final class ApiSummary {
     Map<String, String>? environment,
     Map<String, String?>? executables,
     required this.libraries,
-  }) : environment = environment == null
+  }) : environment = environment == null || environment.isEmpty
            ? const {}
            : Map.unmodifiable(
                Map.fromEntries(
@@ -63,7 +71,7 @@ final class ApiSummary {
                    ..sort((a, b) => a.key.compareTo(b.key)),
                ),
              ),
-       executables = executables == null
+       executables = executables == null || executables.isEmpty
            ? const {}
            : Map.unmodifiable(
                Map.fromEntries(

--- a/pkgs/api_summary/lib/src/api_declaration.dart
+++ b/pkgs/api_summary/lib/src/api_declaration.dart
@@ -46,18 +46,47 @@ enum ApiClassModifier {
 /// and the collection of [libraries] that make up its public API surface.
 final class ApiSummary {
   final String name;
-
+  final Map<String, String> environment;
+  final Map<String, String?> executables;
   final List<ApiLibrary> libraries;
 
-  ApiSummary({required this.name, required this.libraries});
+  ApiSummary({
+    required this.name,
+    Map<String, String>? environment,
+    Map<String, String?>? executables,
+    required this.libraries,
+  }) : environment = environment == null
+           ? const {}
+           : Map.unmodifiable(
+               Map.fromEntries(
+                 environment.entries.toList()
+                   ..sort((a, b) => a.key.compareTo(b.key)),
+               ),
+             ),
+       executables = executables == null
+           ? const {}
+           : Map.unmodifiable(
+               Map.fromEntries(
+                 executables.entries.toList()
+                   ..sort((a, b) => a.key.compareTo(b.key)),
+               ),
+             );
 
   factory ApiSummary.fromJson(Map<String, dynamic> json) => ApiSummary(
     name: json['name'] as String,
+    environment: (json['environment'] as Map<String, dynamic>?)?.map(
+      (k, v) => MapEntry(k, v as String),
+    ),
+    executables: (json['executables'] as Map<String, dynamic>?)?.map(
+      (k, v) => MapEntry(k, v as String?),
+    ),
     libraries: parseList(json, 'libraries', ApiLibrary.fromJson),
   );
 
   Map<String, dynamic> toJson() => {
     'name': name,
+    if (environment.isNotEmpty) 'environment': environment,
+    if (executables.isNotEmpty) 'executables': executables,
     'libraries': libraries.map((e) => e.toJson()).toList(),
   };
 

--- a/pkgs/api_summary/lib/src/text_renderer.dart
+++ b/pkgs/api_summary/lib/src/text_renderer.dart
@@ -104,6 +104,24 @@ final class _ApiTextRenderer {
     ];
 
     final stringBuffer = StringBuffer();
+    if (_package.environment.isNotEmpty) {
+      stringBuffer.writeln('environment:');
+      for (final entry in _package.environment.entries) {
+        stringBuffer.writeln('  ${entry.key}: ${entry.value}');
+      }
+    }
+
+    if (_package.executables.isNotEmpty) {
+      stringBuffer.writeln('executables:');
+      for (final entry in _package.executables.entries) {
+        if (entry.value != null && entry.value != entry.key) {
+          stringBuffer.writeln('  ${entry.key}: ${entry.value}');
+        } else {
+          stringBuffer.writeln('  ${entry.key}');
+        }
+      }
+    }
+
     printNodes(stringBuffer, sortedNodes);
     return stringBuffer.toString();
   }

--- a/pkgs/api_summary/pubspec.yaml
+++ b/pkgs/api_summary/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   args: ^2.6.0
   collection: ^1.19.0
   path: ^1.9.0
+  pub_semver: ^2.1.5
   yaml: ^3.1.2
   yaml_edit: ^2.2.0
 

--- a/pkgs/api_summary/pubspec.yaml
+++ b/pkgs/api_summary/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   collection: ^1.19.0
   path: ^1.9.0
   pubspec_parse: ^1.5.0
-  yaml: ^3.1.2
   yaml_edit: ^2.2.0
 
 dev_dependencies:

--- a/pkgs/api_summary/pubspec.yaml
+++ b/pkgs/api_summary/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   collection: ^1.19.0
   path: ^1.9.0
   pub_semver: ^2.1.5
+  pubspec_parse: ^1.5.0
   yaml: ^3.1.2
   yaml_edit: ^2.2.0
 

--- a/pkgs/api_summary/pubspec.yaml
+++ b/pkgs/api_summary/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   args: ^2.6.0
   collection: ^1.19.0
   path: ^1.9.0
-  pub_semver: ^2.1.5
   pubspec_parse: ^1.5.0
   yaml: ^3.1.2
   yaml_edit: ^2.2.0

--- a/pkgs/api_summary/test/app_test.dart
+++ b/pkgs/api_summary/test/app_test.dart
@@ -83,7 +83,7 @@ void main() {
       ], workingDirectory: packageDir);
 
       expect(result.exitCode, equals(64));
-      expect(result.stderr, contains('Expected pubspec.yaml'));
+      expect(result.stderr, contains('Failed to parse pubspec.yaml'));
     } finally {
       await tempDir.delete(recursive: true);
     }

--- a/pkgs/api_summary/test/pubspec_metadata_test.dart
+++ b/pkgs/api_summary/test/pubspec_metadata_test.dart
@@ -7,56 +7,13 @@ import 'package:test/test.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
 void main() {
-  group('canonicalizeConstraint', () {
-    test('canonicalizes caret syntax', () {
-      expect(canonicalizeConstraint('^1.2.3'), equals('^1.2.3'));
-      expect(canonicalizeConstraint('^1.2.3-alpha'), equals('^1.2.3-alpha'));
-      expect(canonicalizeConstraint('^0.1.2'), equals('^0.1.2'));
-      expect(canonicalizeConstraint('^0.0.3'), equals('^0.0.3'));
-    });
-
-    test('canonicalizes compatible ranges to caret syntax', () {
-      expect(canonicalizeConstraint('>=1.2.3 <2.0.0'), equals('^1.2.3'));
-      expect(canonicalizeConstraint('>=1.2.3 <2.0.0-0'), equals('^1.2.3'));
-      expect(canonicalizeConstraint('>=0.1.2 <0.2.0'), equals('^0.1.2'));
-      expect(canonicalizeConstraint('>=0.0.3 <0.1.0'), equals('^0.0.3'));
-      expect(canonicalizeConstraint('>=3.12.0 <4.0.0'), equals('^3.12.0'));
-    });
-
-    test('preserves non-caret compatible ranges and exact versions', () {
-      expect(
-        canonicalizeConstraint('>=3.0.0 <3.5.0'),
-        equals('>=3.0.0 <3.5.0'),
-      );
-      expect(
-        canonicalizeConstraint('>=0.0.3 <0.0.4'),
-        equals('>=0.0.3 <0.0.4'),
-      );
-      expect(canonicalizeConstraint('>=3.0.0'), equals('>=3.0.0'));
-      expect(
-        canonicalizeConstraint('>1.0.0 <=2.0.0'),
-        equals('>1.0.0 <=2.0.0'),
-      );
-      expect(canonicalizeConstraint('any'), equals('any'));
-      expect(canonicalizeConstraint('1.2.3'), equals('1.2.3'));
-    });
-
-    test('throws ArgumentError on invalid constraint', () {
-      expect(
-        () => canonicalizeConstraint('invalid_version'),
-        throwsArgumentError,
-      );
-      expect(() => canonicalizeConstraint('>=1.0.0 <'), throwsArgumentError);
-    });
-  });
-
   group('ApiSummary environment and executables', () {
     test('sorts environment and executables keys alphabetically', () {
       final summary = ApiSummary(
         name: 'test_pkg',
         environment: {
           'sdk': '^3.12.0',
-          'flutter': '^3.10.0',
+          'flutter': '>=3.2.0 <3.9.0',
           'fuchsia': '>=1.0.0',
         },
         executables: {'z_tool': null, 'a_tool': 'main_a', 'm_tool': 'm_tool'},
@@ -73,10 +30,32 @@ void main() {
       );
     });
 
+    test(
+      'produces identical output regardless of input map insertion order',
+      () {
+        final summaryA = ApiSummary(
+          name: 'test_pkg',
+          environment: {'sdk': '^3.12.0', 'flutter': '>=3.2.0 <3.9.0'},
+          executables: {'z_tool': null, 'a_tool': 'main_a'},
+          libraries: [],
+        );
+
+        final summaryB = ApiSummary(
+          name: 'test_pkg',
+          environment: {'flutter': '>=3.2.0 <3.9.0', 'sdk': '^3.12.0'},
+          executables: {'a_tool': 'main_a', 'z_tool': null},
+          libraries: [],
+        );
+
+        expect(summaryA.toString(), equals(summaryB.toString()));
+        expect(summaryA.toJson(), equals(summaryB.toJson()));
+      },
+    );
+
     test('toJson and fromJson round-trip with environment and executables', () {
       final summary = ApiSummary(
         name: 'test_pkg',
-        environment: {'sdk': '^3.12.0', 'flutter': '^3.10.0'},
+        environment: {'sdk': '^3.12.0', 'flutter': '>=3.2.0 <3.9.0'},
         executables: {'cli_a': null, 'cli_b': 'custom_b'},
         libraries: [],
       );
@@ -85,7 +64,7 @@ void main() {
       expect(json['name'], equals('test_pkg'));
       expect(
         json['environment'],
-        equals({'flutter': '^3.10.0', 'sdk': '^3.12.0'}),
+        equals({'flutter': '>=3.2.0 <3.9.0', 'sdk': '^3.12.0'}),
       );
       expect(json['executables'], equals({'cli_a': null, 'cli_b': 'custom_b'}));
 
@@ -110,7 +89,7 @@ void main() {
     test('text rendering formats environment and executables', () {
       final summary = ApiSummary(
         name: 'test_pkg',
-        environment: {'sdk': '^3.12.0', 'flutter': '^3.10.0'},
+        environment: {'sdk': '^3.12.0', 'flutter': '>=3.2.0 <3.9.0'},
         executables: {
           'simple_tool': null,
           'same_name_tool': 'same_name_tool',
@@ -124,7 +103,7 @@ void main() {
         rendered,
         equals(
           'environment:\n'
-          '  flutter: ^3.10.0\n'
+          '  flutter: >=3.2.0 <3.9.0\n'
           '  sdk: ^3.12.0\n'
           'executables:\n'
           '  custom_tool: custom_script\n'

--- a/pkgs/api_summary/test/pubspec_metadata_test.dart
+++ b/pkgs/api_summary/test/pubspec_metadata_test.dart
@@ -1,0 +1,153 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:api_summary/api_summary.dart';
+import 'package:test/test.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+void main() {
+  group('canonicalizeConstraint', () {
+    test('canonicalizes caret syntax', () {
+      expect(canonicalizeConstraint('^1.2.3'), equals('^1.2.3'));
+      expect(canonicalizeConstraint('^1.2.3-alpha'), equals('^1.2.3-alpha'));
+      expect(canonicalizeConstraint('^0.1.2'), equals('^0.1.2'));
+      expect(canonicalizeConstraint('^0.0.3'), equals('^0.0.3'));
+    });
+
+    test('canonicalizes compatible ranges to caret syntax', () {
+      expect(canonicalizeConstraint('>=1.2.3 <2.0.0'), equals('^1.2.3'));
+      expect(canonicalizeConstraint('>=1.2.3 <2.0.0-0'), equals('^1.2.3'));
+      expect(canonicalizeConstraint('>=0.1.2 <0.2.0'), equals('^0.1.2'));
+      expect(canonicalizeConstraint('>=0.0.3 <0.1.0'), equals('^0.0.3'));
+      expect(canonicalizeConstraint('>=3.12.0 <4.0.0'), equals('^3.12.0'));
+    });
+
+    test('preserves non-caret compatible ranges and exact versions', () {
+      expect(
+        canonicalizeConstraint('>=3.0.0 <3.5.0'),
+        equals('>=3.0.0 <3.5.0'),
+      );
+      expect(
+        canonicalizeConstraint('>=0.0.3 <0.0.4'),
+        equals('>=0.0.3 <0.0.4'),
+      );
+      expect(canonicalizeConstraint('>=3.0.0'), equals('>=3.0.0'));
+      expect(
+        canonicalizeConstraint('>1.0.0 <=2.0.0'),
+        equals('>1.0.0 <=2.0.0'),
+      );
+      expect(canonicalizeConstraint('any'), equals('any'));
+      expect(canonicalizeConstraint('1.2.3'), equals('1.2.3'));
+    });
+
+    test('throws ArgumentError on invalid constraint', () {
+      expect(
+        () => canonicalizeConstraint('invalid_version'),
+        throwsArgumentError,
+      );
+      expect(() => canonicalizeConstraint('>=1.0.0 <'), throwsArgumentError);
+    });
+  });
+
+  group('ApiSummary environment and executables', () {
+    test('sorts environment and executables keys alphabetically', () {
+      final summary = ApiSummary(
+        name: 'test_pkg',
+        environment: {
+          'sdk': '^3.12.0',
+          'flutter': '^3.10.0',
+          'fuchsia': '>=1.0.0',
+        },
+        executables: {'z_tool': null, 'a_tool': 'main_a', 'm_tool': 'm_tool'},
+        libraries: [],
+      );
+
+      expect(
+        summary.environment.keys.toList(),
+        equals(['flutter', 'fuchsia', 'sdk']),
+      );
+      expect(
+        summary.executables.keys.toList(),
+        equals(['a_tool', 'm_tool', 'z_tool']),
+      );
+    });
+
+    test('toJson and fromJson round-trip with environment and executables', () {
+      final summary = ApiSummary(
+        name: 'test_pkg',
+        environment: {'sdk': '^3.12.0', 'flutter': '^3.10.0'},
+        executables: {'cli_a': null, 'cli_b': 'custom_b'},
+        libraries: [],
+      );
+
+      final json = summary.toJson();
+      expect(json['name'], equals('test_pkg'));
+      expect(
+        json['environment'],
+        equals({'flutter': '^3.10.0', 'sdk': '^3.12.0'}),
+      );
+      expect(json['executables'], equals({'cli_a': null, 'cli_b': 'custom_b'}));
+
+      final rehydrated = ApiSummary.fromJson(json);
+      expect(rehydrated.name, equals('test_pkg'));
+      expect(rehydrated.environment, equals(summary.environment));
+      expect(rehydrated.executables, equals(summary.executables));
+    });
+
+    test('toJson omits environment and executables when empty', () {
+      final summary = ApiSummary(name: 'test_pkg', libraries: []);
+
+      final json = summary.toJson();
+      expect(json.containsKey('environment'), isFalse);
+      expect(json.containsKey('executables'), isFalse);
+
+      final rehydrated = ApiSummary.fromJson(json);
+      expect(rehydrated.environment, isEmpty);
+      expect(rehydrated.executables, isEmpty);
+    });
+
+    test('text rendering formats environment and executables', () {
+      final summary = ApiSummary(
+        name: 'test_pkg',
+        environment: {'sdk': '^3.12.0', 'flutter': '^3.10.0'},
+        executables: {
+          'simple_tool': null,
+          'same_name_tool': 'same_name_tool',
+          'custom_tool': 'custom_script',
+        },
+        libraries: [],
+      );
+
+      final rendered = summary.toString();
+      expect(
+        rendered,
+        equals(
+          'environment:\n'
+          '  flutter: ^3.10.0\n'
+          '  sdk: ^3.12.0\n'
+          'executables:\n'
+          '  custom_tool: custom_script\n'
+          '  same_name_tool\n'
+          '  simple_tool\n',
+        ),
+      );
+    });
+
+    test('yaml serialization renders environment and executables', () {
+      final summary = ApiSummary(
+        name: 'test_pkg',
+        environment: {'sdk': '^3.12.0'},
+        executables: {'my_tool': null},
+        libraries: [],
+      );
+
+      final editor = YamlEditor('');
+      editor.update([], summary.toJson());
+      final yaml = '$editor\n';
+
+      expect(yaml, contains('environment:\n  sdk: ^3.12.0'));
+      expect(yaml, contains('executables:\n  my_tool: null'));
+    });
+  });
+}


### PR DESCRIPTION
- Track `environment` SDK/Flutter constraints and `executables` mapping in `ApiSummary`.
- Use `package:pubspec_parse` for pubspec parsing and diagnostic reporting.
- Enforce deterministic alphabetical key sorting on `environment` and `executables` maps.
- Prepend `environment:` and `executables:` blocks to `api.txt` text summaries.
- Add test coverage in `test/pubspec_metadata_test.dart` and update package golden files.

Fixes #2464
Fixes #2466