### PR TITLE
feat(coverage): require Dart 3.9

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.6, dev]
+        sdk: [3.9, dev]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 1.15.2-wip
+## 1.16.0-wip
 
+- Require Dart 3.9.
 - Fixed a race condition in isolate teardown: ignore the benign errors
   produced when an isolate exits between its pause-on-exit callback
   completing and the resume request reaching the VM service.

--- a/pkgs/coverage/benchmark/many_isolates.dart
+++ b/pkgs/coverage/benchmark/many_isolates.dart
@@ -13,8 +13,11 @@ Future<void> main(List<String> args, dynamic message) async {
     var sum = 0;
     for (var i = 0; i < 10; ++i) {
       final port = ReceivePort();
-      final isolate =
-          Isolate.spawnUri(Uri.file('many_isolates.dart'), [], port.sendPort);
+      final isolate = Isolate.spawnUri(
+        Uri.file('many_isolates.dart'),
+        [],
+        port.sendPort,
+      );
       sum += await port.first as int;
       await isolate;
     }

--- a/pkgs/coverage/benchmark/run_benchmarks.dart
+++ b/pkgs/coverage/benchmark/run_benchmarks.dart
@@ -34,20 +34,16 @@ class CoverageBenchmark extends AsyncBenchmarkBase {
     final lcovFile = 'data/$name $iteration lcov.info';
     ++iteration;
 
-    await Process.start(
-      Platform.executable,
-      [
-        if (branchCoverage) '--branch-coverage',
-        'run',
-        if (gatherCoverage) ...[
-          '--pause-isolates-on-exit',
-          '--disable-service-auth-codes',
-          '--enable-vm-service=1234',
-        ],
-        script,
+    await Process.start(Platform.executable, [
+      if (branchCoverage) '--branch-coverage',
+      'run',
+      if (gatherCoverage) ...[
+        '--pause-isolates-on-exit',
+        '--disable-service-auth-codes',
+        '--enable-vm-service=1234',
       ],
-      mode: ProcessStartMode.detached,
-    );
+      script,
+    ], mode: ProcessStartMode.detached);
     if (gatherCoverage) {
       await collect_coverage.main([
         '--wait-paused',
@@ -94,7 +90,8 @@ class JsonEmitter implements ScoreEmitter {
     _results[testName] = value;
   }
 
-  String write() => '[${_results.entries.map((entry) => """{
+  String write() =>
+      '[${_results.entries.map((entry) => """{
   "name": "${entry.key}",
   "unit": "times slower",
   "value": ${(entry.value / _baseline).toStringAsFixed(2)}
@@ -117,19 +114,37 @@ Future<void> runBenchmark(CoverageBenchmark benchmark) async {
 Future<String> runBenchmarkSet(String name, String script) async {
   final captureEmitter = CaptureEmitter();
   await runBenchmark(
-      CoverageBenchmark(captureEmitter, '$name - no coverage', script));
+    CoverageBenchmark(captureEmitter, '$name - no coverage', script),
+  );
   final benchmarkBaseline = captureEmitter.capturedValue;
 
   final emitter = JsonEmitter(benchmarkBaseline);
-  await runBenchmark(CoverageBenchmark(
-      emitter, '$name - basic coverage', script,
-      gatherCoverage: true));
-  await runBenchmark(CoverageBenchmark(
-      emitter, '$name - function coverage', script,
-      gatherCoverage: true, functionCoverage: true));
-  await runBenchmark(CoverageBenchmark(
-      emitter, '$name - branch coverage', script,
-      gatherCoverage: true, branchCoverage: true));
+  await runBenchmark(
+    CoverageBenchmark(
+      emitter,
+      '$name - basic coverage',
+      script,
+      gatherCoverage: true,
+    ),
+  );
+  await runBenchmark(
+    CoverageBenchmark(
+      emitter,
+      '$name - function coverage',
+      script,
+      gatherCoverage: true,
+      functionCoverage: true,
+    ),
+  );
+  await runBenchmark(
+    CoverageBenchmark(
+      emitter,
+      '$name - branch coverage',
+      script,
+      gatherCoverage: true,
+      branchCoverage: true,
+    ),
+  );
   return emitter.write();
 }
 

--- a/pkgs/coverage/bin/collect_coverage.dart
+++ b/pkgs/coverage/bin/collect_coverage.dart
@@ -25,34 +25,43 @@ Future<void> main(List<String> arguments) async {
 
   final out = options.out == null ? stdout : File(options.out!).openWrite();
 
-  await Chain.capture(() async {
-    final coverage = await collect(options.serviceUri, options.resume,
-        options.waitPaused, options.includeDart, options.scopedOutput,
+  await Chain.capture(
+    () async {
+      final coverage = await collect(
+        options.serviceUri,
+        options.resume,
+        options.waitPaused,
+        options.includeDart,
+        options.scopedOutput,
         timeout: options.timeout,
         functionCoverage: options.functionCoverage,
-        branchCoverage: options.branchCoverage);
-    out.write(json.encode(coverage));
-    await out.close();
-  }, onError: (dynamic error, Chain chain) {
-    stderr.writeln(error);
-    stderr.writeln(chain.terse);
-    // See http://www.retro11.de/ouxr/211bsd/usr/include/sysexits.h.html
-    // EX_SOFTWARE
-    exit(70);
-  });
+        branchCoverage: options.branchCoverage,
+      );
+      out.write(json.encode(coverage));
+      await out.close();
+    },
+    onError: (dynamic error, Chain chain) {
+      stderr.writeln(error);
+      stderr.writeln(chain.terse);
+      // See http://www.retro11.de/ouxr/211bsd/usr/include/sysexits.h.html
+      // EX_SOFTWARE
+      exit(70);
+    },
+  );
 }
 
 class Options {
   Options(
-      this.serviceUri,
-      this.out,
-      this.timeout,
-      this.waitPaused,
-      this.resume,
-      this.includeDart,
-      this.functionCoverage,
-      this.branchCoverage,
-      this.scopedOutput);
+    this.serviceUri,
+    this.out,
+    this.timeout,
+    this.waitPaused,
+    this.resume,
+    this.includeDart,
+    this.functionCoverage,
+    this.branchCoverage,
+    this.scopedOutput,
+  );
 
   final Uri serviceUri;
   final String? out;
@@ -68,39 +77,64 @@ class Options {
 @visibleForTesting
 Options parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
   final parser = ArgParser()
-    ..addOption('host',
-        abbr: 'H',
-        help: 'remote VM host. DEPRECATED: use --uri',
-        defaultsTo: '127.0.0.1')
-    ..addOption('port',
-        abbr: 'p',
-        help: 'remote VM port. DEPRECATED: use --uri',
-        defaultsTo: '8181')
+    ..addOption(
+      'host',
+      abbr: 'H',
+      help: 'remote VM host. DEPRECATED: use --uri',
+      defaultsTo: '127.0.0.1',
+    )
+    ..addOption(
+      'port',
+      abbr: 'p',
+      help: 'remote VM port. DEPRECATED: use --uri',
+      defaultsTo: '8181',
+    )
     ..addOption('uri', abbr: 'u', help: 'VM observatory service URI')
     ..addOption('out', abbr: 'o', help: 'output: may be file or stdout')
-    ..addOption('connect-timeout',
-        abbr: 't', help: 'connect timeout in seconds')
-    ..addMultiOption('scope-output',
-        defaultsTo: defaultOptions.scopeOutput,
-        help: 'restrict coverage results so that only scripts that start with '
-            'the provided package path are considered')
-    ..addFlag('wait-paused',
-        abbr: 'w',
-        defaultsTo: false,
-        help: 'wait for all isolates to be paused before collecting coverage')
-    ..addFlag('resume-isolates',
-        abbr: 'r', defaultsTo: false, help: 'resume all isolates on exit')
-    ..addFlag('include-dart',
-        abbr: 'd', defaultsTo: false, help: 'include "dart:" libraries')
-    ..addFlag('function-coverage',
-        abbr: 'f',
-        defaultsTo: defaultOptions.functionCoverage,
-        help: 'Collect function coverage info')
-    ..addFlag('branch-coverage',
-        abbr: 'b',
-        defaultsTo: defaultOptions.branchCoverage,
-        help: 'Collect branch coverage info (Dart VM must also be run with '
-            '--branch-coverage for this to work)')
+    ..addOption(
+      'connect-timeout',
+      abbr: 't',
+      help: 'connect timeout in seconds',
+    )
+    ..addMultiOption(
+      'scope-output',
+      defaultsTo: defaultOptions.scopeOutput,
+      help:
+          'restrict coverage results so that only scripts that start with '
+          'the provided package path are considered',
+    )
+    ..addFlag(
+      'wait-paused',
+      abbr: 'w',
+      defaultsTo: false,
+      help: 'wait for all isolates to be paused before collecting coverage',
+    )
+    ..addFlag(
+      'resume-isolates',
+      abbr: 'r',
+      defaultsTo: false,
+      help: 'resume all isolates on exit',
+    )
+    ..addFlag(
+      'include-dart',
+      abbr: 'd',
+      defaultsTo: false,
+      help: 'include "dart:" libraries',
+    )
+    ..addFlag(
+      'function-coverage',
+      abbr: 'f',
+      defaultsTo: defaultOptions.functionCoverage,
+      help: 'Collect function coverage info',
+    )
+    ..addFlag(
+      'branch-coverage',
+      abbr: 'b',
+      defaultsTo: defaultOptions.branchCoverage,
+      help:
+          'Collect branch coverage info (Dart VM must also be run with '
+          '--branch-coverage for this to work)',
+    )
     ..addFlag('help', abbr: 'h', negatable: false, help: 'show this help');
 
   final args = parser.parse(arguments);
@@ -141,8 +175,9 @@ Options parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
       (outPath == null && defaultOptions.outputDirectory == null)) {
     out = null;
   } else {
-    final outFilePath = p.normalize(outPath ??
-        p.absolute(defaultOptions.outputDirectory!, 'coverage.json'));
+    final outFilePath = p.normalize(
+      outPath ?? p.absolute(defaultOptions.outputDirectory!, 'coverage.json'),
+    );
 
     final outFile = File(outFilePath);
     if (!FileSystemEntity.isDirectorySync(outFilePath) &&

--- a/pkgs/coverage/bin/format_coverage.dart
+++ b/pkgs/coverage/bin/format_coverage.dart
@@ -96,21 +96,27 @@ Future<void> main(List<String> arguments) async {
         );
   final loader = Loader();
   if (env.prettyPrint) {
-    output = await hitmap.prettyPrint(resolver, loader,
-        reportOn: env.reportOn,
-        ignoreGlobs: ignoreGlobs,
-        reportFuncs: env.prettyPrintFunc,
-        reportBranches: env.prettyPrintBranch);
+    output = await hitmap.prettyPrint(
+      resolver,
+      loader,
+      reportOn: env.reportOn,
+      ignoreGlobs: ignoreGlobs,
+      reportFuncs: env.prettyPrintFunc,
+      reportBranches: env.prettyPrintBranch,
+    );
   } else {
     assert(env.lcov);
-    output = hitmap.formatLcov(resolver,
-        reportOn: env.reportOn,
-        ignoreGlobs: ignoreGlobs,
-        basePath: env.baseDirectory);
+    output = hitmap.formatLcov(
+      resolver,
+      reportOn: env.reportOn,
+      ignoreGlobs: ignoreGlobs,
+      basePath: env.baseDirectory,
+    );
   }
 
-  final outputSink =
-      env.output == null ? stdout : File(env.output!).openWrite();
+  final outputSink = env.output == null
+      ? stdout
+      : File(env.output!).openWrite();
 
   outputSink.write(output);
   await outputSink.flush();
@@ -138,22 +144,26 @@ Future<void> main(List<String> arguments) async {
   final failUnder = env.failUnder;
   if (failUnder != null) {
     // Calculate the overall coverage percentage using the utility function.
-    final result = calculateCoveragePercentage(
-      hitmap,
-    );
+    final result = calculateCoveragePercentage(hitmap);
 
     if (env.verbose) {
-      print('Coverage: ${result.percentage.toStringAsFixed(2)}% '
-          '(${result.coveredLines} of ${result.totalLines} lines)');
+      print(
+        'Coverage: ${result.percentage.toStringAsFixed(2)}% '
+        '(${result.coveredLines} of ${result.totalLines} lines)',
+      );
     }
 
     if (result.percentage < failUnder) {
-      print('Error: Coverage ${result.percentage.toStringAsFixed(2)}% '
-          'is less than required ${failUnder.toStringAsFixed(2)}%');
+      print(
+        'Error: Coverage ${result.percentage.toStringAsFixed(2)}% '
+        'is less than required ${failUnder.toStringAsFixed(2)}%',
+      );
       exit(1);
     } else if (env.verbose) {
-      print('Coverage ${result.percentage.toStringAsFixed(2)}% meets or exceeds'
-          'the required ${failUnder.toStringAsFixed(2)}%');
+      print(
+        'Coverage ${result.percentage.toStringAsFixed(2)}% meets or exceeds'
+        'the required ${failUnder.toStringAsFixed(2)}%',
+      );
     }
   }
 }
@@ -164,27 +174,18 @@ Environment parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
   final parser = ArgParser();
 
   parser
-    ..addOption(
-      'sdk-root',
-      abbr: 's',
-      help: 'path to the SDK root',
-    )
+    ..addOption('sdk-root', abbr: 's', help: 'path to the SDK root')
     ..addOption(
       'fail-under',
       help: 'Fail if coverage is less than the given percentage (0-100)',
     )
+    ..addOption('packages', help: '[DEPRECATED] path to the package spec file')
     ..addOption(
-      'packages',
-      help: '[DEPRECATED] path to the package spec file',
+      'package',
+      help: 'root directory of the package',
+      defaultsTo: defaultOptions.packageDirectory,
     )
-    ..addOption('package',
-        help: 'root directory of the package',
-        defaultsTo: defaultOptions.packageDirectory)
-    ..addOption(
-      'in',
-      abbr: 'i',
-      help: 'input(s): may be file or directory',
-    )
+    ..addOption('in', abbr: 'i', help: 'input(s): may be file or directory')
     ..addOption('out', abbr: 'o', help: 'output: may be file or stdout')
     ..addMultiOption(
       'report-on',
@@ -196,34 +197,51 @@ Environment parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
       defaultsTo: '1',
       help: 'number of workers',
     )
-    ..addOption('bazel-workspace',
-        defaultsTo: '', help: 'Bazel workspace directory')
-    ..addOption('base-directory',
-        abbr: 'b',
-        help: 'the base directory relative to which source paths are output')
-    ..addFlag('bazel',
-        defaultsTo: false, help: 'use Bazel-style path resolution')
-    ..addFlag('pretty-print',
-        abbr: 'r',
-        negatable: false,
-        help: 'convert line coverage data to pretty print format')
-    ..addFlag('pretty-print-func',
-        abbr: 'f',
-        negatable: false,
-        help: 'convert function coverage data to pretty print format')
-    ..addFlag('pretty-print-branch',
-        negatable: false,
-        help: 'convert branch coverage data to pretty print format')
-    ..addFlag('lcov',
-        abbr: 'l',
-        negatable: false,
-        help: 'convert coverage data to lcov format')
+    ..addOption(
+      'bazel-workspace',
+      defaultsTo: '',
+      help: 'Bazel workspace directory',
+    )
+    ..addOption(
+      'base-directory',
+      abbr: 'b',
+      help: 'the base directory relative to which source paths are output',
+    )
+    ..addFlag(
+      'bazel',
+      defaultsTo: false,
+      help: 'use Bazel-style path resolution',
+    )
+    ..addFlag(
+      'pretty-print',
+      abbr: 'r',
+      negatable: false,
+      help: 'convert line coverage data to pretty print format',
+    )
+    ..addFlag(
+      'pretty-print-func',
+      abbr: 'f',
+      negatable: false,
+      help: 'convert function coverage data to pretty print format',
+    )
+    ..addFlag(
+      'pretty-print-branch',
+      negatable: false,
+      help: 'convert branch coverage data to pretty print format',
+    )
+    ..addFlag(
+      'lcov',
+      abbr: 'l',
+      negatable: false,
+      help: 'convert coverage data to lcov format',
+    )
     ..addFlag('verbose', abbr: 'v', negatable: false, help: 'verbose output')
     ..addFlag(
       'check-ignore',
       abbr: 'c',
       negatable: false,
-      help: 'check for coverage ignore comments.'
+      help:
+          'check for coverage ignore comments.'
           ' Not supported in web coverage.',
     )
     ..addMultiOption(
@@ -255,8 +273,10 @@ Environment parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
   if (sdkRoot != null) {
     sdkRoot = p.normalize(p.join(p.absolute(sdkRoot), 'lib'));
     if (!FileSystemEntity.isDirectorySync(sdkRoot)) {
-      fail('Provided SDK root "${args["sdk-root"]}" is not a valid SDK '
-          'top-level directory');
+      fail(
+        'Provided SDK root "${args["sdk-root"]}" is not a valid SDK '
+        'top-level directory',
+      );
     }
   }
 
@@ -275,8 +295,10 @@ Environment parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
   if (args['in'] == null && defaultOptions.outputDirectory == null) {
     fail('No input files given.');
   }
-  final input = p.normalize((args['in'] as String?) ??
-      p.absolute(defaultOptions.outputDirectory!, 'coverage.json'));
+  final input = p.normalize(
+    (args['in'] as String?) ??
+        p.absolute(defaultOptions.outputDirectory!, 'coverage.json'),
+  );
   if (!FileSystemEntity.isDirectorySync(input) &&
       !FileSystemEntity.isFileSync(input)) {
     fail('Provided input "${args["in"]}" is neither a directory nor a file.');
@@ -289,7 +311,8 @@ Environment parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
     output = null;
   } else {
     final outFilePath = p.normalize(
-        outPath ?? p.absolute(defaultOptions.outputDirectory!, 'lcov.info'));
+      outPath ?? p.absolute(defaultOptions.outputDirectory!, 'lcov.info'),
+    );
 
     final outfile = File(outFilePath);
     if (!FileSystemEntity.isDirectorySync(outFilePath) &&
@@ -317,7 +340,8 @@ Environment parseArgs(List<String> arguments, CoverageOptions defaultOptions) {
   var prettyPrint = args['pretty-print'] as bool;
   final prettyPrintFunc = args['pretty-print-func'] as bool;
   final prettyPrintBranch = args['pretty-print-branch'] as bool;
-  final numModesChosen = (prettyPrint ? 1 : 0) +
+  final numModesChosen =
+      (prettyPrint ? 1 : 0) +
       (prettyPrintFunc ? 1 : 0) +
       (prettyPrintBranch ? 1 : 0) +
       (lcov ? 1 : 0);

--- a/pkgs/coverage/bin/test_with_coverage.dart
+++ b/pkgs/coverage/bin/test_with_coverage.dart
@@ -16,14 +16,19 @@ import 'format_coverage.dart' as format_coverage;
 
 final _allProcesses = <Process>[];
 
-Future<void> _dartRun(List<String> args,
-    {required void Function(String) onStdout,
-    required void Function(String) onStderr}) async {
+Future<void> _dartRun(
+  List<String> args, {
+  required void Function(String) onStdout,
+  required void Function(String) onStderr,
+}) async {
   final process = await Process.start(Platform.executable, args);
   _allProcesses.add(process);
 
   void listen(
-      Stream<List<int>> stream, IOSink sink, void Function(String) onLine) {
+    Stream<List<int>> stream,
+    IOSink sink,
+    void Function(String) onLine,
+  ) {
     final broadStream = stream.asBroadcastStream();
     broadStream.listen(sink.add);
     broadStream.lines().listen(onLine);
@@ -57,7 +62,8 @@ ArgParser _createArgParser(CoverageOptions defaultOptions) => ArgParser()
   )
   ..addOption(
     'package-name',
-    help: 'Name of the package to test. '
+    help:
+        'Name of the package to test. '
         'Deduced from --package if not provided. '
         'DEPRECATED: use --scope-output',
   )
@@ -68,8 +74,11 @@ ArgParser _createArgParser(CoverageOptions defaultOptions) => ArgParser()
     abbr: 'o',
     help: 'Output directory. Defaults to <package-dir>/coverage.',
   )
-  ..addOption('test',
-      help: 'Test script to run.', defaultsTo: defaultOptions.testScript)
+  ..addOption(
+    'test',
+    help: 'Test script to run.',
+    defaultsTo: defaultOptions.testScript,
+  )
   ..addFlag(
     'function-coverage',
     abbr: 'f',
@@ -86,12 +95,15 @@ ArgParser _createArgParser(CoverageOptions defaultOptions) => ArgParser()
     'fail-under',
     help: 'Fail if coverage is less than the given percentage (0-100)',
   )
-  ..addMultiOption('scope-output',
-      defaultsTo: defaultOptions.scopeOutput,
-      help: 'restrict coverage results so that only scripts that start with '
-          'the provided package path are considered. Defaults to the name of '
-          'the current package (including all subpackages, if this is a '
-          'workspace).')
+  ..addMultiOption(
+    'scope-output',
+    defaultsTo: defaultOptions.scopeOutput,
+    help:
+        'restrict coverage results so that only scripts that start with '
+        'the provided package path are considered. Defaults to the name of '
+        'the current package (including all subpackages, if this is a '
+        'workspace).',
+  )
   ..addFlag('help', abbr: 'h', negatable: false, help: 'Show this help.');
 
 class Flags {
@@ -120,7 +132,9 @@ class Flags {
 
 @visibleForTesting
 Future<Flags> parseArgs(
-    List<String> arguments, CoverageOptions defaultOptions) async {
+  List<String> arguments,
+  CoverageOptions defaultOptions,
+) async {
   final parser = _createArgParser(defaultOptions);
   final args = parser.parse(arguments);
 

--- a/pkgs/coverage/lib/src/chrome.dart
+++ b/pkgs/coverage/lib/src/chrome.dart
@@ -65,9 +65,11 @@ Future<Map<String, dynamic>> parseChromeCoverage(
 
         final sourceLine = columnEntry.sourceLine!;
         final current = coverage[sourceLine + 1] ?? false;
-        coverage[sourceLine + 1] = current ||
+        coverage[sourceLine + 1] =
+            current ||
             coveredPositions.contains(
-                _Position(lineEntry.line + 1, columnEntry.column + 1));
+              _Position(lineEntry.line + 1, columnEntry.column + 1),
+            );
       }
     }
   }
@@ -90,7 +92,9 @@ Future<Map<String, dynamic>> parseChromeCoverage(
 
 /// Returns all covered positions in a provided source.
 Set<_Position> _coveredPositions(
-    String compiledSource, List<bool> offsetCoverage) {
+  String compiledSource,
+  List<bool> offsetCoverage,
+) {
   final positions = <_Position>{};
   // Line is 1 based.
   var line = 1;
@@ -115,11 +119,13 @@ List<_CoverageInfo> _coverageInfoFor(Map<String, dynamic> entry) {
       in (entry['functions'] as List).cast<Map<String, dynamic>>()) {
     for (var range
         in (functions['ranges'] as List).cast<Map<String, dynamic>>()) {
-      result.add(_CoverageInfo(
-        range['startOffset'] as int,
-        range['endOffset'] as int,
-        (range['count'] as int) > 0,
-      ));
+      result.add(
+        _CoverageInfo(
+          range['startOffset'] as int,
+          range['endOffset'] as int,
+          (range['count'] as int) > 0,
+        ),
+      );
     }
   }
   return result;
@@ -131,8 +137,10 @@ List<bool> _offsetCoverage(List<_CoverageInfo> coverageInfo, int sourceLength) {
 
   // Sort coverage information by their size.
   // Coverage information takes granularity as precedence.
-  coverageInfo.sort((a, b) =>
-      (b.endOffset - b.startOffset).compareTo(a.endOffset - a.startOffset));
+  coverageInfo.sort(
+    (a, b) =>
+        (b.endOffset - b.startOffset).compareTo(a.endOffset - a.startOffset),
+  );
 
   for (var range in coverageInfo) {
     for (var i = range.startOffset; i < range.endOffset; i++) {

--- a/pkgs/coverage/lib/src/collect.dart
+++ b/pkgs/coverage/lib/src/collect.dart
@@ -53,14 +53,19 @@ const _debugTokenPositions = bool.fromEnvironment('DEBUG_COVERAGE');
 ///
 /// [serviceOverrideForTesting] is for internal testing only, and should not be
 /// set by users.
-Future<Map<String, dynamic>> collect(Uri serviceUri, bool resume,
-    bool waitPaused, bool includeDart, Set<String>? scopedOutput,
-    {Set<String>? isolateIds,
-    Duration? timeout,
-    bool functionCoverage = false,
-    bool branchCoverage = false,
-    Map<String, Set<int>>? coverableLineCache,
-    VmService? serviceOverrideForTesting}) async {
+Future<Map<String, dynamic>> collect(
+  Uri serviceUri,
+  bool resume,
+  bool waitPaused,
+  bool includeDart,
+  Set<String>? scopedOutput, {
+  Set<String>? isolateIds,
+  Duration? timeout,
+  bool functionCoverage = false,
+  bool branchCoverage = false,
+  Map<String, Set<int>>? coverableLineCache,
+  VmService? serviceOverrideForTesting,
+}) async {
   scopedOutput ??= <String>{};
 
   late VmService service;
@@ -72,37 +77,49 @@ Future<Map<String, dynamic>> collect(Uri serviceUri, bool resume,
         serviceUri.pathSegments.where((c) => c.isNotEmpty).toList()..add('ws');
     final uri = serviceUri.replace(scheme: 'ws', pathSegments: pathSegments);
 
-    await retry(() async {
-      try {
-        final options = const CompressionOptions(enabled: false);
-        final socket = await WebSocket.connect('$uri', compression: options);
-        final controller = StreamController<String>();
-        socket.listen((data) => controller.add(data as String), onDone: () {
-          controller.close();
-          service.dispose();
-        });
-        service = VmService(controller.stream, socket.add,
-            log: StdoutLog(), disposeHandler: socket.close);
-        await service.getVM().timeout(_retryInterval);
-      } on TimeoutException {
-        // The signature changed in vm_service version 6.0.0.
-        // ignore: await_only_futures
-        await service.dispose();
-        rethrow;
-      }
-    }, _retryInterval, timeout: timeout);
+    await retry(
+      () async {
+        try {
+          final options = const CompressionOptions(enabled: false);
+          final socket = await WebSocket.connect('$uri', compression: options);
+          final controller = StreamController<String>();
+          socket.listen(
+            (data) => controller.add(data as String),
+            onDone: () {
+              controller.close();
+              service.dispose();
+            },
+          );
+          service = VmService(
+            controller.stream,
+            socket.add,
+            log: StdoutLog(),
+            disposeHandler: socket.close,
+          );
+          await service.getVM().timeout(_retryInterval);
+        } on TimeoutException {
+          // The signature changed in vm_service version 6.0.0.
+          // ignore: await_only_futures
+          await service.dispose();
+          rethrow;
+        }
+      },
+      _retryInterval,
+      timeout: timeout,
+    );
   }
 
   try {
     return await _getAllCoverage(
-        service,
-        includeDart,
-        functionCoverage,
-        branchCoverage,
-        scopedOutput,
-        isolateIds,
-        coverableLineCache,
-        waitPaused);
+      service,
+      includeDart,
+      functionCoverage,
+      branchCoverage,
+      scopedOutput,
+      isolateIds,
+      coverableLineCache,
+      waitPaused,
+    );
   } finally {
     if (resume && !waitPaused) {
       await _resumeIsolates(service);
@@ -114,14 +131,15 @@ Future<Map<String, dynamic>> collect(Uri serviceUri, bool resume,
 }
 
 Future<Map<String, dynamic>> _getAllCoverage(
-    VmService service,
-    bool includeDart,
-    bool functionCoverage,
-    bool branchCoverage,
-    Set<String> scopedOutput,
-    Set<String>? isolateIds,
-    Map<String, Set<int>>? coverableLineCache,
-    bool waitPaused) async {
+  VmService service,
+  bool includeDart,
+  bool functionCoverage,
+  bool branchCoverage,
+  Set<String> scopedOutput,
+  Set<String>? isolateIds,
+  Map<String, Set<int>>? coverableLineCache,
+  bool waitPaused,
+) async {
   final allCoverage = <Map<String, dynamic>>[];
 
   final sourceReportKinds = [
@@ -165,25 +183,27 @@ Future<Map<String, dynamic>> _getAllCoverage(
     }
 
     final coverage = await _processSourceReport(
-        service,
-        isolateRef,
-        isolateReport,
-        includeDart,
-        functionCoverage,
-        branchCoverage,
-        coverableLineCache,
-        scopedOutput);
+      service,
+      isolateRef,
+      isolateReport,
+      includeDart,
+      functionCoverage,
+      branchCoverage,
+      coverableLineCache,
+      scopedOutput,
+    );
     allCoverage.addAll(coverage);
   }
 
   if (waitPaused) {
-    await IsolatePausedListener(service,
-            (IsolateRef isolateRef, bool isLastIsolateInGroup) async {
+    await IsolatePausedListener(service, (
+      IsolateRef isolateRef,
+      bool isLastIsolateInGroup,
+    ) async {
       if (isLastIsolateInGroup) {
         await collectIsolate(isolateRef);
       }
-    }, stderr.writeln)
-        .waitUntilAllExited();
+    }, stderr.writeln).waitUntilAllExited();
   } else {
     for (final isolateRef in await getAllIsolates(service)) {
       await collectIsolate(isolateRef);
@@ -200,12 +220,14 @@ Future _resumeIsolates(VmService service) async {
     // Guard against sync as well as async errors: sync - when we are writing
     // message to the socket, the socket might be closed; async - when we are
     // waiting for the response, the socket again closes.
-    futures.add(Future.sync(() async {
-      final isolate = await service.getIsolate(isolateRef.id!);
-      if (isolate.pauseEvent!.kind != EventKind.kResume) {
-        await service.resume(isolateRef.id!);
-      }
-    }));
+    futures.add(
+      Future.sync(() async {
+        final isolate = await service.getIsolate(isolateRef.id!);
+        if (isolate.pauseEvent!.kind != EventKind.kResume) {
+          await service.resume(isolateRef.id!);
+        }
+      }),
+    );
   }
   try {
     await Future.wait(futures);
@@ -240,14 +262,15 @@ int? _getLineFromTokenPos(Script script, int tokenPos) {
 
 /// Returns a JSON coverage list backward-compatible with pre-1.16.0 SDKs.
 Future<List<Map<String, dynamic>>> _processSourceReport(
-    VmService service,
-    IsolateRef isolateRef,
-    SourceReport report,
-    bool includeDart,
-    bool functionCoverage,
-    bool branchCoverage,
-    Map<String, Set<int>>? coverableLineCache,
-    Set<String> scopedOutput) async {
+  VmService service,
+  IsolateRef isolateRef,
+  SourceReport report,
+  bool includeDart,
+  bool functionCoverage,
+  bool branchCoverage,
+  Map<String, Set<int>>? coverableLineCache,
+  Set<String> scopedOutput,
+) async {
   final hitMaps = <Uri, HitMap>{};
   final scripts = <ScriptRef, Script>{};
   final libraries = <LibraryRef>{};
@@ -265,9 +288,12 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
   }
 
   HitMap getHitMap(Uri scriptUri) => hitMaps.putIfAbsent(
-      scriptUri,
-      () => HitMap.empty(
-          functionCoverage: functionCoverage, branchCoverage: branchCoverage));
+    scriptUri,
+    () => HitMap.empty(
+      functionCoverage: functionCoverage,
+      branchCoverage: branchCoverage,
+    ),
+  );
 
   Future<void> processFunction(FuncRef funcRef) async {
     final func = await service.getObject(isolateRef.id!, funcRef.id!) as Func;
@@ -289,8 +315,9 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
     if (line == null) {
       if (_debugTokenPositions) {
         stderr.writeln(
-            'tokenPos $tokenPos in function ${funcRef.name} has no line '
-            'mapping for script ${script.uri!}');
+          'tokenPos $tokenPos in function ${funcRef.name} has no line '
+          'mapping for script ${script.uri!}',
+        );
       }
       return;
     }
@@ -314,8 +341,10 @@ Future<List<Map<String, dynamic>>> _processSourceReport(
     // the lines that don't have a hit. Afterwards, add all the lines that were
     // hit or missed to the cache, so that the next coverage collection won't
     // need to compile this library.
-    final coverableLines =
-        coverableLineCache?.putIfAbsent(scriptUriString, () => <int>{});
+    final coverableLines = coverableLineCache?.putIfAbsent(
+      scriptUriString,
+      () => <int>{},
+    );
 
     // Not returned in scripts section of source report.
     if (scriptUri.scheme == 'evaluate') continue;
@@ -413,7 +442,10 @@ extension _MapExtension<T> on Map<T, int> {
 }
 
 Future<String> _getFuncName(
-    VmService service, IsolateRef isolateRef, Func func) async {
+  VmService service,
+  IsolateRef isolateRef,
+  Func func,
+) async {
   if (func.name == null) {
     return '${func.type}:${func.location!.tokenPos}';
   }

--- a/pkgs/coverage/lib/src/coverage_options.dart
+++ b/pkgs/coverage/lib/src/coverage_options.dart
@@ -17,30 +17,40 @@ class CoverageOptions {
   });
 
   factory CoverageOptions.fromConfig(
-      Config options, CoverageOptions defaultOptions, String? optionsFilePath) {
-    var outputDirectory = options.optionalString('output_directory') ??
+    Config options,
+    CoverageOptions defaultOptions,
+    String? optionsFilePath,
+  ) {
+    var outputDirectory =
+        options.optionalString('output_directory') ??
         defaultOptions.outputDirectory;
-    var packageDirectory = options.optionalString('package_directory') ??
+    var packageDirectory =
+        options.optionalString('package_directory') ??
         defaultOptions.packageDirectory;
 
     if (optionsFilePath != null) {
       if (outputDirectory != null && !path.isAbsolute(outputDirectory)) {
         outputDirectory = path.normalize(
-            path.absolute(path.dirname(optionsFilePath), outputDirectory));
+          path.absolute(path.dirname(optionsFilePath), outputDirectory),
+        );
       }
       if (!path.isAbsolute(packageDirectory)) {
         packageDirectory = path.normalize(
-            path.absolute(path.dirname(optionsFilePath), packageDirectory));
+          path.absolute(path.dirname(optionsFilePath), packageDirectory),
+        );
       }
     }
 
     return CoverageOptions(
       outputDirectory: outputDirectory,
-      scopeOutput: options.optionalStringList('scope_output') ??
+      scopeOutput:
+          options.optionalStringList('scope_output') ??
           defaultOptions.scopeOutput,
-      functionCoverage: options.optionalBool('function_coverage') ??
+      functionCoverage:
+          options.optionalBool('function_coverage') ??
           defaultOptions.functionCoverage,
-      branchCoverage: options.optionalBool('branch_coverage') ??
+      branchCoverage:
+          options.optionalBool('branch_coverage') ??
           defaultOptions.branchCoverage,
       packageDirectory: packageDirectory,
       testScript:
@@ -57,9 +67,7 @@ class CoverageOptions {
 }
 
 class CoverageOptionsProvider {
-  CoverageOptionsProvider({
-    String? filePath,
-  }) {
+  CoverageOptionsProvider({String? filePath}) {
     final file = _getOptionsFile(filePath);
     final fileContents = file?.readAsStringSync();
 
@@ -69,8 +77,11 @@ class CoverageOptionsProvider {
       fileSourceUri: file?.uri,
     );
 
-    coverageOptions =
-        CoverageOptions.fromConfig(options, defaultOptions, optionsFilePath);
+    coverageOptions = CoverageOptions.fromConfig(
+      options,
+      defaultOptions,
+      optionsFilePath,
+    );
   }
 
   late final CoverageOptions coverageOptions;
@@ -80,8 +91,9 @@ class CoverageOptionsProvider {
   File? _getOptionsFile(String? filePath) {
     filePath ??= findOptionsFilePath();
 
-    optionsFilePath =
-        filePath != null ? path.normalize(path.absolute(filePath)) : null;
+    optionsFilePath = filePath != null
+        ? path.normalize(path.absolute(filePath))
+        : null;
 
     if (optionsFilePath == null) {
       return null;

--- a/pkgs/coverage/lib/src/coverage_percentage.dart
+++ b/pkgs/coverage/lib/src/coverage_percentage.dart
@@ -23,8 +23,9 @@ CoverageResult calculateCoveragePercentage(Map<String, HitMap> hitmap) {
     }
     coveredLines += lineHits.values.where((v) => v > 0).length;
   }
-  final coveragePercentage =
-      totalLines > 0 ? coveredLines * 100 / totalLines : 0.0;
+  final coveragePercentage = totalLines > 0
+      ? coveredLines * 100 / totalLines
+      : 0.0;
 
   return CoverageResult(
     percentage: coveragePercentage,

--- a/pkgs/coverage/lib/src/formatter.dart
+++ b/pkgs/coverage/lib/src/formatter.dart
@@ -34,9 +34,11 @@ class LcovFormatter implements Formatter {
 
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) {
-    return Future.value(hitmap
-        .map((key, value) => MapEntry(key, HitMap(value)))
-        .formatLcov(resolver, basePath: basePath, reportOn: reportOn));
+    return Future.value(
+      hitmap
+          .map((key, value) => MapEntry(key, HitMap(value)))
+          .formatLcov(resolver, basePath: basePath, reportOn: reportOn),
+    );
   }
 }
 
@@ -51,8 +53,12 @@ class PrettyPrintFormatter implements Formatter {
   ///
   /// If [reportOn] is provided, coverage report output is limited to files
   /// prefixed with one of the paths included.
-  PrettyPrintFormatter(this.resolver, this.loader,
-      {this.reportOn, this.reportFuncs = false});
+  PrettyPrintFormatter(
+    this.resolver,
+    this.loader, {
+    this.reportOn,
+    this.reportFuncs = false,
+  });
 
   final Resolver resolver;
   final Loader loader;
@@ -61,9 +67,14 @@ class PrettyPrintFormatter implements Formatter {
 
   @override
   Future<String> format(Map<String, Map<int, int>> hitmap) {
-    return hitmap.map((key, value) => MapEntry(key, HitMap(value))).prettyPrint(
-        resolver, loader,
-        reportOn: reportOn, reportFuncs: reportFuncs);
+    return hitmap
+        .map((key, value) => MapEntry(key, HitMap(value)))
+        .prettyPrint(
+          resolver,
+          loader,
+          reportOn: reportOn,
+          reportFuncs: reportFuncs,
+        );
   }
 }
 
@@ -175,16 +186,17 @@ extension FileHitMapsFormatter on Map<String, HitMap> {
       }
       if (reportBranches && v.branchHits == null) {
         throw StateError(
-            'Branch coverage formatting was requested, but the hit map is '
-            'missing branch coverage information. Did you run '
-            'collect_coverage with the --branch-coverage flag?');
+          'Branch coverage formatting was requested, but the hit map is '
+          'missing branch coverage information. Did you run '
+          'collect_coverage with the --branch-coverage flag?',
+        );
       }
 
       final hits = reportFuncs
           ? v.funcHits!
           : reportBranches
-              ? v.branchHits!
-              : v.lineHits;
+          ? v.branchHits!
+          : v.lineHits;
       buf.writeln(source);
       for (var line = 1; line <= lines.length; line++) {
         var prefix = _prefix;

--- a/pkgs/coverage/lib/src/hitmap.dart
+++ b/pkgs/coverage/lib/src/hitmap.dart
@@ -21,11 +21,12 @@ class HitMap {
   /// Constructs an empty hitmap, optionally with function and branch coverage
   /// tables.
   HitMap.empty({bool functionCoverage = false, bool branchCoverage = false})
-      : this(
-            null,
-            functionCoverage ? <int, int>{} : null,
-            functionCoverage ? <int, String>{} : null,
-            branchCoverage ? <int, int>{} : null);
+    : this(
+        null,
+        functionCoverage ? <int, int>{} : null,
+        functionCoverage ? <int, String>{} : null,
+        branchCoverage ? <int, int>{} : null,
+      );
 
   /// Map from line to hit count for that line.
   final Map<int, int> lineHits;
@@ -137,11 +138,15 @@ class HitMap {
     String? packagePath,
   }) async {
     final resolver = await Resolver.create(
-        packagesPath: packagesPath, packagePath: packagePath);
-    return parseJsonSync(jsonResult,
-        checkIgnoredLines: checkIgnoredLines,
-        ignoredLinesInFilesCache: {},
-        resolver: resolver);
+      packagesPath: packagesPath,
+      packagePath: packagePath,
+    );
+    return parseJsonSync(
+      jsonResult,
+      checkIgnoredLines: checkIgnoredLines,
+      ignoredLinesInFilesCache: {},
+      resolver: resolver,
+    );
   }
 
   /// Generates a merged hitmap from a set of coverage JSON files.
@@ -157,13 +162,15 @@ class HitMap {
       final jsonMap = json.decode(contents) as Map<String, dynamic>;
       if (jsonMap.containsKey('coverage')) {
         final jsonResult = jsonMap['coverage'] as List;
-        globalHitmap.merge(await HitMap.parseJson(
-          jsonResult.cast<Map<String, dynamic>>(),
-          checkIgnoredLines: checkIgnoredLines,
-          // ignore: deprecated_member_use_from_same_package
-          packagesPath: packagesPath,
-          packagePath: packagePath,
-        ));
+        globalHitmap.merge(
+          await HitMap.parseJson(
+            jsonResult.cast<Map<String, dynamic>>(),
+            checkIgnoredLines: checkIgnoredLines,
+            // ignore: deprecated_member_use_from_same_package
+            packagesPath: packagesPath,
+            packagePath: packagePath,
+          ),
+        );
       }
     }
     return globalHitmap;
@@ -279,7 +286,9 @@ Future<Map<String, Map<int, int>>> createHitmap(
 /// Merges [newMap] into [result].
 @Deprecated('Migrate to FileHitMaps.merge')
 void mergeHitmaps(
-    Map<String, Map<int, int>> newMap, Map<String, Map<int, int>> result) {
+  Map<String, Map<int, int>> newMap,
+  Map<String, Map<int, int>> result,
+) {
   newMap.forEach((file, v) {
     final fileResult = result[file];
     if (fileResult != null) {
@@ -306,10 +315,12 @@ Future<Map<String, Map<int, int>>> parseCoverage(
   @Deprecated('Use packagePath') String? packagesPath,
   String? packagePath,
 }) async {
-  final result = await HitMap.parseFiles(files,
-      checkIgnoredLines: checkIgnoredLines,
-      packagesPath: packagesPath,
-      packagePath: packagePath);
+  final result = await HitMap.parseFiles(
+    files,
+    checkIgnoredLines: checkIgnoredLines,
+    packagesPath: packagesPath,
+    packagePath: packagePath,
+  );
   return result.map((key, value) => MapEntry(key, value.lineHits));
 }
 
@@ -329,25 +340,25 @@ List<T> _flattenMap<T>(Map map) {
 }
 
 /// Returns a JSON hit map backward-compatible with pre-1.16.0 SDKs.
-Map<String, dynamic> hitmapToJson(HitMap hitmap, Uri scriptUri) =>
-    <String, dynamic>{
-      'source': '$scriptUri',
-      'script': {
-        'type': '@Script',
-        'fixedId': true,
-        'id':
-            'libraries/1/scripts/${Uri.encodeComponent(scriptUri.toString())}',
-        'uri': '$scriptUri',
-        '_kind': 'library',
-      },
-      'hits': _flattenMap<int>(hitmap.lineHits),
-      if (hitmap.funcHits != null)
-        'funcHits': _flattenMap<int>(hitmap.funcHits!),
-      if (hitmap.funcNames != null)
-        'funcNames': _flattenMap<dynamic>(hitmap.funcNames!),
-      if (hitmap.branchHits != null)
-        'branchHits': _flattenMap<int>(hitmap.branchHits!),
-    };
+Map<String, dynamic> hitmapToJson(
+  HitMap hitmap,
+  Uri scriptUri,
+) => <String, dynamic>{
+  'source': '$scriptUri',
+  'script': {
+    'type': '@Script',
+    'fixedId': true,
+    'id': 'libraries/1/scripts/${Uri.encodeComponent(scriptUri.toString())}',
+    'uri': '$scriptUri',
+    '_kind': 'library',
+  },
+  'hits': _flattenMap<int>(hitmap.lineHits),
+  if (hitmap.funcHits != null) 'funcHits': _flattenMap<int>(hitmap.funcHits!),
+  if (hitmap.funcNames != null)
+    'funcNames': _flattenMap<dynamic>(hitmap.funcNames!),
+  if (hitmap.branchHits != null)
+    'branchHits': _flattenMap<int>(hitmap.branchHits!),
+};
 
 /// Sorts the hits array based on the line numbers.
 List _sortHits(List hits) {

--- a/pkgs/coverage/lib/src/isolate_paused_listener.dart
+++ b/pkgs/coverage/lib/src/isolate_paused_listener.dart
@@ -12,8 +12,8 @@ import 'util.dart';
 
 typedef SyncIsolateCallback = void Function(IsolateRef isolate);
 typedef AsyncIsolateCallback = Future<void> Function(IsolateRef isolate);
-typedef AsyncIsolatePausedCallback = Future<void> Function(
-    IsolateRef isolate, bool isLastIsolateInGroup);
+typedef AsyncIsolatePausedCallback =
+    Future<void> Function(IsolateRef isolate, bool isLastIsolateInGroup);
 typedef AsyncVmServiceEventCallback = Future<void> Function(Event event);
 typedef SyncErrorLogger = void Function(String message);
 
@@ -133,8 +133,10 @@ class IsolatePausedListener {
     group.exit(isolateRef);
     --_numIsolates;
     if (group.noLiveIsolates && !group.collected) {
-      _log('ERROR: An isolate exited without pausing, causing '
-          'coverage data to be lost for group ${isolateRef.isolateGroupId!}.');
+      _log(
+        'ERROR: An isolate exited without pausing, causing '
+        'coverage data to be lost for group ${isolateRef.isolateGroupId!}.',
+      );
     }
     if (isolateRef.id! == _mainIsolate?.id) {
       // Main isolate exited without pausing.
@@ -176,10 +178,11 @@ extension on Completer {
 ///    if an exit event arrives while [onIsolatePaused] is being awaited.
 ///  - Each callback will only be called once per isolate.
 Future<void> listenToIsolateLifecycleEvents(
-    VmService service,
-    SyncIsolateCallback onIsolateStarted,
-    AsyncIsolateCallback onIsolatePaused,
-    SyncIsolateCallback onIsolateExited) async {
+  VmService service,
+  SyncIsolateCallback onIsolateStarted,
+  AsyncIsolateCallback onIsolatePaused,
+  SyncIsolateCallback onIsolateExited,
+) async {
   final started = <String>{};
   void onStart(IsolateRef isolateRef) {
     if (started.add(isolateRef.id!)) onIsolateStarted(isolateRef);

--- a/pkgs/coverage/lib/src/resolver.dart
+++ b/pkgs/coverage/lib/src/resolver.dart
@@ -11,15 +11,15 @@ import 'package:path/path.dart' as p;
 class Resolver {
   @Deprecated('Use Resolver.create')
   Resolver({this.packagesPath, this.sdkRoot})
-      : _packages = packagesPath != null ? _parsePackages(packagesPath) : null,
-        packagePath = null;
+    : _packages = packagesPath != null ? _parsePackages(packagesPath) : null,
+      packagePath = null;
 
-  Resolver._(
-      {this.packagesPath,
-      this.packagePath,
-      this.sdkRoot,
-      Map<String, Uri>? packages})
-      : _packages = packages;
+  Resolver._({
+    this.packagesPath,
+    this.packagePath,
+    this.sdkRoot,
+    Map<String, Uri>? packages,
+  }) : _packages = packages;
 
   static Future<Resolver> create({
     String? packagesPath,
@@ -63,11 +63,7 @@ class Resolver {
         }
         // Canonicalize path. For instance: _collection-dev => _collection_dev.
         path = path.replaceAll('-', '_');
-        final pathSegments = [
-          sdkRoot,
-          path,
-          ...uri.pathSegments.sublist(1),
-        ];
+        final pathSegments = [sdkRoot, path, ...uri.pathSegments.sublist(1)];
         filePath = p.joinAll(pathSegments);
       } else {
         // Resolve 'dart:something' to be something/something.dart in the SDK.
@@ -111,10 +107,12 @@ class Resolver {
   static Map<String, Uri> _parsePackages(String packagesPath) {
     final content = File(packagesPath).readAsStringSync();
     final packagesUri = p.toUri(packagesPath);
-    final parsed =
-        PackageConfig.parseString(content, Uri.base.resolveUri(packagesUri));
+    final parsed = PackageConfig.parseString(
+      content,
+      Uri.base.resolveUri(packagesUri),
+    );
     return {
-      for (var package in parsed.packages) package.name: package.packageUriRoot
+      for (var package in parsed.packages) package.name: package.packageUriRoot,
     };
   }
 
@@ -122,7 +120,7 @@ class Resolver {
     final parsed = await findPackageConfig(Directory(packagePath));
     if (parsed == null) return null;
     return {
-      for (var package in parsed.packages) package.name: package.packageUriRoot
+      for (var package in parsed.packages) package.name: package.packageUriRoot,
     };
   }
 }
@@ -148,8 +146,10 @@ class BazelResolver extends Resolver {
       return _resolveBazelPackage(uri.pathSegments);
     }
     if (uri.scheme == 'file') {
-      final runfilesPathSegment =
-          '.runfiles/$workspacePath'.replaceAll(RegExp(r'/*$'), '/');
+      final runfilesPathSegment = '.runfiles/$workspacePath'.replaceAll(
+        RegExp(r'/*$'),
+        '/',
+      );
       final runfilesPos = uri.path.indexOf(runfilesPathSegment);
       if (runfilesPos >= 0) {
         final pathStart = runfilesPos + runfilesPathSegment.length;

--- a/pkgs/coverage/lib/src/run_and_collect.dart
+++ b/pkgs/coverage/lib/src/run_and_collect.dart
@@ -8,11 +8,13 @@ import 'dart:io';
 import 'collect.dart';
 import 'util.dart';
 
-Future<Map<String, dynamic>> runAndCollect(String scriptPath,
-    {List<String>? scriptArgs,
-    bool checked = false,
-    bool includeDart = false,
-    Duration? timeout}) async {
+Future<Map<String, dynamic>> runAndCollect(
+  String scriptPath, {
+  List<String>? scriptArgs,
+  bool checked = false,
+  bool includeDart = false,
+  Duration? timeout,
+}) async {
   final dartArgs = [
     '--enable-vm-service',
     '--pause_isolates_on_exit',

--- a/pkgs/coverage/lib/src/util.dart
+++ b/pkgs/coverage/lib/src/util.dart
@@ -13,8 +13,11 @@ import 'package:yaml/yaml.dart';
 // TODO(cbracken) make generic
 /// Retries the specified function with the specified interval and returns
 /// the result on successful completion.
-Future<dynamic> retry(Future Function() f, Duration interval,
-    {Duration? timeout}) async {
+Future<dynamic> retry(
+  Future Function() f,
+  Duration interval, {
+  Duration? timeout,
+}) async {
   var keepGoing = true;
 
   Future<dynamic> withTimeout(Future Function() f, {Duration? duration}) {
@@ -22,13 +25,16 @@ Future<dynamic> retry(Future Function() f, Duration interval,
       return f();
     }
 
-    return f().timeout(duration, onTimeout: () {
-      keepGoing = false;
-      final msg = duration.inSeconds == 0
-          ? '${duration.inMilliseconds}ms'
-          : '${duration.inSeconds}s';
-      throw StateError('Failed to complete within $msg');
-    });
+    return f().timeout(
+      duration,
+      onTimeout: () {
+        keepGoing = false;
+        final msg = duration.inSeconds == 0
+            ? '${duration.inMilliseconds}ms'
+            : '${duration.inSeconds}s';
+        throw StateError('Failed to complete within $msg');
+      },
+    );
   }
 
   return withTimeout(() async {

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -1,11 +1,11 @@
 name: coverage
-version: 1.15.2-wip
+version: 1.16.0-wip
 description: Coverage data manipulation and formatting
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/coverage
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acoverage
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.9.0
 
 dependencies:
   args: ^2.0.0

--- a/pkgs/coverage/test/chrome_test.dart
+++ b/pkgs/coverage/test/chrome_test.dart
@@ -32,9 +32,13 @@ Future<Uri> sourceUriProvider(String sourceUrl, String scriptId) async =>
 
 void main() {
   test('reports correctly', () async {
-    final preciseCoverage = json.decode(
-        await File('test/test_files/chrome_precise_report.txt')
-            .readAsString()) as List;
+    final preciseCoverage =
+        json.decode(
+              await File(
+                'test/test_files/chrome_precise_report.txt',
+              ).readAsString(),
+            )
+            as List;
 
     final report = await parseChromeCoverage(
       preciseCoverage.cast(),
@@ -43,11 +47,11 @@ void main() {
       sourceUriProvider,
     );
 
-    final sourceReport =
-        (report['coverage'] as List<Map<String, dynamic>>).firstWhere(
-      (Map<String, dynamic> report) =>
-          report['source'].toString().contains('main_test.dart'),
-    );
+    final sourceReport = (report['coverage'] as List<Map<String, dynamic>>)
+        .firstWhere(
+          (Map<String, dynamic> report) =>
+              report['source'].toString().contains('main_test.dart'),
+        );
 
     final expectedHits = {
       7: 1,

--- a/pkgs/coverage/test/collect_coverage_api_test.dart
+++ b/pkgs/coverage/test/collect_coverage_api_test.dart
@@ -50,61 +50,64 @@ void main() {
   });
 
   test('collect_coverage_api with isolateIds', () async {
-    final coverage =
-        coverageDataFromJson(await _collectCoverage(isolateIds: true));
+    final coverage = coverageDataFromJson(
+      await _collectCoverage(isolateIds: true),
+    );
     expect(coverage, isEmpty);
   });
 
   test('collect_coverage_api with function coverage', () async {
-    final coverage =
-        coverageDataFromJson(await _collectCoverage(functionCoverage: true));
+    final coverage = coverageDataFromJson(
+      await _collectCoverage(functionCoverage: true),
+    );
     expect(coverage, isNotEmpty);
 
     final sources = coverage.sources();
 
     final functionInfo = functionInfoFromSources(sources);
 
-    expect(
-      functionInfo[_sampleAppFileUri]!,
-      {
-        'main': 1,
-        'usedMethod': 1,
-        'unusedMethod': 0,
-      },
-    );
+    expect(functionInfo[_sampleAppFileUri]!, {
+      'main': 1,
+      'usedMethod': 1,
+      'unusedMethod': 0,
+    });
 
-    expect(
-      functionInfo[_isolateLibFileUri]!,
-      {
-        'BarClass.BarClass': 1,
-        'fooAsync': 1,
-        'fooSync': 1,
-        'isolateTask': 1,
-        'BarClass.baz': 1
-      },
-    );
+    expect(functionInfo[_isolateLibFileUri]!, {
+      'BarClass.BarClass': 1,
+      'fooAsync': 1,
+      'fooSync': 1,
+      'isolateTask': 1,
+      'BarClass.baz': 1,
+    });
   });
 
   test('collect_coverage_api with branch coverage', () async {
-    final coverage =
-        coverageDataFromJson(await _collectCoverage(branchCoverage: true));
+    final coverage = coverageDataFromJson(
+      await _collectCoverage(branchCoverage: true),
+    );
     expect(coverage, isNotEmpty);
 
     final sources = coverage.sources();
 
     // Dart VM versions before 2.17 don't support branch coverage.
-    expect(sources[_sampleAppFileUri],
-        everyElement(containsPair('branchHits', isNotEmpty)));
-    expect(sources[_isolateLibFileUri],
-        everyElement(containsPair('branchHits', isNotEmpty)));
+    expect(
+      sources[_sampleAppFileUri],
+      everyElement(containsPair('branchHits', isNotEmpty)),
+    );
+    expect(
+      sources[_isolateLibFileUri],
+      everyElement(containsPair('branchHits', isNotEmpty)),
+    );
   });
 
   test('collect_coverage_api with coverableLineCache', () async {
     final coverableLineCache = <String, Set<int>>{};
-    final coverage =
-        await _collectCoverage(coverableLineCache: coverableLineCache);
+    final coverage = await _collectCoverage(
+      coverableLineCache: coverableLineCache,
+    );
     final result = await HitMap.parseJson(
-        coverage['coverage'] as List<Map<String, dynamic>>);
+      coverage['coverage'] as List<Map<String, dynamic>>,
+    );
 
     expect(coverableLineCache, contains(_sampleAppFileUri));
     expect(coverableLineCache, contains(_isolateLibFileUri));
@@ -118,10 +121,12 @@ void main() {
     // libraries. The result should be that _isolateLibFileUri should be the
     // same, but _sampleAppFileUri should be missing all its missed lines.
     coverableLineCache[_sampleAppFileUri] = {};
-    final coverage2 =
-        await _collectCoverage(coverableLineCache: coverableLineCache);
+    final coverage2 = await _collectCoverage(
+      coverableLineCache: coverableLineCache,
+    );
     final result2 = await HitMap.parseJson(
-        coverage2['coverage'] as List<Map<String, dynamic>>);
+      coverage2['coverage'] as List<Map<String, dynamic>>,
+    );
 
     // _isolateLibFileUri still has missed lines, but _sampleAppFileUri doesn't.
     expect(result2[_sampleAppFileUri]!.lineHits.containsValue(0), isFalse);
@@ -129,30 +134,41 @@ void main() {
 
     // _isolateLibFileUri is the same. _sampleAppFileUri is the same, but
     // without all its missed lines.
-    expect(result2[_isolateLibFileUri]!.lineHits,
-        result[_isolateLibFileUri]!.lineHits);
+    expect(
+      result2[_isolateLibFileUri]!.lineHits,
+      result[_isolateLibFileUri]!.lineHits,
+    );
     result[_sampleAppFileUri]!.lineHits.removeWhere((line, hits) => hits == 0);
-    expect(result2[_sampleAppFileUri]!.lineHits,
-        result[_sampleAppFileUri]!.lineHits);
+    expect(
+      result2[_sampleAppFileUri]!.lineHits,
+      result[_sampleAppFileUri]!.lineHits,
+    );
   }, skip: !platformVersionCheck(3, 2));
 }
 
-Future<Map<String, dynamic>> _collectCoverage(
-    {Set<String> scopedOutput = const {},
-    bool isolateIds = false,
-    bool functionCoverage = false,
-    bool branchCoverage = false,
-    Map<String, Set<int>>? coverableLineCache}) async {
+Future<Map<String, dynamic>> _collectCoverage({
+  Set<String> scopedOutput = const {},
+  bool isolateIds = false,
+  bool functionCoverage = false,
+  bool branchCoverage = false,
+  Map<String, Set<int>>? coverableLineCache,
+}) async {
   // run the sample app, with the right flags
   final sampleProcess = await runTestApp();
 
   final serviceUri = await serviceUriFromProcess(sampleProcess.stdoutStream());
   final isolateIdSet = isolateIds ? <String>{} : null;
 
-  return collect(serviceUri, true, true, false, scopedOutput,
-      timeout: timeout,
-      isolateIds: isolateIdSet,
-      functionCoverage: functionCoverage,
-      branchCoverage: branchCoverage,
-      coverableLineCache: coverableLineCache);
+  return collect(
+    serviceUri,
+    true,
+    true,
+    false,
+    scopedOutput,
+    timeout: timeout,
+    isolateIds: isolateIdSet,
+    functionCoverage: functionCoverage,
+    branchCoverage: branchCoverage,
+    coverableLineCache: coverableLineCache,
+  );
 }

--- a/pkgs/coverage/test/collect_coverage_config_test.dart
+++ b/pkgs/coverage/test/collect_coverage_config_test.dart
@@ -27,8 +27,10 @@ void main() {
     });
 
     test('format coverage', () {
-      final formattedCoverage =
-          format_coverage.parseArgs(formatCoverageArgs, defaults);
+      final formattedCoverage = format_coverage.parseArgs(
+        formatCoverageArgs,
+        defaults,
+      );
 
       expect(formattedCoverage.output, isNull);
       expect(formattedCoverage.packagePath, defaults.packageDirectory);
@@ -37,10 +39,14 @@ void main() {
     test('test with coverage', () async {
       final testCoverage = await test_with_coverage.parseArgs([], defaults);
 
-      expect(path.canonicalize(testCoverage.packageDir),
-          path.canonicalize(defaults.packageDirectory));
-      expect(path.canonicalize(testCoverage.outDir),
-          path.canonicalize('coverage'));
+      expect(
+        path.canonicalize(testCoverage.packageDir),
+        path.canonicalize(defaults.packageDirectory),
+      );
+      expect(
+        path.canonicalize(testCoverage.outDir),
+        path.canonicalize('coverage'),
+      );
       expect(testCoverage.testScript, defaults.testScript);
       expect(testCoverage.functionCoverage, defaults.functionCoverage);
       expect(testCoverage.branchCoverage, defaults.branchCoverage);
@@ -55,29 +61,43 @@ void main() {
 
     // Parse arguments with empty command line args
     final collectedCoverage = collect_coverage.parseArgs([], configuredOptions);
-    final formattedCoverage =
-        format_coverage.parseArgs(formatCoverageArgs, configuredOptions);
-    final testCoverage =
-        await test_with_coverage.parseArgs([], configuredOptions);
+    final formattedCoverage = format_coverage.parseArgs(
+      formatCoverageArgs,
+      configuredOptions,
+    );
+    final testCoverage = await test_with_coverage.parseArgs(
+      [],
+      configuredOptions,
+    );
 
     // Verify collect coverage yaml values
     expect(collectedCoverage.scopedOutput, ['lib', 'src']);
     expect(collectedCoverage.functionCoverage, isTrue);
     expect(collectedCoverage.branchCoverage, isFalse);
-    expect(path.canonicalize(collectedCoverage.out!),
-        path.canonicalize('var/coverage_data/coverage.json'));
+    expect(
+      path.canonicalize(collectedCoverage.out!),
+      path.canonicalize('var/coverage_data/coverage.json'),
+    );
 
     // Verify format coverage yaml values
-    expect(path.canonicalize(formattedCoverage.output!),
-        path.canonicalize('var/coverage_data/lcov.info'));
-    expect(path.canonicalize(formattedCoverage.packagePath),
-        path.canonicalize('test/test_files'));
+    expect(
+      path.canonicalize(formattedCoverage.output!),
+      path.canonicalize('var/coverage_data/lcov.info'),
+    );
+    expect(
+      path.canonicalize(formattedCoverage.packagePath),
+      path.canonicalize('test/test_files'),
+    );
 
     // Verify test with coverage yaml values
-    expect(path.canonicalize(testCoverage.packageDir),
-        path.canonicalize('test/test_files'));
-    expect(path.canonicalize(testCoverage.outDir),
-        path.canonicalize('var/coverage_data'));
+    expect(
+      path.canonicalize(testCoverage.packageDir),
+      path.canonicalize('test/test_files'),
+    );
+    expect(
+      path.canonicalize(testCoverage.outDir),
+      path.canonicalize('var/coverage_data'),
+    );
     expect(testCoverage.testScript, 'test1');
     expect(testCoverage.functionCoverage, isTrue);
     expect(testCoverage.branchCoverage, isFalse);
@@ -91,19 +111,29 @@ void main() {
       ).coverageOptions;
 
       // Parse arguments with empty command line args
-      final collectedCoverage =
-          collect_coverage.parseArgs([], configuredOptions);
-      final testCoverage =
-          await test_with_coverage.parseArgs([], configuredOptions);
-      final formattedCoverage =
-          format_coverage.parseArgs([], configuredOptions);
+      final collectedCoverage = collect_coverage.parseArgs(
+        [],
+        configuredOptions,
+      );
+      final testCoverage = await test_with_coverage.parseArgs(
+        [],
+        configuredOptions,
+      );
+      final formattedCoverage = format_coverage.parseArgs(
+        [],
+        configuredOptions,
+      );
 
-      expect(path.canonicalize(collectedCoverage.out!),
-          path.canonicalize('var/coverage_data/custom_coverage/coverage.json'));
+      expect(
+        path.canonicalize(collectedCoverage.out!),
+        path.canonicalize('var/coverage_data/custom_coverage/coverage.json'),
+      );
       expect(collectedCoverage.scopedOutput, ['lib', 'test']);
       expect(collectedCoverage.functionCoverage, isFalse);
-      expect(path.canonicalize(formattedCoverage.output!),
-          path.canonicalize('var/coverage_data/custom_coverage/lcov.info'));
+      expect(
+        path.canonicalize(formattedCoverage.output!),
+        path.canonicalize('var/coverage_data/custom_coverage/lcov.info'),
+      );
       expect(testCoverage.scopeOutput, ['lib', 'test']);
     });
 
@@ -113,29 +143,43 @@ void main() {
       ).coverageOptions;
 
       // Parse arguments with empty command line args
-      final collectedCoverage =
-          collect_coverage.parseArgs([], configuredOptions);
-      final formattedCoverage =
-          format_coverage.parseArgs([], configuredOptions);
-      final testCoverage =
-          await test_with_coverage.parseArgs([], configuredOptions);
+      final collectedCoverage = collect_coverage.parseArgs(
+        [],
+        configuredOptions,
+      );
+      final formattedCoverage = format_coverage.parseArgs(
+        [],
+        configuredOptions,
+      );
+      final testCoverage = await test_with_coverage.parseArgs(
+        [],
+        configuredOptions,
+      );
 
       // Verify collect coverage yaml values
       expect(collectedCoverage.scopedOutput, ['lib', 'tools']);
       expect(collectedCoverage.branchCoverage, isFalse);
       expect(collectedCoverage.functionCoverage, isTrue);
-      expect(path.canonicalize(collectedCoverage.out!),
-          path.canonicalize('var/coverage_data/custom_lcov/coverage.json'));
+      expect(
+        path.canonicalize(collectedCoverage.out!),
+        path.canonicalize('var/coverage_data/custom_lcov/coverage.json'),
+      );
 
       // Verify format coverage yaml values
-      expect(path.canonicalize(formattedCoverage.output!),
-          path.canonicalize('var/coverage_data/custom_lcov/lcov.info'));
-      expect(path.canonicalize(formattedCoverage.packagePath),
-          path.canonicalize('test/test_coverage_options'));
+      expect(
+        path.canonicalize(formattedCoverage.output!),
+        path.canonicalize('var/coverage_data/custom_lcov/lcov.info'),
+      );
+      expect(
+        path.canonicalize(formattedCoverage.packagePath),
+        path.canonicalize('test/test_coverage_options'),
+      );
 
       // Verify test with coverage yaml values
-      expect(path.canonicalize(testCoverage.outDir),
-          path.canonicalize('var/coverage_data/custom_lcov'));
+      expect(
+        path.canonicalize(testCoverage.outDir),
+        path.canonicalize('var/coverage_data/custom_lcov'),
+      );
       expect(testCoverage.testScript, 'custom_test');
       expect(testCoverage.functionCoverage, isTrue);
     });
@@ -166,15 +210,19 @@ void main() {
       ], configuredOptions);
 
       // Verify collect coverage command line args
-      expect(collectedCoverage.out,
-          path.normalize('var/coverage_data/coverage.json'));
+      expect(
+        collectedCoverage.out,
+        path.normalize('var/coverage_data/coverage.json'),
+      );
       expect(collectedCoverage.scopedOutput, ['lib']);
       expect(collectedCoverage.functionCoverage, isFalse);
       expect(collectedCoverage.branchCoverage, isTrue);
 
       // Verify format coverage command line args
-      expect(formattedCoverage.output,
-          path.normalize('var/coverage_data/out_test.info'));
+      expect(
+        formattedCoverage.output,
+        path.normalize('var/coverage_data/out_test.info'),
+      );
       expect(formattedCoverage.packagePath, '../code_builder');
 
       // Verify test with coverage command line args
@@ -225,9 +273,10 @@ void main() {
 
   test('format exception when empty yaml file', () {
     expect(
-        () => CoverageOptionsProvider(
-              filePath: 'test/test_coverage_options/empty.yaml',
-            ),
-        throwsFormatException);
+      () => CoverageOptionsProvider(
+        filePath: 'test/test_coverage_options/empty.yaml',
+      ),
+      throwsFormatException,
+    );
   });
 }

--- a/pkgs/coverage/test/collect_coverage_mock_test.dart
+++ b/pkgs/coverage/test/collect_coverage_mock_test.dart
@@ -47,13 +47,15 @@ MockVmService _mockService(
     isoGroups.add(_isoGroup(group.key, isosOfGroup));
     isoRefs.addAll(isosOfGroup);
   }
-  when(service.getVM()).thenAnswer(
-      (_) async => VM(isolates: isoRefs, isolateGroups: isoGroupRefs));
+  when(
+    service.getVM(),
+  ).thenAnswer((_) async => VM(isolates: isoRefs, isolateGroups: isoGroupRefs));
   for (final group in isoGroups) {
     when(service.getIsolateGroup(group.id)).thenAnswer((_) async => group);
   }
-  when(service.getVersion()).thenAnswer(
-      (_) async => Version(major: majorVersion, minor: minorVersion));
+  when(
+    service.getVersion(),
+  ).thenAnswer((_) async => Version(major: majorVersion, minor: minorVersion));
   return service;
 }
 
@@ -61,44 +63,37 @@ void main() {
   group('Mock VM Service', () {
     test('Collect coverage', () async {
       final service = _mockService(4, 13);
-      when(service.getSourceReport(
-        'isolate',
-        ['Coverage'],
-        forceCompile: true,
-        reportLines: true,
-      )).thenAnswer((_) async => SourceReport(
-            ranges: [
-              _range(
-                0,
-                SourceReportCoverage(
-                  hits: [12],
-                  misses: [47],
-                ),
-              ),
-              _range(
-                1,
-                SourceReportCoverage(
-                  hits: [95],
-                  misses: [52],
-                ),
-              ),
-            ],
-            scripts: [
-              ScriptRef(
-                uri: 'package:foo/foo.dart',
-                id: 'foo',
-              ),
-              ScriptRef(
-                uri: 'package:bar/bar.dart',
-                id: 'bar',
-              ),
-            ],
-          ));
+      when(
+        service.getSourceReport(
+          'isolate',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+        ),
+      ).thenAnswer(
+        (_) async => SourceReport(
+          ranges: [
+            _range(0, SourceReportCoverage(hits: [12], misses: [47])),
+            _range(1, SourceReportCoverage(hits: [95], misses: [52])),
+          ],
+          scripts: [
+            ScriptRef(uri: 'package:foo/foo.dart', id: 'foo'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: 'bar'),
+          ],
+        ),
+      );
 
-      final jsonResult = await collect(Uri(), false, false, false, null,
-          serviceOverrideForTesting: service);
+      final jsonResult = await collect(
+        Uri(),
+        false,
+        false,
+        false,
+        null,
+        serviceOverrideForTesting: service,
+      );
       final result = await HitMap.parseJson(
-          jsonResult['coverage'] as List<Map<String, dynamic>>);
+        jsonResult['coverage'] as List<Map<String, dynamic>>,
+      );
 
       expect(result.length, 2);
       expect(result['package:foo/foo.dart']?.lineHits, {12: 1, 47: 0});
@@ -107,130 +102,129 @@ void main() {
 
     test('Collect coverage, scoped output', () async {
       final service = _mockService(4, 13);
-      when(service.getSourceReport(
-        'isolate',
-        ['Coverage'],
-        forceCompile: true,
-        reportLines: true,
-        libraryFilters: ['package:foo/'],
-      )).thenAnswer((_) async => SourceReport(
-            ranges: [
-              _range(
-                0,
-                SourceReportCoverage(
-                  hits: [12],
-                  misses: [47],
-                ),
-              ),
-            ],
-            scripts: [
-              ScriptRef(
-                uri: 'package:foo/foo.dart',
-                id: 'foo',
-              ),
-            ],
-          ));
+      when(
+        service.getSourceReport(
+          'isolate',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+          libraryFilters: ['package:foo/'],
+        ),
+      ).thenAnswer(
+        (_) async => SourceReport(
+          ranges: [
+            _range(0, SourceReportCoverage(hits: [12], misses: [47])),
+          ],
+          scripts: [ScriptRef(uri: 'package:foo/foo.dart', id: 'foo')],
+        ),
+      );
 
-      final jsonResult = await collect(Uri(), false, false, false, {'foo'},
-          serviceOverrideForTesting: service);
+      final jsonResult = await collect(Uri(), false, false, false, {
+        'foo',
+      }, serviceOverrideForTesting: service);
       final result = await HitMap.parseJson(
-          jsonResult['coverage'] as List<Map<String, dynamic>>);
+        jsonResult['coverage'] as List<Map<String, dynamic>>,
+      );
 
       expect(result.length, 1);
       expect(result['package:foo/foo.dart']?.lineHits, {12: 1, 47: 0});
     });
 
     test('Collect coverage, fast isolate group deduping', () async {
-      final service = _mockService(4, 13, isolateGroups: {
-        'isolateGroupA': ['isolate1', 'isolate2'],
-        'isolateGroupB': ['isolate3'],
-      });
-      when(service.getSourceReport(
-        'isolate1',
-        ['Coverage'],
-        forceCompile: true,
-        reportLines: true,
-      )).thenAnswer((_) async => SourceReport(
-            ranges: [
-              _range(
-                0,
-                SourceReportCoverage(
-                  hits: [12],
-                  misses: [47],
-                ),
-              ),
-              _range(
-                1,
-                SourceReportCoverage(
-                  hits: [95],
-                  misses: [52],
-                ),
-              ),
-            ],
-            scripts: [
-              ScriptRef(
-                uri: 'package:foo/foo.dart',
-                id: 'foo',
-              ),
-              ScriptRef(
-                uri: 'package:bar/bar.dart',
-                id: 'bar',
-              ),
-            ],
-          ));
-      when(service.getSourceReport(
-        'isolate3',
-        ['Coverage'],
-        forceCompile: true,
-        reportLines: true,
-      )).thenAnswer((_) async => SourceReport(
-            ranges: [
-              _range(
-                0,
-                SourceReportCoverage(
-                  hits: [34],
-                  misses: [61],
-                ),
-              ),
-            ],
-            scripts: [
-              ScriptRef(
-                uri: 'package:baz/baz.dart',
-                id: 'baz',
-              ),
-            ],
-          ));
+      final service = _mockService(
+        4,
+        13,
+        isolateGroups: {
+          'isolateGroupA': ['isolate1', 'isolate2'],
+          'isolateGroupB': ['isolate3'],
+        },
+      );
+      when(
+        service.getSourceReport(
+          'isolate1',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+        ),
+      ).thenAnswer(
+        (_) async => SourceReport(
+          ranges: [
+            _range(0, SourceReportCoverage(hits: [12], misses: [47])),
+            _range(1, SourceReportCoverage(hits: [95], misses: [52])),
+          ],
+          scripts: [
+            ScriptRef(uri: 'package:foo/foo.dart', id: 'foo'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: 'bar'),
+          ],
+        ),
+      );
+      when(
+        service.getSourceReport(
+          'isolate3',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+        ),
+      ).thenAnswer(
+        (_) async => SourceReport(
+          ranges: [
+            _range(0, SourceReportCoverage(hits: [34], misses: [61])),
+          ],
+          scripts: [ScriptRef(uri: 'package:baz/baz.dart', id: 'baz')],
+        ),
+      );
 
-      final jsonResult = await collect(Uri(), false, false, false, null,
-          serviceOverrideForTesting: service);
+      final jsonResult = await collect(
+        Uri(),
+        false,
+        false,
+        false,
+        null,
+        serviceOverrideForTesting: service,
+      );
       final result = await HitMap.parseJson(
-          jsonResult['coverage'] as List<Map<String, dynamic>>);
+        jsonResult['coverage'] as List<Map<String, dynamic>>,
+      );
 
       expect(result.length, 3);
       expect(result['package:foo/foo.dart']?.lineHits, {12: 1, 47: 0});
       expect(result['package:bar/bar.dart']?.lineHits, {95: 1, 52: 0});
       expect(result['package:baz/baz.dart']?.lineHits, {34: 1, 61: 0});
-      verifyNever(service.getSourceReport('isolate2', ['Coverage'],
-          forceCompile: true, reportLines: true));
+      verifyNever(
+        service.getSourceReport(
+          'isolate2',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+        ),
+      );
       verifyNever(service.getIsolateGroup('isolateGroupA'));
       verifyNever(service.getIsolateGroup('isolateGroupB'));
     });
 
-    test(
-        'Collect coverage, no scoped output, '
+    test('Collect coverage, no scoped output, '
         'handles SentinelException from getSourceReport', () async {
       final service = _mockService(4, 13);
-      when(service.getSourceReport(
-        'isolate',
-        ['Coverage'],
-        forceCompile: true,
-        reportLines: true,
-      )).thenThrow(FakeSentinelException());
+      when(
+        service.getSourceReport(
+          'isolate',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+        ),
+      ).thenThrow(FakeSentinelException());
 
-      final jsonResult = await collect(Uri(), false, false, false, null,
-          serviceOverrideForTesting: service);
+      final jsonResult = await collect(
+        Uri(),
+        false,
+        false,
+        false,
+        null,
+        serviceOverrideForTesting: service,
+      );
       final result = await HitMap.parseJson(
-          jsonResult['coverage'] as List<Map<String, dynamic>>);
+        jsonResult['coverage'] as List<Map<String, dynamic>>,
+      );
 
       expect(result.length, 0);
     });
@@ -239,47 +233,40 @@ void main() {
       // Expect that on the first getSourceReport call, librariesAlreadyCompiled
       // is empty.
       final service = _mockService(4, 13);
-      when(service.getSourceReport(
-        'isolate',
-        ['Coverage'],
-        forceCompile: true,
-        reportLines: true,
-        librariesAlreadyCompiled: [],
-      )).thenAnswer((_) async => SourceReport(
-            ranges: [
-              _range(
-                0,
-                SourceReportCoverage(
-                  hits: [12],
-                  misses: [47],
-                ),
-              ),
-              _range(
-                1,
-                SourceReportCoverage(
-                  hits: [95],
-                  misses: [52],
-                ),
-              ),
-            ],
-            scripts: [
-              ScriptRef(
-                uri: 'package:foo/foo.dart',
-                id: 'foo',
-              ),
-              ScriptRef(
-                uri: 'package:bar/bar.dart',
-                id: 'bar',
-              ),
-            ],
-          ));
+      when(
+        service.getSourceReport(
+          'isolate',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+          librariesAlreadyCompiled: [],
+        ),
+      ).thenAnswer(
+        (_) async => SourceReport(
+          ranges: [
+            _range(0, SourceReportCoverage(hits: [12], misses: [47])),
+            _range(1, SourceReportCoverage(hits: [95], misses: [52])),
+          ],
+          scripts: [
+            ScriptRef(uri: 'package:foo/foo.dart', id: 'foo'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: 'bar'),
+          ],
+        ),
+      );
 
       final coverableLineCache = <String, Set<int>>{};
-      final jsonResult = await collect(Uri(), false, false, false, null,
-          coverableLineCache: coverableLineCache,
-          serviceOverrideForTesting: service);
+      final jsonResult = await collect(
+        Uri(),
+        false,
+        false,
+        false,
+        null,
+        coverableLineCache: coverableLineCache,
+        serviceOverrideForTesting: service,
+      );
       final result = await HitMap.parseJson(
-          jsonResult['coverage'] as List<Map<String, dynamic>>);
+        jsonResult['coverage'] as List<Map<String, dynamic>>,
+      );
 
       expect(result.length, 2);
       expect(result['package:foo/foo.dart']?.lineHits, {12: 1, 47: 0});
@@ -296,58 +283,44 @@ void main() {
       // seen. The response won't contain any misses for these libraries,
       // because they won't be force compiled. We'll also return a 3rd library,
       // which will contain misses, as it hasn't been compiled yet.
-      when(service.getSourceReport(
-        'isolate',
-        ['Coverage'],
-        forceCompile: true,
-        reportLines: true,
-        librariesAlreadyCompiled: [
-          'package:foo/foo.dart',
-          'package:bar/bar.dart'
-        ],
-      )).thenAnswer((_) async => SourceReport(
-            ranges: [
-              _range(
-                0,
-                SourceReportCoverage(
-                  hits: [47],
-                ),
-              ),
-              _range(
-                1,
-                SourceReportCoverage(
-                  hits: [95],
-                ),
-              ),
-              _range(
-                2,
-                SourceReportCoverage(
-                  hits: [36],
-                  misses: [81],
-                ),
-              ),
-            ],
-            scripts: [
-              ScriptRef(
-                uri: 'package:foo/foo.dart',
-                id: 'foo',
-              ),
-              ScriptRef(
-                uri: 'package:bar/bar.dart',
-                id: 'bar',
-              ),
-              ScriptRef(
-                uri: 'package:baz/baz.dart',
-                id: 'baz',
-              ),
-            ],
-          ));
+      when(
+        service.getSourceReport(
+          'isolate',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+          librariesAlreadyCompiled: [
+            'package:foo/foo.dart',
+            'package:bar/bar.dart',
+          ],
+        ),
+      ).thenAnswer(
+        (_) async => SourceReport(
+          ranges: [
+            _range(0, SourceReportCoverage(hits: [47])),
+            _range(1, SourceReportCoverage(hits: [95])),
+            _range(2, SourceReportCoverage(hits: [36], misses: [81])),
+          ],
+          scripts: [
+            ScriptRef(uri: 'package:foo/foo.dart', id: 'foo'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: 'bar'),
+            ScriptRef(uri: 'package:baz/baz.dart', id: 'baz'),
+          ],
+        ),
+      );
 
-      final jsonResult2 = await collect(Uri(), false, false, false, null,
-          coverableLineCache: coverableLineCache,
-          serviceOverrideForTesting: service);
+      final jsonResult2 = await collect(
+        Uri(),
+        false,
+        false,
+        false,
+        null,
+        coverableLineCache: coverableLineCache,
+        serviceOverrideForTesting: service,
+      );
       final result2 = await HitMap.parseJson(
-          jsonResult2['coverage'] as List<Map<String, dynamic>>);
+        jsonResult2['coverage'] as List<Map<String, dynamic>>,
+      );
 
       // The missed lines still appear in foo and bar, even though they weren't
       // returned in the response. They were read from the cache.
@@ -364,50 +337,37 @@ void main() {
       });
     });
 
-    test(
-        'Collect coverage, scoped output, '
+    test('Collect coverage, scoped output, '
         'handles SourceReports that contain unfiltered ranges', () async {
       // Regression test for https://github.com/dart-lang/tools/issues/530
       final service = _mockService(4, 13);
-      when(service.getSourceReport(
-        'isolate',
-        ['Coverage'],
-        forceCompile: true,
-        reportLines: true,
-        libraryFilters: ['package:foo/'],
-      )).thenAnswer((_) async => SourceReport(
-            ranges: [
-              _range(
-                0,
-                SourceReportCoverage(
-                  hits: [12],
-                  misses: [47],
-                ),
-              ),
-              _range(
-                1,
-                SourceReportCoverage(
-                  hits: [86],
-                  misses: [91],
-                ),
-              ),
-            ],
-            scripts: [
-              ScriptRef(
-                uri: 'package:foo/foo.dart',
-                id: 'foo',
-              ),
-              ScriptRef(
-                uri: 'package:bar/bar.dart',
-                id: 'bar',
-              ),
-            ],
-          ));
+      when(
+        service.getSourceReport(
+          'isolate',
+          ['Coverage'],
+          forceCompile: true,
+          reportLines: true,
+          libraryFilters: ['package:foo/'],
+        ),
+      ).thenAnswer(
+        (_) async => SourceReport(
+          ranges: [
+            _range(0, SourceReportCoverage(hits: [12], misses: [47])),
+            _range(1, SourceReportCoverage(hits: [86], misses: [91])),
+          ],
+          scripts: [
+            ScriptRef(uri: 'package:foo/foo.dart', id: 'foo'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: 'bar'),
+          ],
+        ),
+      );
 
-      final jsonResult = await collect(Uri(), false, false, false, {'foo'},
-          serviceOverrideForTesting: service);
+      final jsonResult = await collect(Uri(), false, false, false, {
+        'foo',
+      }, serviceOverrideForTesting: service);
       final result = await HitMap.parseJson(
-          jsonResult['coverage'] as List<Map<String, dynamic>>);
+        jsonResult['coverage'] as List<Map<String, dynamic>>,
+      );
 
       expect(result.length, 1);
       expect(result['package:foo/foo.dart']?.lineHits, {12: 1, 47: 0});

--- a/pkgs/coverage/test/collect_coverage_mock_test.mocks.dart
+++ b/pkgs/coverage/test/collect_coverage_mock_test.mocks.dart
@@ -23,338 +23,173 @@ import 'package:vm_service/src/vm_service.dart' as _i2;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeBreakpoint_0 extends _i1.SmartFake implements _i2.Breakpoint {
-  _FakeBreakpoint_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeBreakpoint_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeSuccess_1 extends _i1.SmartFake implements _i2.Success {
-  _FakeSuccess_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeSuccess_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeIdZone_2 extends _i1.SmartFake implements _i2.IdZone {
-  _FakeIdZone_2(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeIdZone_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeResponse_3 extends _i1.SmartFake implements _i2.Response {
-  _FakeResponse_3(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeResponse_3(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeAllocationProfile_4 extends _i1.SmartFake
     implements _i2.AllocationProfile {
-  _FakeAllocationProfile_4(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeAllocationProfile_4(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeCpuSamples_5 extends _i1.SmartFake implements _i2.CpuSamples {
-  _FakeCpuSamples_5(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeCpuSamples_5(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeClassList_6 extends _i1.SmartFake implements _i2.ClassList {
-  _FakeClassList_6(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeClassList_6(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFlagList_7 extends _i1.SmartFake implements _i2.FlagList {
-  _FakeFlagList_7(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFlagList_7(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeInboundReferences_8 extends _i1.SmartFake
     implements _i2.InboundReferences {
-  _FakeInboundReferences_8(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeInboundReferences_8(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeInstanceSet_9 extends _i1.SmartFake implements _i2.InstanceSet {
-  _FakeInstanceSet_9(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeInstanceSet_9(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeInstanceRef_10 extends _i1.SmartFake implements _i2.InstanceRef {
-  _FakeInstanceRef_10(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeInstanceRef_10(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeIsolate_11 extends _i1.SmartFake implements _i2.Isolate {
-  _FakeIsolate_11(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeIsolate_11(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeIsolateGroup_12 extends _i1.SmartFake implements _i2.IsolateGroup {
-  _FakeIsolateGroup_12(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeIsolateGroup_12(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeEvent_13 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_13(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeEvent_13(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeMemoryUsage_14 extends _i1.SmartFake implements _i2.MemoryUsage {
-  _FakeMemoryUsage_14(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeMemoryUsage_14(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeScriptList_15 extends _i1.SmartFake implements _i2.ScriptList {
-  _FakeScriptList_15(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeScriptList_15(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeObj_16 extends _i1.SmartFake implements _i2.Obj {
-  _FakeObj_16(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeObj_16(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakePerfettoCpuSamples_17 extends _i1.SmartFake
     implements _i2.PerfettoCpuSamples {
-  _FakePerfettoCpuSamples_17(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakePerfettoCpuSamples_17(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakePerfettoTimeline_18 extends _i1.SmartFake
     implements _i2.PerfettoTimeline {
-  _FakePerfettoTimeline_18(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakePerfettoTimeline_18(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakePortList_19 extends _i1.SmartFake implements _i2.PortList {
-  _FakePortList_19(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakePortList_19(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeRetainingPath_20 extends _i1.SmartFake implements _i2.RetainingPath {
-  _FakeRetainingPath_20(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeRetainingPath_20(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeProcessMemoryUsage_21 extends _i1.SmartFake
     implements _i2.ProcessMemoryUsage {
-  _FakeProcessMemoryUsage_21(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeProcessMemoryUsage_21(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeStack_22 extends _i1.SmartFake implements _i2.Stack {
-  _FakeStack_22(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeStack_22(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeProtocolList_23 extends _i1.SmartFake implements _i2.ProtocolList {
-  _FakeProtocolList_23(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeProtocolList_23(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeSourceReport_24 extends _i1.SmartFake implements _i2.SourceReport {
-  _FakeSourceReport_24(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeSourceReport_24(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeVersion_25 extends _i1.SmartFake implements _i2.Version {
-  _FakeVersion_25(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeVersion_25(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeVM_26 extends _i1.SmartFake implements _i2.VM {
-  _FakeVM_26(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeVM_26(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeTimeline_27 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_27(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeTimeline_27(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeTimelineFlags_28 extends _i1.SmartFake implements _i2.TimelineFlags {
-  _FakeTimelineFlags_28(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeTimelineFlags_28(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeTimestamp_29 extends _i1.SmartFake implements _i2.Timestamp {
-  _FakeTimestamp_29(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeTimestamp_29(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeUriList_30 extends _i1.SmartFake implements _i2.UriList {
-  _FakeUriList_30(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeUriList_30(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeReloadReport_31 extends _i1.SmartFake implements _i2.ReloadReport {
-  _FakeReloadReport_31(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeReloadReport_31(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFuture_32<T1> extends _i1.SmartFake implements _i3.Future<T1> {
-  _FakeFuture_32(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFuture_32(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [VmService].
@@ -366,103 +201,132 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
   }
 
   @override
-  _i3.Stream<String> get onSend => (super.noSuchMethod(
-        Invocation.getter(#onSend),
-        returnValue: _i3.Stream<String>.empty(),
-      ) as _i3.Stream<String>);
+  _i3.Stream<String> get onSend =>
+      (super.noSuchMethod(
+            Invocation.getter(#onSend),
+            returnValue: _i3.Stream<String>.empty(),
+          )
+          as _i3.Stream<String>);
 
   @override
-  _i3.Stream<String> get onReceive => (super.noSuchMethod(
-        Invocation.getter(#onReceive),
-        returnValue: _i3.Stream<String>.empty(),
-      ) as _i3.Stream<String>);
+  _i3.Stream<String> get onReceive =>
+      (super.noSuchMethod(
+            Invocation.getter(#onReceive),
+            returnValue: _i3.Stream<String>.empty(),
+          )
+          as _i3.Stream<String>);
 
   @override
-  _i3.Future<void> get onDone => (super.noSuchMethod(
-        Invocation.getter(#onDone),
-        returnValue: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+  _i3.Future<void> get onDone =>
+      (super.noSuchMethod(
+            Invocation.getter(#onDone),
+            returnValue: _i3.Future<void>.value(),
+          )
+          as _i3.Future<void>);
 
   @override
-  _i3.Stream<_i2.Event> get onVMEvent => (super.noSuchMethod(
-        Invocation.getter(#onVMEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onVMEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onVMEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onIsolateEvent => (super.noSuchMethod(
-        Invocation.getter(#onIsolateEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onIsolateEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onIsolateEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onDebugEvent => (super.noSuchMethod(
-        Invocation.getter(#onDebugEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onDebugEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onDebugEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onProfilerEvent => (super.noSuchMethod(
-        Invocation.getter(#onProfilerEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onProfilerEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onProfilerEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onGCEvent => (super.noSuchMethod(
-        Invocation.getter(#onGCEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onGCEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onGCEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onExtensionEvent => (super.noSuchMethod(
-        Invocation.getter(#onExtensionEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onExtensionEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onExtensionEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onTimelineEvent => (super.noSuchMethod(
-        Invocation.getter(#onTimelineEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onTimelineEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onTimelineEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onLoggingEvent => (super.noSuchMethod(
-        Invocation.getter(#onLoggingEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onLoggingEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onLoggingEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onServiceEvent => (super.noSuchMethod(
-        Invocation.getter(#onServiceEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onServiceEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onServiceEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onHeapSnapshotEvent => (super.noSuchMethod(
-        Invocation.getter(#onHeapSnapshotEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onHeapSnapshotEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onHeapSnapshotEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onStdoutEvent => (super.noSuchMethod(
-        Invocation.getter(#onStdoutEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onStdoutEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onStdoutEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> get onStderrEvent => (super.noSuchMethod(
-        Invocation.getter(#onStderrEvent),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> get onStderrEvent =>
+      (super.noSuchMethod(
+            Invocation.getter(#onStderrEvent),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
-  _i3.Stream<_i2.Event> onEvent(String? streamId) => (super.noSuchMethod(
-        Invocation.method(
-          #onEvent,
-          [streamId],
-        ),
-        returnValue: _i3.Stream<_i2.Event>.empty(),
-      ) as _i3.Stream<_i2.Event>);
+  _i3.Stream<_i2.Event> onEvent(String? streamId) =>
+      (super.noSuchMethod(
+            Invocation.method(#onEvent, [streamId]),
+            returnValue: _i3.Stream<_i2.Event>.empty(),
+          )
+          as _i3.Stream<_i2.Event>);
 
   @override
   _i3.Future<_i2.Breakpoint> addBreakpoint(
@@ -472,28 +336,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     int? column,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #addBreakpoint,
-          [
-            isolateId,
-            scriptId,
-            line,
-          ],
-          {#column: column},
-        ),
-        returnValue: _i3.Future<_i2.Breakpoint>.value(_FakeBreakpoint_0(
-          this,
-          Invocation.method(
-            #addBreakpoint,
-            [
-              isolateId,
-              scriptId,
-              line,
-            ],
-            {#column: column},
-          ),
-        )),
-      ) as _i3.Future<_i2.Breakpoint>);
+            Invocation.method(
+              #addBreakpoint,
+              [isolateId, scriptId, line],
+              {#column: column},
+            ),
+            returnValue: _i3.Future<_i2.Breakpoint>.value(
+              _FakeBreakpoint_0(
+                this,
+                Invocation.method(
+                  #addBreakpoint,
+                  [isolateId, scriptId, line],
+                  {#column: column},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Breakpoint>);
 
   @override
   _i3.Future<_i2.Breakpoint> addBreakpointWithScriptUri(
@@ -503,28 +362,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     int? column,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #addBreakpointWithScriptUri,
-          [
-            isolateId,
-            scriptUri,
-            line,
-          ],
-          {#column: column},
-        ),
-        returnValue: _i3.Future<_i2.Breakpoint>.value(_FakeBreakpoint_0(
-          this,
-          Invocation.method(
-            #addBreakpointWithScriptUri,
-            [
-              isolateId,
-              scriptUri,
-              line,
-            ],
-            {#column: column},
-          ),
-        )),
-      ) as _i3.Future<_i2.Breakpoint>);
+            Invocation.method(
+              #addBreakpointWithScriptUri,
+              [isolateId, scriptUri, line],
+              {#column: column},
+            ),
+            returnValue: _i3.Future<_i2.Breakpoint>.value(
+              _FakeBreakpoint_0(
+                this,
+                Invocation.method(
+                  #addBreakpointWithScriptUri,
+                  [isolateId, scriptUri, line],
+                  {#column: column},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Breakpoint>);
 
   @override
   _i3.Future<_i2.Breakpoint> addBreakpointAtEntry(
@@ -532,55 +386,41 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? functionId,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #addBreakpointAtEntry,
-          [
-            isolateId,
-            functionId,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Breakpoint>.value(_FakeBreakpoint_0(
-          this,
-          Invocation.method(
-            #addBreakpointAtEntry,
-            [
-              isolateId,
-              functionId,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Breakpoint>);
+            Invocation.method(#addBreakpointAtEntry, [isolateId, functionId]),
+            returnValue: _i3.Future<_i2.Breakpoint>.value(
+              _FakeBreakpoint_0(
+                this,
+                Invocation.method(#addBreakpointAtEntry, [
+                  isolateId,
+                  functionId,
+                ]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Breakpoint>);
 
   @override
   _i3.Future<_i2.Success> clearCpuSamples(String? isolateId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #clearCpuSamples,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #clearCpuSamples,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#clearCpuSamples, [isolateId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#clearCpuSamples, [isolateId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
-  _i3.Future<_i2.Success> clearVMTimeline() => (super.noSuchMethod(
-        Invocation.method(
-          #clearVMTimeline,
-          [],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #clearVMTimeline,
-            [],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+  _i3.Future<_i2.Success> clearVMTimeline() =>
+      (super.noSuchMethod(
+            Invocation.method(#clearVMTimeline, []),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(this, Invocation.method(#clearVMTimeline, [])),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.IdZone> createIdZone(
@@ -590,53 +430,36 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     int? capacity,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #createIdZone,
-          [
-            isolateId,
-            backingBufferKind,
-            idAssignmentPolicy,
-          ],
-          {#capacity: capacity},
-        ),
-        returnValue: _i3.Future<_i2.IdZone>.value(_FakeIdZone_2(
-          this,
-          Invocation.method(
-            #createIdZone,
-            [
-              isolateId,
-              backingBufferKind,
-              idAssignmentPolicy,
-            ],
-            {#capacity: capacity},
-          ),
-        )),
-      ) as _i3.Future<_i2.IdZone>);
+            Invocation.method(
+              #createIdZone,
+              [isolateId, backingBufferKind, idAssignmentPolicy],
+              {#capacity: capacity},
+            ),
+            returnValue: _i3.Future<_i2.IdZone>.value(
+              _FakeIdZone_2(
+                this,
+                Invocation.method(
+                  #createIdZone,
+                  [isolateId, backingBufferKind, idAssignmentPolicy],
+                  {#capacity: capacity},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.IdZone>);
 
   @override
-  _i3.Future<_i2.Success> deleteIdZone(
-    String? isolateId,
-    String? idZoneId,
-  ) =>
+  _i3.Future<_i2.Success> deleteIdZone(String? isolateId, String? idZoneId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #deleteIdZone,
-          [
-            isolateId,
-            idZoneId,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #deleteIdZone,
-            [
-              isolateId,
-              idZoneId,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#deleteIdZone, [isolateId, idZoneId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#deleteIdZone, [isolateId, idZoneId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Success> invalidateIdZone(
@@ -644,24 +467,15 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #invalidateIdZone,
-          [
-            isolateId,
-            idZoneId,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #invalidateIdZone,
-            [
-              isolateId,
-              idZoneId,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#invalidateIdZone, [isolateId, idZoneId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#invalidateIdZone, [isolateId, idZoneId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Response> invoke(
@@ -673,36 +487,26 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #invoke,
-          [
-            isolateId,
-            targetId,
-            selector,
-            argumentIds,
-          ],
-          {
-            #disableBreakpoints: disableBreakpoints,
-            #idZoneId: idZoneId,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_3(
-          this,
-          Invocation.method(
-            #invoke,
-            [
-              isolateId,
-              targetId,
-              selector,
-              argumentIds,
-            ],
-            {
-              #disableBreakpoints: disableBreakpoints,
-              #idZoneId: idZoneId,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #invoke,
+              [isolateId, targetId, selector, argumentIds],
+              {#disableBreakpoints: disableBreakpoints, #idZoneId: idZoneId},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_3(
+                this,
+                Invocation.method(
+                  #invoke,
+                  [isolateId, targetId, selector, argumentIds],
+                  {
+                    #disableBreakpoints: disableBreakpoints,
+                    #idZoneId: idZoneId,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> evaluate(
@@ -714,36 +518,31 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #evaluate,
-          [
-            isolateId,
-            targetId,
-            expression,
-          ],
-          {
-            #scope: scope,
-            #disableBreakpoints: disableBreakpoints,
-            #idZoneId: idZoneId,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_3(
-          this,
-          Invocation.method(
-            #evaluate,
-            [
-              isolateId,
-              targetId,
-              expression,
-            ],
-            {
-              #scope: scope,
-              #disableBreakpoints: disableBreakpoints,
-              #idZoneId: idZoneId,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #evaluate,
+              [isolateId, targetId, expression],
+              {
+                #scope: scope,
+                #disableBreakpoints: disableBreakpoints,
+                #idZoneId: idZoneId,
+              },
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_3(
+                this,
+                Invocation.method(
+                  #evaluate,
+                  [isolateId, targetId, expression],
+                  {
+                    #scope: scope,
+                    #disableBreakpoints: disableBreakpoints,
+                    #idZoneId: idZoneId,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> evaluateInFrame(
@@ -755,36 +554,31 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #evaluateInFrame,
-          [
-            isolateId,
-            frameIndex,
-            expression,
-          ],
-          {
-            #scope: scope,
-            #disableBreakpoints: disableBreakpoints,
-            #idZoneId: idZoneId,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_3(
-          this,
-          Invocation.method(
-            #evaluateInFrame,
-            [
-              isolateId,
-              frameIndex,
-              expression,
-            ],
-            {
-              #scope: scope,
-              #disableBreakpoints: disableBreakpoints,
-              #idZoneId: idZoneId,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #evaluateInFrame,
+              [isolateId, frameIndex, expression],
+              {
+                #scope: scope,
+                #disableBreakpoints: disableBreakpoints,
+                #idZoneId: idZoneId,
+              },
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_3(
+                this,
+                Invocation.method(
+                  #evaluateInFrame,
+                  [isolateId, frameIndex, expression],
+                  {
+                    #scope: scope,
+                    #disableBreakpoints: disableBreakpoints,
+                    #idZoneId: idZoneId,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.AllocationProfile> getAllocationProfile(
@@ -793,27 +587,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     bool? gc,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getAllocationProfile,
-          [isolateId],
-          {
-            #reset: reset,
-            #gc: gc,
-          },
-        ),
-        returnValue:
-            _i3.Future<_i2.AllocationProfile>.value(_FakeAllocationProfile_4(
-          this,
-          Invocation.method(
-            #getAllocationProfile,
-            [isolateId],
-            {
-              #reset: reset,
-              #gc: gc,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.AllocationProfile>);
+            Invocation.method(
+              #getAllocationProfile,
+              [isolateId],
+              {#reset: reset, #gc: gc},
+            ),
+            returnValue: _i3.Future<_i2.AllocationProfile>.value(
+              _FakeAllocationProfile_4(
+                this,
+                Invocation.method(
+                  #getAllocationProfile,
+                  [isolateId],
+                  {#reset: reset, #gc: gc},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.AllocationProfile>);
 
   @override
   _i3.Future<_i2.CpuSamples> getAllocationTraces(
@@ -823,44 +613,44 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? classId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getAllocationTraces,
-          [isolateId],
-          {
-            #timeOriginMicros: timeOriginMicros,
-            #timeExtentMicros: timeExtentMicros,
-            #classId: classId,
-          },
-        ),
-        returnValue: _i3.Future<_i2.CpuSamples>.value(_FakeCpuSamples_5(
-          this,
-          Invocation.method(
-            #getAllocationTraces,
-            [isolateId],
-            {
-              #timeOriginMicros: timeOriginMicros,
-              #timeExtentMicros: timeExtentMicros,
-              #classId: classId,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.CpuSamples>);
+            Invocation.method(
+              #getAllocationTraces,
+              [isolateId],
+              {
+                #timeOriginMicros: timeOriginMicros,
+                #timeExtentMicros: timeExtentMicros,
+                #classId: classId,
+              },
+            ),
+            returnValue: _i3.Future<_i2.CpuSamples>.value(
+              _FakeCpuSamples_5(
+                this,
+                Invocation.method(
+                  #getAllocationTraces,
+                  [isolateId],
+                  {
+                    #timeOriginMicros: timeOriginMicros,
+                    #timeExtentMicros: timeExtentMicros,
+                    #classId: classId,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.CpuSamples>);
 
   @override
   _i3.Future<_i2.ClassList> getClassList(String? isolateId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getClassList,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.ClassList>.value(_FakeClassList_6(
-          this,
-          Invocation.method(
-            #getClassList,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.ClassList>);
+            Invocation.method(#getClassList, [isolateId]),
+            returnValue: _i3.Future<_i2.ClassList>.value(
+              _FakeClassList_6(
+                this,
+                Invocation.method(#getClassList, [isolateId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.ClassList>);
 
   @override
   _i3.Future<_i2.CpuSamples> getCpuSamples(
@@ -869,41 +659,33 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     int? timeExtentMicros,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getCpuSamples,
-          [
-            isolateId,
-            timeOriginMicros,
-            timeExtentMicros,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.CpuSamples>.value(_FakeCpuSamples_5(
-          this,
-          Invocation.method(
-            #getCpuSamples,
-            [
+            Invocation.method(#getCpuSamples, [
               isolateId,
               timeOriginMicros,
               timeExtentMicros,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.CpuSamples>);
+            ]),
+            returnValue: _i3.Future<_i2.CpuSamples>.value(
+              _FakeCpuSamples_5(
+                this,
+                Invocation.method(#getCpuSamples, [
+                  isolateId,
+                  timeOriginMicros,
+                  timeExtentMicros,
+                ]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.CpuSamples>);
 
   @override
-  _i3.Future<_i2.FlagList> getFlagList() => (super.noSuchMethod(
-        Invocation.method(
-          #getFlagList,
-          [],
-        ),
-        returnValue: _i3.Future<_i2.FlagList>.value(_FakeFlagList_7(
-          this,
-          Invocation.method(
-            #getFlagList,
-            [],
-          ),
-        )),
-      ) as _i3.Future<_i2.FlagList>);
+  _i3.Future<_i2.FlagList> getFlagList() =>
+      (super.noSuchMethod(
+            Invocation.method(#getFlagList, []),
+            returnValue: _i3.Future<_i2.FlagList>.value(
+              _FakeFlagList_7(this, Invocation.method(#getFlagList, [])),
+            ),
+          )
+          as _i3.Future<_i2.FlagList>);
 
   @override
   _i3.Future<_i2.InboundReferences> getInboundReferences(
@@ -913,29 +695,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getInboundReferences,
-          [
-            isolateId,
-            targetId,
-            limit,
-          ],
-          {#idZoneId: idZoneId},
-        ),
-        returnValue:
-            _i3.Future<_i2.InboundReferences>.value(_FakeInboundReferences_8(
-          this,
-          Invocation.method(
-            #getInboundReferences,
-            [
-              isolateId,
-              targetId,
-              limit,
-            ],
-            {#idZoneId: idZoneId},
-          ),
-        )),
-      ) as _i3.Future<_i2.InboundReferences>);
+            Invocation.method(
+              #getInboundReferences,
+              [isolateId, targetId, limit],
+              {#idZoneId: idZoneId},
+            ),
+            returnValue: _i3.Future<_i2.InboundReferences>.value(
+              _FakeInboundReferences_8(
+                this,
+                Invocation.method(
+                  #getInboundReferences,
+                  [isolateId, targetId, limit],
+                  {#idZoneId: idZoneId},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.InboundReferences>);
 
   @override
   _i3.Future<_i2.InstanceSet> getInstances(
@@ -947,36 +723,31 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getInstances,
-          [
-            isolateId,
-            objectId,
-            limit,
-          ],
-          {
-            #includeSubclasses: includeSubclasses,
-            #includeImplementers: includeImplementers,
-            #idZoneId: idZoneId,
-          },
-        ),
-        returnValue: _i3.Future<_i2.InstanceSet>.value(_FakeInstanceSet_9(
-          this,
-          Invocation.method(
-            #getInstances,
-            [
-              isolateId,
-              objectId,
-              limit,
-            ],
-            {
-              #includeSubclasses: includeSubclasses,
-              #includeImplementers: includeImplementers,
-              #idZoneId: idZoneId,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.InstanceSet>);
+            Invocation.method(
+              #getInstances,
+              [isolateId, objectId, limit],
+              {
+                #includeSubclasses: includeSubclasses,
+                #includeImplementers: includeImplementers,
+                #idZoneId: idZoneId,
+              },
+            ),
+            returnValue: _i3.Future<_i2.InstanceSet>.value(
+              _FakeInstanceSet_9(
+                this,
+                Invocation.method(
+                  #getInstances,
+                  [isolateId, objectId, limit],
+                  {
+                    #includeSubclasses: includeSubclasses,
+                    #includeImplementers: includeImplementers,
+                    #idZoneId: idZoneId,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.InstanceSet>);
 
   @override
   _i3.Future<_i2.InstanceRef> getInstancesAsList(
@@ -987,130 +758,113 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getInstancesAsList,
-          [
-            isolateId,
-            objectId,
-          ],
-          {
-            #includeSubclasses: includeSubclasses,
-            #includeImplementers: includeImplementers,
-            #idZoneId: idZoneId,
-          },
-        ),
-        returnValue: _i3.Future<_i2.InstanceRef>.value(_FakeInstanceRef_10(
-          this,
-          Invocation.method(
-            #getInstancesAsList,
-            [
-              isolateId,
-              objectId,
-            ],
-            {
-              #includeSubclasses: includeSubclasses,
-              #includeImplementers: includeImplementers,
-              #idZoneId: idZoneId,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.InstanceRef>);
+            Invocation.method(
+              #getInstancesAsList,
+              [isolateId, objectId],
+              {
+                #includeSubclasses: includeSubclasses,
+                #includeImplementers: includeImplementers,
+                #idZoneId: idZoneId,
+              },
+            ),
+            returnValue: _i3.Future<_i2.InstanceRef>.value(
+              _FakeInstanceRef_10(
+                this,
+                Invocation.method(
+                  #getInstancesAsList,
+                  [isolateId, objectId],
+                  {
+                    #includeSubclasses: includeSubclasses,
+                    #includeImplementers: includeImplementers,
+                    #idZoneId: idZoneId,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.InstanceRef>);
 
   @override
-  _i3.Future<_i2.Isolate> getIsolate(String? isolateId) => (super.noSuchMethod(
-        Invocation.method(
-          #getIsolate,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.Isolate>.value(_FakeIsolate_11(
-          this,
-          Invocation.method(
-            #getIsolate,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.Isolate>);
+  _i3.Future<_i2.Isolate> getIsolate(String? isolateId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getIsolate, [isolateId]),
+            returnValue: _i3.Future<_i2.Isolate>.value(
+              _FakeIsolate_11(
+                this,
+                Invocation.method(#getIsolate, [isolateId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Isolate>);
 
   @override
   _i3.Future<_i2.IsolateGroup> getIsolateGroup(String? isolateGroupId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getIsolateGroup,
-          [isolateGroupId],
-        ),
-        returnValue: _i3.Future<_i2.IsolateGroup>.value(_FakeIsolateGroup_12(
-          this,
-          Invocation.method(
-            #getIsolateGroup,
-            [isolateGroupId],
-          ),
-        )),
-      ) as _i3.Future<_i2.IsolateGroup>);
+            Invocation.method(#getIsolateGroup, [isolateGroupId]),
+            returnValue: _i3.Future<_i2.IsolateGroup>.value(
+              _FakeIsolateGroup_12(
+                this,
+                Invocation.method(#getIsolateGroup, [isolateGroupId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.IsolateGroup>);
 
   @override
   _i3.Future<_i2.Event> getIsolatePauseEvent(String? isolateId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getIsolatePauseEvent,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.Event>.value(_FakeEvent_13(
-          this,
-          Invocation.method(
-            #getIsolatePauseEvent,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.Event>);
+            Invocation.method(#getIsolatePauseEvent, [isolateId]),
+            returnValue: _i3.Future<_i2.Event>.value(
+              _FakeEvent_13(
+                this,
+                Invocation.method(#getIsolatePauseEvent, [isolateId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Event>);
 
   @override
   _i3.Future<_i2.MemoryUsage> getMemoryUsage(String? isolateId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getMemoryUsage,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.MemoryUsage>.value(_FakeMemoryUsage_14(
-          this,
-          Invocation.method(
-            #getMemoryUsage,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.MemoryUsage>);
+            Invocation.method(#getMemoryUsage, [isolateId]),
+            returnValue: _i3.Future<_i2.MemoryUsage>.value(
+              _FakeMemoryUsage_14(
+                this,
+                Invocation.method(#getMemoryUsage, [isolateId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.MemoryUsage>);
 
   @override
   _i3.Future<_i2.MemoryUsage> getIsolateGroupMemoryUsage(
-          String? isolateGroupId) =>
+    String? isolateGroupId,
+  ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getIsolateGroupMemoryUsage,
-          [isolateGroupId],
-        ),
-        returnValue: _i3.Future<_i2.MemoryUsage>.value(_FakeMemoryUsage_14(
-          this,
-          Invocation.method(
-            #getIsolateGroupMemoryUsage,
-            [isolateGroupId],
-          ),
-        )),
-      ) as _i3.Future<_i2.MemoryUsage>);
+            Invocation.method(#getIsolateGroupMemoryUsage, [isolateGroupId]),
+            returnValue: _i3.Future<_i2.MemoryUsage>.value(
+              _FakeMemoryUsage_14(
+                this,
+                Invocation.method(#getIsolateGroupMemoryUsage, [
+                  isolateGroupId,
+                ]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.MemoryUsage>);
 
   @override
   _i3.Future<_i2.ScriptList> getScripts(String? isolateId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getScripts,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.ScriptList>.value(_FakeScriptList_15(
-          this,
-          Invocation.method(
-            #getScripts,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.ScriptList>);
+            Invocation.method(#getScripts, [isolateId]),
+            returnValue: _i3.Future<_i2.ScriptList>.value(
+              _FakeScriptList_15(
+                this,
+                Invocation.method(#getScripts, [isolateId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.ScriptList>);
 
   @override
   _i3.Future<_i2.Obj> getObject(
@@ -1121,34 +875,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getObject,
-          [
-            isolateId,
-            objectId,
-          ],
-          {
-            #offset: offset,
-            #count: count,
-            #idZoneId: idZoneId,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Obj>.value(_FakeObj_16(
-          this,
-          Invocation.method(
-            #getObject,
-            [
-              isolateId,
-              objectId,
-            ],
-            {
-              #offset: offset,
-              #count: count,
-              #idZoneId: idZoneId,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Obj>);
+            Invocation.method(
+              #getObject,
+              [isolateId, objectId],
+              {#offset: offset, #count: count, #idZoneId: idZoneId},
+            ),
+            returnValue: _i3.Future<_i2.Obj>.value(
+              _FakeObj_16(
+                this,
+                Invocation.method(
+                  #getObject,
+                  [isolateId, objectId],
+                  {#offset: offset, #count: count, #idZoneId: idZoneId},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Obj>);
 
   @override
   _i3.Future<_i2.PerfettoCpuSamples> getPerfettoCpuSamples(
@@ -1157,27 +900,29 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     int? timeExtentMicros,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getPerfettoCpuSamples,
-          [isolateId],
-          {
-            #timeOriginMicros: timeOriginMicros,
-            #timeExtentMicros: timeExtentMicros,
-          },
-        ),
-        returnValue:
-            _i3.Future<_i2.PerfettoCpuSamples>.value(_FakePerfettoCpuSamples_17(
-          this,
-          Invocation.method(
-            #getPerfettoCpuSamples,
-            [isolateId],
-            {
-              #timeOriginMicros: timeOriginMicros,
-              #timeExtentMicros: timeExtentMicros,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.PerfettoCpuSamples>);
+            Invocation.method(
+              #getPerfettoCpuSamples,
+              [isolateId],
+              {
+                #timeOriginMicros: timeOriginMicros,
+                #timeExtentMicros: timeExtentMicros,
+              },
+            ),
+            returnValue: _i3.Future<_i2.PerfettoCpuSamples>.value(
+              _FakePerfettoCpuSamples_17(
+                this,
+                Invocation.method(
+                  #getPerfettoCpuSamples,
+                  [isolateId],
+                  {
+                    #timeOriginMicros: timeOriginMicros,
+                    #timeExtentMicros: timeExtentMicros,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.PerfettoCpuSamples>);
 
   @override
   _i3.Future<_i2.PerfettoTimeline> getPerfettoVMTimeline({
@@ -1185,42 +930,31 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     int? timeExtentMicros,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getPerfettoVMTimeline,
-          [],
-          {
-            #timeOriginMicros: timeOriginMicros,
-            #timeExtentMicros: timeExtentMicros,
-          },
-        ),
-        returnValue:
-            _i3.Future<_i2.PerfettoTimeline>.value(_FakePerfettoTimeline_18(
-          this,
-          Invocation.method(
-            #getPerfettoVMTimeline,
-            [],
-            {
+            Invocation.method(#getPerfettoVMTimeline, [], {
               #timeOriginMicros: timeOriginMicros,
               #timeExtentMicros: timeExtentMicros,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.PerfettoTimeline>);
+            }),
+            returnValue: _i3.Future<_i2.PerfettoTimeline>.value(
+              _FakePerfettoTimeline_18(
+                this,
+                Invocation.method(#getPerfettoVMTimeline, [], {
+                  #timeOriginMicros: timeOriginMicros,
+                  #timeExtentMicros: timeExtentMicros,
+                }),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.PerfettoTimeline>);
 
   @override
-  _i3.Future<_i2.PortList> getPorts(String? isolateId) => (super.noSuchMethod(
-        Invocation.method(
-          #getPorts,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.PortList>.value(_FakePortList_19(
-          this,
-          Invocation.method(
-            #getPorts,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.PortList>);
+  _i3.Future<_i2.PortList> getPorts(String? isolateId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getPorts, [isolateId]),
+            returnValue: _i3.Future<_i2.PortList>.value(
+              _FakePortList_19(this, Invocation.method(#getPorts, [isolateId])),
+            ),
+          )
+          as _i3.Future<_i2.PortList>);
 
   @override
   _i3.Future<_i2.RetainingPath> getRetainingPath(
@@ -1230,45 +964,36 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getRetainingPath,
-          [
-            isolateId,
-            targetId,
-            limit,
-          ],
-          {#idZoneId: idZoneId},
-        ),
-        returnValue: _i3.Future<_i2.RetainingPath>.value(_FakeRetainingPath_20(
-          this,
-          Invocation.method(
-            #getRetainingPath,
-            [
-              isolateId,
-              targetId,
-              limit,
-            ],
-            {#idZoneId: idZoneId},
-          ),
-        )),
-      ) as _i3.Future<_i2.RetainingPath>);
+            Invocation.method(
+              #getRetainingPath,
+              [isolateId, targetId, limit],
+              {#idZoneId: idZoneId},
+            ),
+            returnValue: _i3.Future<_i2.RetainingPath>.value(
+              _FakeRetainingPath_20(
+                this,
+                Invocation.method(
+                  #getRetainingPath,
+                  [isolateId, targetId, limit],
+                  {#idZoneId: idZoneId},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.RetainingPath>);
 
   @override
   _i3.Future<_i2.ProcessMemoryUsage> getProcessMemoryUsage() =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getProcessMemoryUsage,
-          [],
-        ),
-        returnValue:
-            _i3.Future<_i2.ProcessMemoryUsage>.value(_FakeProcessMemoryUsage_21(
-          this,
-          Invocation.method(
-            #getProcessMemoryUsage,
-            [],
-          ),
-        )),
-      ) as _i3.Future<_i2.ProcessMemoryUsage>);
+            Invocation.method(#getProcessMemoryUsage, []),
+            returnValue: _i3.Future<_i2.ProcessMemoryUsage>.value(
+              _FakeProcessMemoryUsage_21(
+                this,
+                Invocation.method(#getProcessMemoryUsage, []),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.ProcessMemoryUsage>);
 
   @override
   _i3.Future<_i2.Stack> getStack(
@@ -1277,41 +1002,36 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? idZoneId,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getStack,
-          [isolateId],
-          {
-            #limit: limit,
-            #idZoneId: idZoneId,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Stack>.value(_FakeStack_22(
-          this,
-          Invocation.method(
-            #getStack,
-            [isolateId],
-            {
-              #limit: limit,
-              #idZoneId: idZoneId,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Stack>);
+            Invocation.method(
+              #getStack,
+              [isolateId],
+              {#limit: limit, #idZoneId: idZoneId},
+            ),
+            returnValue: _i3.Future<_i2.Stack>.value(
+              _FakeStack_22(
+                this,
+                Invocation.method(
+                  #getStack,
+                  [isolateId],
+                  {#limit: limit, #idZoneId: idZoneId},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Stack>);
 
   @override
-  _i3.Future<_i2.ProtocolList> getSupportedProtocols() => (super.noSuchMethod(
-        Invocation.method(
-          #getSupportedProtocols,
-          [],
-        ),
-        returnValue: _i3.Future<_i2.ProtocolList>.value(_FakeProtocolList_23(
-          this,
-          Invocation.method(
-            #getSupportedProtocols,
-            [],
-          ),
-        )),
-      ) as _i3.Future<_i2.ProtocolList>);
+  _i3.Future<_i2.ProtocolList> getSupportedProtocols() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSupportedProtocols, []),
+            returnValue: _i3.Future<_i2.ProtocolList>.value(
+              _FakeProtocolList_23(
+                this,
+                Invocation.method(#getSupportedProtocols, []),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.ProtocolList>);
 
   @override
   _i3.Future<_i2.SourceReport> getSourceReport(
@@ -1326,72 +1046,59 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     List<String>? librariesAlreadyCompiled,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getSourceReport,
-          [
-            isolateId,
-            reports,
-          ],
-          {
-            #scriptId: scriptId,
-            #tokenPos: tokenPos,
-            #endTokenPos: endTokenPos,
-            #forceCompile: forceCompile,
-            #reportLines: reportLines,
-            #libraryFilters: libraryFilters,
-            #librariesAlreadyCompiled: librariesAlreadyCompiled,
-          },
-        ),
-        returnValue: _i3.Future<_i2.SourceReport>.value(_FakeSourceReport_24(
-          this,
-          Invocation.method(
-            #getSourceReport,
-            [
-              isolateId,
-              reports,
-            ],
-            {
-              #scriptId: scriptId,
-              #tokenPos: tokenPos,
-              #endTokenPos: endTokenPos,
-              #forceCompile: forceCompile,
-              #reportLines: reportLines,
-              #libraryFilters: libraryFilters,
-              #librariesAlreadyCompiled: librariesAlreadyCompiled,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.SourceReport>);
+            Invocation.method(
+              #getSourceReport,
+              [isolateId, reports],
+              {
+                #scriptId: scriptId,
+                #tokenPos: tokenPos,
+                #endTokenPos: endTokenPos,
+                #forceCompile: forceCompile,
+                #reportLines: reportLines,
+                #libraryFilters: libraryFilters,
+                #librariesAlreadyCompiled: librariesAlreadyCompiled,
+              },
+            ),
+            returnValue: _i3.Future<_i2.SourceReport>.value(
+              _FakeSourceReport_24(
+                this,
+                Invocation.method(
+                  #getSourceReport,
+                  [isolateId, reports],
+                  {
+                    #scriptId: scriptId,
+                    #tokenPos: tokenPos,
+                    #endTokenPos: endTokenPos,
+                    #forceCompile: forceCompile,
+                    #reportLines: reportLines,
+                    #libraryFilters: libraryFilters,
+                    #librariesAlreadyCompiled: librariesAlreadyCompiled,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.SourceReport>);
 
   @override
-  _i3.Future<_i2.Version> getVersion() => (super.noSuchMethod(
-        Invocation.method(
-          #getVersion,
-          [],
-        ),
-        returnValue: _i3.Future<_i2.Version>.value(_FakeVersion_25(
-          this,
-          Invocation.method(
-            #getVersion,
-            [],
-          ),
-        )),
-      ) as _i3.Future<_i2.Version>);
+  _i3.Future<_i2.Version> getVersion() =>
+      (super.noSuchMethod(
+            Invocation.method(#getVersion, []),
+            returnValue: _i3.Future<_i2.Version>.value(
+              _FakeVersion_25(this, Invocation.method(#getVersion, [])),
+            ),
+          )
+          as _i3.Future<_i2.Version>);
 
   @override
-  _i3.Future<_i2.VM> getVM() => (super.noSuchMethod(
-        Invocation.method(
-          #getVM,
-          [],
-        ),
-        returnValue: _i3.Future<_i2.VM>.value(_FakeVM_26(
-          this,
-          Invocation.method(
-            #getVM,
-            [],
-          ),
-        )),
-      ) as _i3.Future<_i2.VM>);
+  _i3.Future<_i2.VM> getVM() =>
+      (super.noSuchMethod(
+            Invocation.method(#getVM, []),
+            returnValue: _i3.Future<_i2.VM>.value(
+              _FakeVM_26(this, Invocation.method(#getVM, [])),
+            ),
+          )
+          as _i3.Future<_i2.VM>);
 
   @override
   _i3.Future<_i2.Timeline> getVMTimeline({
@@ -1399,86 +1106,67 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     int? timeExtentMicros,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getVMTimeline,
-          [],
-          {
-            #timeOriginMicros: timeOriginMicros,
-            #timeExtentMicros: timeExtentMicros,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Timeline>.value(_FakeTimeline_27(
-          this,
-          Invocation.method(
-            #getVMTimeline,
-            [],
-            {
+            Invocation.method(#getVMTimeline, [], {
               #timeOriginMicros: timeOriginMicros,
               #timeExtentMicros: timeExtentMicros,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Timeline>);
+            }),
+            returnValue: _i3.Future<_i2.Timeline>.value(
+              _FakeTimeline_27(
+                this,
+                Invocation.method(#getVMTimeline, [], {
+                  #timeOriginMicros: timeOriginMicros,
+                  #timeExtentMicros: timeExtentMicros,
+                }),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Timeline>);
 
   @override
-  _i3.Future<_i2.TimelineFlags> getVMTimelineFlags() => (super.noSuchMethod(
-        Invocation.method(
-          #getVMTimelineFlags,
-          [],
-        ),
-        returnValue: _i3.Future<_i2.TimelineFlags>.value(_FakeTimelineFlags_28(
-          this,
-          Invocation.method(
-            #getVMTimelineFlags,
-            [],
-          ),
-        )),
-      ) as _i3.Future<_i2.TimelineFlags>);
+  _i3.Future<_i2.TimelineFlags> getVMTimelineFlags() =>
+      (super.noSuchMethod(
+            Invocation.method(#getVMTimelineFlags, []),
+            returnValue: _i3.Future<_i2.TimelineFlags>.value(
+              _FakeTimelineFlags_28(
+                this,
+                Invocation.method(#getVMTimelineFlags, []),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.TimelineFlags>);
 
   @override
-  _i3.Future<_i2.Timestamp> getVMTimelineMicros() => (super.noSuchMethod(
-        Invocation.method(
-          #getVMTimelineMicros,
-          [],
-        ),
-        returnValue: _i3.Future<_i2.Timestamp>.value(_FakeTimestamp_29(
-          this,
-          Invocation.method(
-            #getVMTimelineMicros,
-            [],
-          ),
-        )),
-      ) as _i3.Future<_i2.Timestamp>);
+  _i3.Future<_i2.Timestamp> getVMTimelineMicros() =>
+      (super.noSuchMethod(
+            Invocation.method(#getVMTimelineMicros, []),
+            returnValue: _i3.Future<_i2.Timestamp>.value(
+              _FakeTimestamp_29(
+                this,
+                Invocation.method(#getVMTimelineMicros, []),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Timestamp>);
 
   @override
-  _i3.Future<_i2.Success> pause(String? isolateId) => (super.noSuchMethod(
-        Invocation.method(
-          #pause,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #pause,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+  _i3.Future<_i2.Success> pause(String? isolateId) =>
+      (super.noSuchMethod(
+            Invocation.method(#pause, [isolateId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(this, Invocation.method(#pause, [isolateId])),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
-  _i3.Future<_i2.Success> kill(String? isolateId) => (super.noSuchMethod(
-        Invocation.method(
-          #kill,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #kill,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+  _i3.Future<_i2.Success> kill(String? isolateId) =>
+      (super.noSuchMethod(
+            Invocation.method(#kill, [isolateId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(this, Invocation.method(#kill, [isolateId])),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.UriList> lookupResolvedPackageUris(
@@ -1487,26 +1175,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     bool? local,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #lookupResolvedPackageUris,
-          [
-            isolateId,
-            uris,
-          ],
-          {#local: local},
-        ),
-        returnValue: _i3.Future<_i2.UriList>.value(_FakeUriList_30(
-          this,
-          Invocation.method(
-            #lookupResolvedPackageUris,
-            [
-              isolateId,
-              uris,
-            ],
-            {#local: local},
-          ),
-        )),
-      ) as _i3.Future<_i2.UriList>);
+            Invocation.method(
+              #lookupResolvedPackageUris,
+              [isolateId, uris],
+              {#local: local},
+            ),
+            returnValue: _i3.Future<_i2.UriList>.value(
+              _FakeUriList_30(
+                this,
+                Invocation.method(
+                  #lookupResolvedPackageUris,
+                  [isolateId, uris],
+                  {#local: local},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.UriList>);
 
   @override
   _i3.Future<_i2.UriList> lookupPackageUris(
@@ -1514,49 +1199,28 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     List<String>? uris,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #lookupPackageUris,
-          [
-            isolateId,
-            uris,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.UriList>.value(_FakeUriList_30(
-          this,
-          Invocation.method(
-            #lookupPackageUris,
-            [
-              isolateId,
-              uris,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.UriList>);
+            Invocation.method(#lookupPackageUris, [isolateId, uris]),
+            returnValue: _i3.Future<_i2.UriList>.value(
+              _FakeUriList_30(
+                this,
+                Invocation.method(#lookupPackageUris, [isolateId, uris]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.UriList>);
 
   @override
-  _i3.Future<_i2.Success> registerService(
-    String? service,
-    String? alias,
-  ) =>
+  _i3.Future<_i2.Success> registerService(String? service, String? alias) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #registerService,
-          [
-            service,
-            alias,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #registerService,
-            [
-              service,
-              alias,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#registerService, [service, alias]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#registerService, [service, alias]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.ReloadReport> reloadSources(
@@ -1567,30 +1231,33 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? packagesUri,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #reloadSources,
-          [isolateId],
-          {
-            #force: force,
-            #pause: pause,
-            #rootLibUri: rootLibUri,
-            #packagesUri: packagesUri,
-          },
-        ),
-        returnValue: _i3.Future<_i2.ReloadReport>.value(_FakeReloadReport_31(
-          this,
-          Invocation.method(
-            #reloadSources,
-            [isolateId],
-            {
-              #force: force,
-              #pause: pause,
-              #rootLibUri: rootLibUri,
-              #packagesUri: packagesUri,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.ReloadReport>);
+            Invocation.method(
+              #reloadSources,
+              [isolateId],
+              {
+                #force: force,
+                #pause: pause,
+                #rootLibUri: rootLibUri,
+                #packagesUri: packagesUri,
+              },
+            ),
+            returnValue: _i3.Future<_i2.ReloadReport>.value(
+              _FakeReloadReport_31(
+                this,
+                Invocation.method(
+                  #reloadSources,
+                  [isolateId],
+                  {
+                    #force: force,
+                    #pause: pause,
+                    #rootLibUri: rootLibUri,
+                    #packagesUri: packagesUri,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.ReloadReport>);
 
   @override
   _i3.Future<_i2.Success> removeBreakpoint(
@@ -1598,40 +1265,28 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? breakpointId,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #removeBreakpoint,
-          [
-            isolateId,
-            breakpointId,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #removeBreakpoint,
-            [
-              isolateId,
-              breakpointId,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#removeBreakpoint, [isolateId, breakpointId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#removeBreakpoint, [isolateId, breakpointId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Success> requestHeapSnapshot(String? isolateId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #requestHeapSnapshot,
-          [isolateId],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #requestHeapSnapshot,
-            [isolateId],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#requestHeapSnapshot, [isolateId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#requestHeapSnapshot, [isolateId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Success> resume(
@@ -1640,26 +1295,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     int? frameIndex,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #resume,
-          [isolateId],
-          {
-            #step: step,
-            #frameIndex: frameIndex,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #resume,
-            [isolateId],
-            {
-              #step: step,
-              #frameIndex: frameIndex,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(
+              #resume,
+              [isolateId],
+              {#step: step, #frameIndex: frameIndex},
+            ),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(
+                  #resume,
+                  [isolateId],
+                  {#step: step, #frameIndex: frameIndex},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Breakpoint> setBreakpointState(
@@ -1668,26 +1320,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     bool? enable,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setBreakpointState,
-          [
-            isolateId,
-            breakpointId,
-            enable,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Breakpoint>.value(_FakeBreakpoint_0(
-          this,
-          Invocation.method(
-            #setBreakpointState,
-            [
+            Invocation.method(#setBreakpointState, [
               isolateId,
               breakpointId,
               enable,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Breakpoint>);
+            ]),
+            returnValue: _i3.Future<_i2.Breakpoint>.value(
+              _FakeBreakpoint_0(
+                this,
+                Invocation.method(#setBreakpointState, [
+                  isolateId,
+                  breakpointId,
+                  enable,
+                ]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Breakpoint>);
 
   @override
   _i3.Future<_i2.Success> setExceptionPauseMode(
@@ -1695,24 +1344,15 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     String? mode,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setExceptionPauseMode,
-          [
-            isolateId,
-            mode,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #setExceptionPauseMode,
-            [
-              isolateId,
-              mode,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#setExceptionPauseMode, [isolateId, mode]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#setExceptionPauseMode, [isolateId, mode]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Success> setIsolatePauseMode(
@@ -1721,51 +1361,39 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     bool? shouldPauseOnExit,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setIsolatePauseMode,
-          [isolateId],
-          {
-            #exceptionPauseMode: exceptionPauseMode,
-            #shouldPauseOnExit: shouldPauseOnExit,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #setIsolatePauseMode,
-            [isolateId],
-            {
-              #exceptionPauseMode: exceptionPauseMode,
-              #shouldPauseOnExit: shouldPauseOnExit,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(
+              #setIsolatePauseMode,
+              [isolateId],
+              {
+                #exceptionPauseMode: exceptionPauseMode,
+                #shouldPauseOnExit: shouldPauseOnExit,
+              },
+            ),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(
+                  #setIsolatePauseMode,
+                  [isolateId],
+                  {
+                    #exceptionPauseMode: exceptionPauseMode,
+                    #shouldPauseOnExit: shouldPauseOnExit,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
-  _i3.Future<_i2.Response> setFlag(
-    String? name,
-    String? value,
-  ) =>
+  _i3.Future<_i2.Response> setFlag(String? name, String? value) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setFlag,
-          [
-            name,
-            value,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_3(
-          this,
-          Invocation.method(
-            #setFlag,
-            [
-              name,
-              value,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(#setFlag, [name, value]),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_3(this, Invocation.method(#setFlag, [name, value])),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Success> setLibraryDebuggable(
@@ -1774,51 +1402,36 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     bool? isDebuggable,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setLibraryDebuggable,
-          [
-            isolateId,
-            libraryId,
-            isDebuggable,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #setLibraryDebuggable,
-            [
+            Invocation.method(#setLibraryDebuggable, [
               isolateId,
               libraryId,
               isDebuggable,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            ]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#setLibraryDebuggable, [
+                  isolateId,
+                  libraryId,
+                  isDebuggable,
+                ]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
-  _i3.Future<_i2.Success> setName(
-    String? isolateId,
-    String? name,
-  ) =>
+  _i3.Future<_i2.Success> setName(String? isolateId, String? name) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setName,
-          [
-            isolateId,
-            name,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #setName,
-            [
-              isolateId,
-              name,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#setName, [isolateId, name]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#setName, [isolateId, name]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Success> setTraceClassAllocation(
@@ -1827,103 +1440,85 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     bool? enable,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setTraceClassAllocation,
-          [
-            isolateId,
-            classId,
-            enable,
-          ],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #setTraceClassAllocation,
-            [
+            Invocation.method(#setTraceClassAllocation, [
               isolateId,
               classId,
               enable,
-            ],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            ]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#setTraceClassAllocation, [
+                  isolateId,
+                  classId,
+                  enable,
+                ]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
-  _i3.Future<_i2.Success> setVMName(String? name) => (super.noSuchMethod(
-        Invocation.method(
-          #setVMName,
-          [name],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #setVMName,
-            [name],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+  _i3.Future<_i2.Success> setVMName(String? name) =>
+      (super.noSuchMethod(
+            Invocation.method(#setVMName, [name]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(this, Invocation.method(#setVMName, [name])),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Success> setVMTimelineFlags(List<String>? recordedStreams) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setVMTimelineFlags,
-          [recordedStreams],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #setVMTimelineFlags,
-            [recordedStreams],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#setVMTimelineFlags, [recordedStreams]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#setVMTimelineFlags, [recordedStreams]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
-  _i3.Future<_i2.Success> streamCancel(String? streamId) => (super.noSuchMethod(
-        Invocation.method(
-          #streamCancel,
-          [streamId],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #streamCancel,
-            [streamId],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+  _i3.Future<_i2.Success> streamCancel(String? streamId) =>
+      (super.noSuchMethod(
+            Invocation.method(#streamCancel, [streamId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#streamCancel, [streamId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Success> streamCpuSamplesWithUserTag(List<String>? userTags) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #streamCpuSamplesWithUserTag,
-          [userTags],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #streamCpuSamplesWithUserTag,
-            [userTags],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+            Invocation.method(#streamCpuSamplesWithUserTag, [userTags]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#streamCpuSamplesWithUserTag, [userTags]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
-  _i3.Future<_i2.Success> streamListen(String? streamId) => (super.noSuchMethod(
-        Invocation.method(
-          #streamListen,
-          [streamId],
-        ),
-        returnValue: _i3.Future<_i2.Success>.value(_FakeSuccess_1(
-          this,
-          Invocation.method(
-            #streamListen,
-            [streamId],
-          ),
-        )),
-      ) as _i3.Future<_i2.Success>);
+  _i3.Future<_i2.Success> streamListen(String? streamId) =>
+      (super.noSuchMethod(
+            Invocation.method(#streamListen, [streamId]),
+            returnValue: _i3.Future<_i2.Success>.value(
+              _FakeSuccess_1(
+                this,
+                Invocation.method(#streamListen, [streamId]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Success>);
 
   @override
   _i3.Future<_i2.Response> callMethod(
@@ -1932,26 +1527,23 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     Map<String, dynamic>? args,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #callMethod,
-          [method],
-          {
-            #isolateId: isolateId,
-            #args: args,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_3(
-          this,
-          Invocation.method(
-            #callMethod,
-            [method],
-            {
-              #isolateId: isolateId,
-              #args: args,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #callMethod,
+              [method],
+              {#isolateId: isolateId, #args: args},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_3(
+                this,
+                Invocation.method(
+                  #callMethod,
+                  [method],
+                  {#isolateId: isolateId, #args: args},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> callServiceExtension(
@@ -1960,88 +1552,56 @@ class MockVmService extends _i1.Mock implements _i2.VmService {
     Map<String, dynamic>? args,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #callServiceExtension,
-          [method],
-          {
-            #isolateId: isolateId,
-            #args: args,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_3(
-          this,
-          Invocation.method(
-            #callServiceExtension,
-            [method],
-            {
-              #isolateId: isolateId,
-              #args: args,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
-
-  @override
-  _i3.Future<void> dispose() => (super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-
-  @override
-  _i3.Future<T> wrapFuture<T>(
-    String? name,
-    _i3.Future<T>? future,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #wrapFuture,
-          [
-            name,
-            future,
-          ],
-        ),
-        returnValue: _i4.ifNotNull(
-              _i4.dummyValueOrNull<T>(
+            Invocation.method(
+              #callServiceExtension,
+              [method],
+              {#isolateId: isolateId, #args: args},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_3(
                 this,
                 Invocation.method(
-                  #wrapFuture,
-                  [
-                    name,
-                    future,
-                  ],
+                  #callServiceExtension,
+                  [method],
+                  {#isolateId: isolateId, #args: args},
                 ),
               ),
-              (T v) => _i3.Future<T>.value(v),
-            ) ??
-            _FakeFuture_32<T>(
-              this,
-              Invocation.method(
-                #wrapFuture,
-                [
-                  name,
-                  future,
-                ],
-              ),
             ),
-      ) as _i3.Future<T>);
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
-  void registerServiceCallback(
-    String? service,
-    _i2.ServiceCallback? cb,
-  ) =>
+  _i3.Future<void> dispose() =>
+      (super.noSuchMethod(
+            Invocation.method(#dispose, []),
+            returnValue: _i3.Future<void>.value(),
+            returnValueForMissingStub: _i3.Future<void>.value(),
+          )
+          as _i3.Future<void>);
+
+  @override
+  _i3.Future<T> wrapFuture<T>(String? name, _i3.Future<T>? future) =>
+      (super.noSuchMethod(
+            Invocation.method(#wrapFuture, [name, future]),
+            returnValue:
+                _i4.ifNotNull(
+                  _i4.dummyValueOrNull<T>(
+                    this,
+                    Invocation.method(#wrapFuture, [name, future]),
+                  ),
+                  (T v) => _i3.Future<T>.value(v),
+                ) ??
+                _FakeFuture_32<T>(
+                  this,
+                  Invocation.method(#wrapFuture, [name, future]),
+                ),
+          )
+          as _i3.Future<T>);
+
+  @override
+  void registerServiceCallback(String? service, _i2.ServiceCallback? cb) =>
       super.noSuchMethod(
-        Invocation.method(
-          #registerServiceCallback,
-          [
-            service,
-            cb,
-          ],
-        ),
+        Invocation.method(#registerServiceCallback, [service, cb]),
         returnValueForMissingStub: null,
       );
 }

--- a/pkgs/coverage/test/collect_coverage_test.dart
+++ b/pkgs/coverage/test/collect_coverage_test.dart
@@ -28,8 +28,9 @@ void main() {
     final resultString = await _getCoverageResult();
 
     // analyze the output json
-    final coverage =
-        coverageDataFromJson(json.decode(resultString) as Map<String, dynamic>);
+    final coverage = coverageDataFromJson(
+      json.decode(resultString) as Map<String, dynamic>,
+    );
 
     expect(coverage, isNotEmpty);
 
@@ -48,30 +49,14 @@ void main() {
     final coverage = [
       {
         'source': 'foo',
-        'script': '{type: @Script, fixedId: true, '
+        'script':
+            '{type: @Script, fixedId: true, '
             'id: bar.dart, uri: bar.dart, _kind: library}',
-        'hits': [
-          45,
-          1,
-          46,
-          1,
-          49,
-          0,
-          50,
-          0,
-          15,
-          1,
-          16,
-          2,
-          17,
-          2,
-        ]
-      }
+        'hits': [45, 1, 46, 1, 49, 0, 50, 0, 15, 1, 16, 2, 17, 2],
+      },
     ];
     // ignore: deprecated_member_use_from_same_package
-    final hitMap = await createHitmap(
-      coverage.cast<Map<String, dynamic>>(),
-    );
+    final hitMap = await createHitmap(coverage.cast<Map<String, dynamic>>());
     final expectedHits = {15: 1, 16: 2, 17: 2, 45: 1, 46: 1, 49: 0, 50: 0};
     expect(hitMap['foo'], expectedHits);
   });
@@ -80,25 +65,11 @@ void main() {
     final coverage = [
       {
         'source': 'foo',
-        'script': '{type: @Script, fixedId: true, '
+        'script':
+            '{type: @Script, fixedId: true, '
             'id: bar.dart, uri: bar.dart, _kind: library}',
-        'hits': [
-          45,
-          1,
-          46,
-          1,
-          49,
-          0,
-          50,
-          0,
-          15,
-          1,
-          16,
-          2,
-          17,
-          2,
-        ]
-      }
+        'hits': [45, 1, 46, 1, 49, 0, 50, 0, 15, 1, 16, 2, 17, 2],
+      },
     ];
     final hitMap = await HitMap.parseJson(
       coverage.cast<Map<String, dynamic>>(),
@@ -132,26 +103,27 @@ void main() {
       38: 1,
       39: 1,
       41: 1,
-      42: 4,
-      43: 2,
-      44: 1,
-      45: 3,
-      46: 1,
-      49: 1,
-      50: 1,
+      42: 1,
+      43: 3,
+      44: 2,
+      45: 1,
+      46: 3,
+      47: 1,
+      51: 1,
       52: 1,
-      55: 1,
-      56: 1,
+      54: 1,
       57: 1,
-      60: 1,
-      61: 1,
+      58: 1,
+      59: 1,
+      62: 1,
       63: 1,
-      64: 1,
       65: 1,
+      66: 1,
       67: 1,
-      68: 1,
       69: 1,
-      72: 3,
+      70: 1,
+      71: 1,
+      74: 3,
     };
     expect(isolateFile?.lineHits, expectedHits);
     expect(isolateFile?.funcHits, {11: 1, 19: 1, 23: 1, 28: 1, 38: 1});
@@ -160,24 +132,21 @@ void main() {
       19: 'BarClass.BarClass',
       23: 'BarClass.baz',
       28: 'fooAsync',
-      38: 'isolateTask'
+      38: 'isolateTask',
     });
-    expect(
-      isolateFile?.branchHits,
-      {
-        11: 1,
-        12: 1,
-        15: 0,
-        19: 1,
-        23: 1,
-        28: 1,
-        29: 1,
-        32: 0,
-        38: 1,
-        42: 1,
-        72: 1,
-      },
-    );
+    expect(isolateFile?.branchHits, {
+      11: 1,
+      12: 1,
+      15: 0,
+      19: 1,
+      23: 1,
+      28: 1,
+      29: 1,
+      32: 0,
+      38: 1,
+      43: 1,
+      74: 1,
+    });
   });
 
   test('parseCoverage', () async {
@@ -226,8 +195,11 @@ void main() {
       final coverageResults = await _getCoverageResult();
       await outputFile.writeAsString(coverageResults, flush: true);
 
-      final parsedResult = await HitMap.parseFiles([outputFile],
-          packagePath: '.', checkIgnoredLines: true);
+      final parsedResult = await HitMap.parseFiles(
+        [outputFile],
+        packagePath: '.',
+        checkIgnoredLines: true,
+      );
 
       // This file has ignore:coverage-file.
       expect(parsedResult, isNot(contains(_sampleAppFileUri)));
@@ -257,31 +229,50 @@ void main() {
 
   test('FileHitMaps.merge', () {
     final resultMap = <String, HitMap>{
-      'foo.dart':
-          HitMap({10: 2, 20: 0}, {15: 0, 25: 1}, {15: 'bobble', 25: 'cobble'}),
-      'bar.dart': HitMap(
-          {10: 3, 20: 1, 30: 0}, {15: 5, 25: 0}, {15: 'gobble', 25: 'wobble'}),
+      'foo.dart': HitMap({10: 2, 20: 0}, {15: 0, 25: 1}, {
+        15: 'bobble',
+        25: 'cobble',
+      }),
+      'bar.dart': HitMap({10: 3, 20: 1, 30: 0}, {15: 5, 25: 0}, {
+        15: 'gobble',
+        25: 'wobble',
+      }),
     };
     final newMap = <String, HitMap>{
-      'bar.dart': HitMap(
-          {10: 2, 20: 0, 40: 3}, {15: 1, 35: 4}, {15: 'gobble', 35: 'dobble'}),
-      'baz.dart': HitMap(
-          {10: 1, 20: 0, 30: 1}, {15: 0, 25: 2}, {15: 'lobble', 25: 'zobble'}),
+      'bar.dart': HitMap({10: 2, 20: 0, 40: 3}, {15: 1, 35: 4}, {
+        15: 'gobble',
+        35: 'dobble',
+      }),
+      'baz.dart': HitMap({10: 1, 20: 0, 30: 1}, {15: 0, 25: 2}, {
+        15: 'lobble',
+        25: 'zobble',
+      }),
     };
     resultMap.merge(newMap);
     expect(resultMap['foo.dart']?.lineHits, <int, int>{10: 2, 20: 0});
     expect(resultMap['foo.dart']?.funcHits, <int, int>{15: 0, 25: 1});
-    expect(resultMap['foo.dart']?.funcNames,
-        <int, String>{15: 'bobble', 25: 'cobble'});
-    expect(resultMap['bar.dart']?.lineHits,
-        <int, int>{10: 5, 20: 1, 30: 0, 40: 3});
+    expect(resultMap['foo.dart']?.funcNames, <int, String>{
+      15: 'bobble',
+      25: 'cobble',
+    });
+    expect(resultMap['bar.dart']?.lineHits, <int, int>{
+      10: 5,
+      20: 1,
+      30: 0,
+      40: 3,
+    });
     expect(resultMap['bar.dart']?.funcHits, <int, int>{15: 6, 25: 0, 35: 4});
-    expect(resultMap['bar.dart']?.funcNames,
-        <int, String>{15: 'gobble', 25: 'wobble', 35: 'dobble'});
+    expect(resultMap['bar.dart']?.funcNames, <int, String>{
+      15: 'gobble',
+      25: 'wobble',
+      35: 'dobble',
+    });
     expect(resultMap['baz.dart']?.lineHits, <int, int>{10: 1, 20: 0, 30: 1});
     expect(resultMap['baz.dart']?.funcHits, <int, int>{15: 0, 25: 2});
-    expect(resultMap['baz.dart']?.funcNames,
-        <int, String>{15: 'lobble', 25: 'zobble'});
+    expect(resultMap['baz.dart']?.funcNames, <int, String>{
+      15: 'lobble',
+      25: 'zobble',
+    });
   });
 }
 
@@ -291,7 +282,9 @@ Future<String> _getCoverageResult() async =>
     _coverageData ??= await _collectCoverage(false, false);
 
 Future<String> _collectCoverage(
-    bool functionCoverage, bool branchCoverage) async {
+  bool functionCoverage,
+  bool branchCoverage,
+) async {
   expect(FileSystemEntity.isFileSync(testAppPath), isTrue);
 
   // Run the sample app with the right flags.
@@ -309,10 +302,12 @@ Future<String> _collectCoverage(
     '--uri',
     '$serviceUri',
     '--resume-isolates',
-    '--wait-paused'
+    '--wait-paused',
   ]);
 
-  await toolResult.shouldExit(0).timeout(
+  await toolResult
+      .shouldExit(0)
+      .timeout(
         timeout,
         onTimeout: () =>
             throw StateError('We timed out waiting for the tool to finish.'),

--- a/pkgs/coverage/test/config_file_locator_test.dart
+++ b/pkgs/coverage/test/config_file_locator_test.dart
@@ -13,37 +13,47 @@ void main() {
 
   test('options file exists', () {
     testDirectory = Directory('$baseTestPath/pkg1/lib/src');
-    var filePath =
-        CoverageOptionsProvider.findOptionsFilePath(directory: testDirectory);
-    expect(path.normalize('$baseTestPath/pkg1/coverage_options.yaml'),
-        path.normalize(filePath!));
+    var filePath = CoverageOptionsProvider.findOptionsFilePath(
+      directory: testDirectory,
+    );
+    expect(
+      path.normalize('$baseTestPath/pkg1/coverage_options.yaml'),
+      path.normalize(filePath!),
+    );
 
     testDirectory = Directory('$baseTestPath/pkg1/lib');
-    filePath =
-        CoverageOptionsProvider.findOptionsFilePath(directory: testDirectory);
-    expect(path.normalize('$baseTestPath/pkg1/coverage_options.yaml'),
-        path.normalize(filePath!));
+    filePath = CoverageOptionsProvider.findOptionsFilePath(
+      directory: testDirectory,
+    );
+    expect(
+      path.normalize('$baseTestPath/pkg1/coverage_options.yaml'),
+      path.normalize(filePath!),
+    );
   });
 
   test('options file missing', () {
     testDirectory = Directory('$baseTestPath/pkg2/lib/src');
-    var filePath =
-        CoverageOptionsProvider.findOptionsFilePath(directory: testDirectory);
+    var filePath = CoverageOptionsProvider.findOptionsFilePath(
+      directory: testDirectory,
+    );
     expect(filePath, isNull);
 
     testDirectory = Directory('$baseTestPath/pkg2/lib');
-    filePath =
-        CoverageOptionsProvider.findOptionsFilePath(directory: testDirectory);
+    filePath = CoverageOptionsProvider.findOptionsFilePath(
+      directory: testDirectory,
+    );
     expect(filePath, isNull);
   });
 
   test('no pubspec found', () {
     var filePath = CoverageOptionsProvider.findOptionsFilePath(
-        directory: Directory.systemTemp);
+      directory: Directory.systemTemp,
+    );
     expect(filePath, isNull);
 
     filePath = CoverageOptionsProvider.findOptionsFilePath(
-        directory: Directory.systemTemp);
+      directory: Directory.systemTemp,
+    );
     expect(filePath, isNull);
   });
 }

--- a/pkgs/coverage/test/filter_ignored_test.dart
+++ b/pkgs/coverage/test/filter_ignored_test.dart
@@ -22,9 +22,7 @@ void main() {
         {1: 'abc', 2: 'def'},
         {1: 1, 2: 2, 3: 3},
       ),
-      fileUri('another_nonexistent_file.dart'): HitMap(
-        {1: 1, 2: 2, 3: 3},
-      ),
+      fileUri('another_nonexistent_file.dart'): HitMap({1: 1, 2: 2, 3: 3}),
       fileUri('test/test_files/test_app.dart'): HitMap(
         {1: 1, 2: 2, 3: 3},
         {1: 1, 2: 2, 3: 3},
@@ -41,14 +39,12 @@ void main() {
 
     // Lines ignored in test/test_files/test_app_isolate.dart.
     const ignores = [
-      52,
       54,
-      55,
       56,
       57,
       58,
-      63,
-      64,
+      59,
+      60,
       65,
       66,
       67,
@@ -58,6 +54,8 @@ void main() {
       71,
       72,
       73,
+      74,
+      75,
     ];
 
     final expected = {
@@ -67,30 +65,30 @@ void main() {
         {1: 'abc', 2: 'def'},
         {1: 1, 2: 2, 3: 3},
       ),
-      fileUri('another_nonexistent_file.dart'): HitMap(
-        {1: 1, 2: 2, 3: 3},
-      ),
+      fileUri('another_nonexistent_file.dart'): HitMap({1: 1, 2: 2, 3: 3}),
       fileUri('test/test_files/test_app_isolate.dart'): HitMap(
         {
           for (var i = 50; i < 100; ++i)
-            if (!ignores.contains(i)) i: i
+            if (!ignores.contains(i)) i: i,
         },
         {
           for (var i = 50; i < 100; ++i)
-            if (!ignores.contains(i)) i: i
+            if (!ignores.contains(i)) i: i,
         },
         {for (var i = 50; i < 100; ++i) i: '$i'},
         {
           for (var i = 50; i < 100; ++i)
-            if (!ignores.contains(i)) i: i
+            if (!ignores.contains(i)) i: i,
         },
       ),
     };
 
     final resolver = await Resolver.create(packagePath: '.');
 
-    final actual =
-        hitmaps.filterIgnored(ignoredLinesInFilesCache: {}, resolver: resolver);
+    final actual = hitmaps.filterIgnored(
+      ignoredLinesInFilesCache: {},
+      resolver: resolver,
+    );
 
     expect(actual.keys.toList(), expected.keys.toList());
     for (final source in expected.keys) {

--- a/pkgs/coverage/test/format_coverage_test.dart
+++ b/pkgs/coverage/test/format_coverage_test.dart
@@ -30,8 +30,8 @@ void main() {
     final files = filesToProcess(testDir.path);
     expect(files.length, equals(2));
     expect(
-        files.map((f) => f.path),
-        containsAll(
-            [endsWith('coverage_a.json'), endsWith('coverage_b.json')]));
+      files.map((f) => f.path),
+      containsAll([endsWith('coverage_a.json'), endsWith('coverage_b.json')]),
+    );
   });
 }

--- a/pkgs/coverage/test/function_coverage_test.dart
+++ b/pkgs/coverage/test/function_coverage_test.dart
@@ -55,8 +55,9 @@ void main() {
     });
 
     // test_library.dart.
-    final testLibraryPath =
-        p.absolute(p.join('test', 'test_files', 'test_library.dart'));
+    final testLibraryPath = p.absolute(
+      p.join('test', 'test_files', 'test_library.dart'),
+    );
     final testLibraryUri = p.toUri(testLibraryPath).toString();
     expect(hitMap, contains(testLibraryUri));
     final libraryfile = hitMap[testLibraryUri]!;
@@ -64,8 +65,9 @@ void main() {
     expect(libraryfile.funcNames, {7: 'libraryFunction'});
 
     // test_library_part.dart.
-    final testLibraryPartPath =
-        p.absolute(p.join('test', 'test_files', 'test_library_part.dart'));
+    final testLibraryPartPath = p.absolute(
+      p.join('test', 'test_files', 'test_library_part.dart'),
+    );
     final testLibraryPartUri = p.toUri(testLibraryPartPath).toString();
     expect(hitMap, contains(testLibraryPartUri));
     final libraryPartFile = hitMap[testLibraryPartUri]!;
@@ -78,8 +80,11 @@ Future<String> _collectCoverage() async {
   expect(FileSystemEntity.isFileSync(_funcCovApp), isTrue);
 
   // Run the sample app with the right flags.
-  final sampleProcess = await TestProcess.start(Platform.resolvedExecutable,
-      ['--enable-vm-service=0', '--pause_isolates_on_exit', _funcCovApp]);
+  final sampleProcess = await TestProcess.start(Platform.resolvedExecutable, [
+    '--enable-vm-service=0',
+    '--pause_isolates_on_exit',
+    _funcCovApp,
+  ]);
 
   final serviceUri = await serviceUriFromProcess(sampleProcess.stdoutStream());
 
@@ -90,10 +95,12 @@ Future<String> _collectCoverage() async {
     '--uri',
     '$serviceUri',
     '--resume-isolates',
-    '--wait-paused'
+    '--wait-paused',
   ]);
 
-  await toolResult.shouldExit(0).timeout(
+  await toolResult
+      .shouldExit(0)
+      .timeout(
         timeout,
         onTimeout: () =>
             throw StateError('We timed out waiting for the tool to finish.'),

--- a/pkgs/coverage/test/isolate_paused_listener_test.dart
+++ b/pkgs/coverage/test/isolate_paused_listener_test.dart
@@ -11,32 +11,22 @@ import 'package:vm_service/vm_service.dart';
 
 import 'collect_coverage_mock_test.mocks.dart';
 
-Event event(
-  String id, {
-  String? kind,
-  String? groupId,
-  String? name,
-}) =>
-    Event(
-        kind: kind,
-        isolate: IsolateRef(
-          isolateGroupId: groupId,
-          id: id,
-          name: name,
-        ));
+Event event(String id, {String? kind, String? groupId, String? name}) => Event(
+  kind: kind,
+  isolate: IsolateRef(isolateGroupId: groupId, id: id, name: name),
+);
 
 Isolate isolate(
   String id, {
   String? groupId,
   String? name,
   String? pauseKind,
-}) =>
-    Isolate(
-      isolateGroupId: groupId,
-      id: id,
-      name: name,
-      pauseEvent: pauseKind == null ? null : Event(kind: pauseKind),
-    );
+}) => Isolate(
+  isolateGroupId: groupId,
+  id: id,
+  name: name,
+  pauseEvent: pauseKind == null ? null : Event(kind: pauseKind),
+);
 
 (MockVmService, StreamController<Event>) createServiceAndEventStreams() {
   final service = MockVmService();
@@ -142,8 +132,10 @@ void main() {
     expect(group.noLiveIsolates, isFalse);
 
     group.start(IsolateRef(id: 'b'));
-    expect(group.running.map((iso) => iso.id).toList(),
-        unorderedEquals(['a', 'b']));
+    expect(
+      group.running.map((iso) => iso.id).toList(),
+      unorderedEquals(['a', 'b']),
+    );
     expect(group.paused, isEmpty);
     expect(group.noRunningIsolates, isFalse);
     expect(group.noLiveIsolates, isFalse);
@@ -162,22 +154,28 @@ void main() {
 
     group.pause(IsolateRef(id: 'c'));
     expect(group.running.map((iso) => iso.id).toList(), unorderedEquals(['b']));
-    expect(group.paused.map((iso) => iso.id).toList(),
-        unorderedEquals(['a', 'c']));
+    expect(
+      group.paused.map((iso) => iso.id).toList(),
+      unorderedEquals(['a', 'c']),
+    );
     expect(group.noRunningIsolates, isFalse);
     expect(group.noLiveIsolates, isFalse);
 
     group.start(IsolateRef(id: 'c'));
-    expect(group.running.map((iso) => iso.id).toList(),
-        unorderedEquals(['b', 'c']));
+    expect(
+      group.running.map((iso) => iso.id).toList(),
+      unorderedEquals(['b', 'c']),
+    );
     expect(group.paused.map((iso) => iso.id).toList(), unorderedEquals(['a']));
     expect(group.noRunningIsolates, isFalse);
     expect(group.noLiveIsolates, isFalse);
 
     group.pause(IsolateRef(id: 'c'));
     expect(group.running.map((iso) => iso.id).toList(), unorderedEquals(['b']));
-    expect(group.paused.map((iso) => iso.id).toList(),
-        unorderedEquals(['a', 'c']));
+    expect(
+      group.paused.map((iso) => iso.id).toList(),
+      unorderedEquals(['a', 'c']),
+    );
     expect(group.noRunningIsolates, isFalse);
     expect(group.noLiveIsolates, isFalse);
 
@@ -189,8 +187,10 @@ void main() {
 
     group.pause(IsolateRef(id: 'b'));
     expect(group.running, isEmpty);
-    expect(group.paused.map((iso) => iso.id).toList(),
-        unorderedEquals(['b', 'c']));
+    expect(
+      group.paused.map((iso) => iso.id).toList(),
+      unorderedEquals(['b', 'c']),
+    );
     expect(group.noRunningIsolates, isTrue);
     expect(group.noLiveIsolates, isFalse);
 
@@ -242,8 +242,9 @@ void main() {
       (service, allEvents) = createServiceAndEventStreams();
 
       isolates = Completer<List<Isolate>>();
-      when(service.getVM())
-          .thenAnswer((_) async => VM(isolates: await isolates.future));
+      when(
+        service.getVM(),
+      ).thenAnswer((_) async => VM(isolates: await isolates.future));
       when(service.getIsolate(any)).thenAnswer((invocation) async {
         final id = invocation.positionalArguments[0];
         return (await isolates.future).firstWhere((iso) => iso.id == id);
@@ -346,12 +347,7 @@ void main() {
       exitEvent('B');
 
       await endTest();
-      expect(received, [
-        'Start A',
-        'Pause A',
-        'Start B',
-        'Exit B',
-      ]);
+      expect(received, ['Start A', 'Pause A', 'Start B', 'Exit B']);
     });
 
     test('pause event after exit is ignored', () async {
@@ -361,10 +357,7 @@ void main() {
       pauseEvent('A');
 
       await endTest();
-      expect(received, [
-        'Start A',
-        'Exit A',
-      ]);
+      expect(received, ['Start A', 'Exit A']);
     });
 
     test('event deduping', () async {
@@ -409,13 +402,7 @@ void main() {
       otherEvent('C', EventKind.kInspect);
 
       await endTest();
-      expect(received, [
-        'Start A',
-        'Pause A',
-        'Exit A',
-        'Start B',
-        'Exit B',
-      ]);
+      expect(received, ['Start A', 'Pause A', 'Exit A', 'Start B', 'Exit B']);
     });
 
     test('exit event during pause callback', () async {
@@ -431,19 +418,11 @@ void main() {
         await Future<void>.delayed(Duration.zero);
       }
 
-      expect(received, [
-        'Start A',
-        'Pause A',
-      ]);
+      expect(received, ['Start A', 'Pause A']);
 
       delayingTheOnPauseCallback.complete();
       await endTest();
-      expect(received, [
-        'Start A',
-        'Pause A',
-        'Pause done A',
-        'Exit A',
-      ]);
+      expect(received, ['Start A', 'Pause A', 'Pause done A', 'Exit A']);
     });
 
     test('exit event during pause callback, event deduping', () async {
@@ -463,19 +442,11 @@ void main() {
         await Future<void>.delayed(Duration.zero);
       }
 
-      expect(received, [
-        'Start A',
-        'Pause A',
-      ]);
+      expect(received, ['Start A', 'Pause A']);
 
       delayingTheOnPauseCallback.complete();
       await endTest();
-      expect(received, [
-        'Start A',
-        'Pause A',
-        'Pause done A',
-        'Exit A',
-      ]);
+      expect(received, ['Start A', 'Pause A', 'Pause done A', 'Exit A']);
     });
   });
 
@@ -491,27 +462,25 @@ void main() {
     late Set<String> resumeFailures;
     Exception Function(String id)? resumeErrorBuilder;
 
-    void startEvent(String id, String groupId, [String? name]) =>
-        allEvents.add(event(
-          id,
-          kind: EventKind.kIsolateStart,
-          groupId: groupId,
-          name: name ?? id,
-        ));
-    void exitEvent(String id, String groupId, [String? name]) =>
-        allEvents.add(event(
-          id,
-          kind: EventKind.kIsolateExit,
-          groupId: groupId,
-          name: name ?? id,
-        ));
-    void pauseEvent(String id, String groupId, [String? name]) =>
-        allEvents.add(event(
-          id,
-          kind: EventKind.kPauseExit,
-          groupId: groupId,
-          name: name ?? id,
-        ));
+    void startEvent(String id, String groupId, [String? name]) => allEvents.add(
+      event(
+        id,
+        kind: EventKind.kIsolateStart,
+        groupId: groupId,
+        name: name ?? id,
+      ),
+    );
+    void exitEvent(String id, String groupId, [String? name]) => allEvents.add(
+      event(
+        id,
+        kind: EventKind.kIsolateExit,
+        groupId: groupId,
+        name: name ?? id,
+      ),
+    );
+    void pauseEvent(String id, String groupId, [String? name]) => allEvents.add(
+      event(id, kind: EventKind.kPauseExit, groupId: groupId, name: name ?? id),
+    );
 
     Future<void> endTest() async {
       await allIsolatesExited;
@@ -520,50 +489,58 @@ void main() {
 
     setUp(() {
       lastError = null;
-      Zone.current.fork(
-        specification: ZoneSpecification(
-          handleUncaughtError: (Zone self, ZoneDelegate parent, Zone zone,
-              Object error, StackTrace stackTrace) {
-            lastError = error;
-          },
-        ),
-      ).runGuarded(() {
-        (service, allEvents) = createServiceAndEventStreams();
+      Zone.current
+          .fork(
+            specification: ZoneSpecification(
+              handleUncaughtError:
+                  (
+                    Zone self,
+                    ZoneDelegate parent,
+                    Zone zone,
+                    Object error,
+                    StackTrace stackTrace,
+                  ) {
+                    lastError = error;
+                  },
+            ),
+          )
+          .runGuarded(() {
+            (service, allEvents) = createServiceAndEventStreams();
 
-        // Backfill was tested above, so this test does everything using events,
-        // for simplicity. No need to report any isolates.
-        when(service.getVM()).thenAnswer((_) async => VM());
+            // Backfill was tested above, so this test does everything using
+            // events, for simplicity. No need to report any isolates.
+            when(service.getVM()).thenAnswer((_) async => VM());
 
-        received = <String>[];
-        delayTheOnPauseCallback = null;
-        resumeFailures = <String>{};
-        resumeErrorBuilder = null;
-        when(service.resume(any)).thenAnswer((invocation) async {
-          final id = invocation.positionalArguments[0] as String;
-          received.add('Resume $id');
-          if (resumeFailures.contains(id)) {
-            throw resumeErrorBuilder?.call(id) ??
-                RPCError('resume', -32000, id);
-          }
-          return Success();
-        });
+            received = <String>[];
+            delayTheOnPauseCallback = null;
+            resumeFailures = <String>{};
+            resumeErrorBuilder = null;
+            when(service.resume(any)).thenAnswer((invocation) async {
+              final id = invocation.positionalArguments[0] as String;
+              received.add('Resume $id');
+              if (resumeFailures.contains(id)) {
+                throw resumeErrorBuilder?.call(id) ??
+                    RPCError('resume', -32000, id);
+              }
+              return Success();
+            });
 
-        stopped = false;
-        allIsolatesExited = IsolatePausedListener(
-          service,
-          (iso, isLastIsolateInGroup) async {
-            expect(stopped, isFalse);
-            received
-                .add('Pause ${iso.id}. Collect group ${iso.isolateGroupId}? '
-                    '${isLastIsolateInGroup ? 'Yes' : 'No'}');
-            if (delayTheOnPauseCallback != null) {
-              await delayTheOnPauseCallback!(iso.id!);
-              received.add('Pause done ${iso.id}');
-            }
-          },
-          (message) => received.add(message),
-        ).waitUntilAllExited();
-      });
+            stopped = false;
+            allIsolatesExited = IsolatePausedListener(service, (
+              iso,
+              isLastIsolateInGroup,
+            ) async {
+              expect(stopped, isFalse);
+              received.add(
+                'Pause ${iso.id}. Collect group ${iso.isolateGroupId}? '
+                '${isLastIsolateInGroup ? 'Yes' : 'No'}',
+              );
+              if (delayTheOnPauseCallback != null) {
+                await delayTheOnPauseCallback!(iso.id!);
+                received.add('Pause done ${iso.id}');
+              }
+            }, (message) => received.add(message)).waitUntilAllExited();
+          });
     });
 
     test('ordinary flows', () async {
@@ -739,10 +716,7 @@ void main() {
 
       await endTest();
 
-      expect(received, [
-        'Pause A. Collect group 1? Yes',
-        'Resume A',
-      ]);
+      expect(received, ['Pause A. Collect group 1? Yes', 'Resume A']);
     });
 
     test('all other isolates exit before main isolate pauses', () async {
@@ -766,8 +740,7 @@ void main() {
       ]);
     });
 
-    test(
-        'all other isolates exit before main isolate pauses, then main '
+    test('all other isolates exit before main isolate pauses, then main '
         'starts another isolate, then pauses before they exit', () async {
       startEvent('A', '1', 'main');
       startEvent('B', '1');
@@ -797,8 +770,7 @@ void main() {
       ]);
     });
 
-    test(
-        'all other isolates exit before main isolate pauses, then main '
+    test('all other isolates exit before main isolate pauses, then main '
         'starts another isolate, then pauses before they pause', () async {
       startEvent('A', '1', 'main');
       startEvent('B', '1');
@@ -956,14 +928,17 @@ void main() {
         'RPCError ${RPCErrorKind.kIsolateMustBePaused.code} '
             '(isolate must be paused)',
         (String id) => RPCError(
-            'resume',
-            RPCErrorKind.kIsolateMustBePaused.code,
-            'Isolate must be paused: $id'),
+          'resume',
+          RPCErrorKind.kIsolateMustBePaused.code,
+          'Isolate must be paused: $id',
+        ),
       ),
       (
         'SentinelException (isolate collected)',
-        (String id) => SentinelException.parse(
-            'resume', {'type': 'Sentinel', 'kind': 'Collected'}),
+        (String id) => SentinelException.parse('resume', {
+          'type': 'Sentinel',
+          'kind': 'Collected',
+        }),
       ),
     ]) {
       test('$description when resuming exited isolate is ignored', () async {
@@ -989,13 +964,15 @@ void main() {
       });
     }
 
-    test(
-        'RPCError ${RPCErrorKind.kIsolateMustBeRunnable.code} '
+    test('RPCError ${RPCErrorKind.kIsolateMustBeRunnable.code} '
         '(isolate must be runnable) when resuming other isolate is not '
         'ignored', () async {
       resumeFailures = {'other'};
-      resumeErrorBuilder = (id) => RPCError('resume',
-          RPCErrorKind.kIsolateMustBeRunnable.code, 'Isolate must be runnable');
+      resumeErrorBuilder = (id) => RPCError(
+        'resume',
+        RPCErrorKind.kIsolateMustBeRunnable.code,
+        'Isolate must be runnable',
+      );
 
       startEvent('main', '1');
       startEvent('other', '2');

--- a/pkgs/coverage/test/lcov_test.dart
+++ b/pkgs/coverage/test/lcov_test.dart
@@ -20,8 +20,9 @@ final _sampleGeneratedPath = p.join('test', 'test_files', 'test_app.g.dart');
 final _isolateLibPath = p.join('test', 'test_files', 'test_app_isolate.dart');
 
 final _sampleAppFileUri = p.toUri(p.absolute(_sampleAppPath)).toString();
-final _sampleGeneratedFileUri =
-    p.toUri(p.absolute(_sampleGeneratedPath)).toString();
+final _sampleGeneratedFileUri = p
+    .toUri(p.absolute(_sampleGeneratedPath))
+    .toString();
 final _isolateLibFileUri = p.toUri(p.absolute(_isolateLibPath)).toString();
 
 void main() {
@@ -39,20 +40,41 @@ void main() {
     final sampleAppFuncNames = sampleAppHitMap?.funcNames;
     final sampleAppBranchHits = sampleAppHitMap?.branchHits;
 
-    expect(sampleAppHitLines, containsPair(53, greaterThanOrEqualTo(1)),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppHitLines, containsPair(57, 0),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppHitLines, isNot(contains(39)),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppHitFuncs, containsPair(52, 1),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppHitFuncs, containsPair(56, 0),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppFuncNames, containsPair(52, 'usedMethod'),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppBranchHits, containsPair(48, 1),
-        reason: 'be careful if you modify the test file');
+    expect(
+      sampleAppHitLines,
+      containsPair(56, greaterThanOrEqualTo(1)),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppHitLines,
+      containsPair(60, 0),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppHitLines,
+      isNot(contains(42)),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppHitFuncs,
+      containsPair(55, 1),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppHitFuncs,
+      containsPair(59, 0),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppFuncNames,
+      containsPair(55, 'usedMethod'),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppBranchHits,
+      containsPair(51, 1),
+      reason: 'be careful if you modify the test file',
+    );
   });
 
   test('validate hitMap, old VM without branch coverage', () async {
@@ -68,18 +90,36 @@ void main() {
     final sampleAppHitFuncs = sampleAppHitMap?.funcHits;
     final sampleAppFuncNames = sampleAppHitMap?.funcNames;
 
-    expect(sampleAppHitLines, containsPair(53, greaterThanOrEqualTo(1)),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppHitLines, containsPair(57, 0),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppHitLines, isNot(contains(39)),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppHitFuncs, containsPair(52, 1),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppHitFuncs, containsPair(56, 0),
-        reason: 'be careful if you modify the test file');
-    expect(sampleAppFuncNames, containsPair(52, 'usedMethod'),
-        reason: 'be careful if you modify the test file');
+    expect(
+      sampleAppHitLines,
+      containsPair(56, greaterThanOrEqualTo(1)),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppHitLines,
+      containsPair(60, 0),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppHitLines,
+      isNot(contains(42)),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppHitFuncs,
+      containsPair(55, 1),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppHitFuncs,
+      containsPair(59, 0),
+      reason: 'be careful if you modify the test file',
+    );
+    expect(
+      sampleAppFuncNames,
+      containsPair(55, 'usedMethod'),
+      reason: 'be careful if you modify the test file',
+    );
   });
 
   group('LcovFormatter', () {
@@ -90,8 +130,9 @@ void main() {
       // ignore: deprecated_member_use_from_same_package
       final formatter = LcovFormatter(resolver);
 
-      final res = await formatter
-          .format(hitmap.map((key, value) => MapEntry(key, value.lineHits)));
+      final res = await formatter.format(
+        hitmap.map((key, value) => MapEntry(key, value.lineHits)),
+      );
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_sampleGeneratedPath)));
@@ -154,21 +195,23 @@ void main() {
     });
 
     test(
-        'formatLcov() excludes files matching glob patterns regardless of their'
-        'presence on reportOn list', () async {
-      final hitmap = await _getHitMap();
+      'formatLcov() excludes files matching glob patterns regardless of their'
+      'presence on reportOn list',
+      () async {
+        final hitmap = await _getHitMap();
 
-      final resolver = await Resolver.create(packagePath: '.');
-      final res = hitmap.formatLcov(
-        resolver,
-        reportOn: ['test/'],
-        ignoreGlobs: {Glob('**/*.g.dart')},
-      );
+        final resolver = await Resolver.create(packagePath: '.');
+        final res = hitmap.formatLcov(
+          resolver,
+          reportOn: ['test/'],
+          ignoreGlobs: {Glob('**/*.g.dart')},
+        );
 
-      expect(res, contains(p.absolute(_sampleAppPath)));
-      expect(res, isNot(contains(p.absolute(_sampleGeneratedPath))));
-      expect(res, contains(p.absolute(_isolateLibPath)));
-    });
+        expect(res, contains(p.absolute(_sampleAppPath)));
+        expect(res, isNot(contains(p.absolute(_sampleGeneratedPath))));
+        expect(res, contains(p.absolute(_isolateLibPath)));
+      },
+    );
 
     test('formatLcov() uses paths relative to basePath', () async {
       final hitmap = await _getHitMap();
@@ -177,7 +220,9 @@ void main() {
       final res = hitmap.formatLcov(resolver, basePath: p.absolute('lib'));
 
       expect(
-          res, isNot(contains(p.absolute(p.join('lib', 'src', 'util.dart')))));
+        res,
+        isNot(contains(p.absolute(p.join('lib', 'src', 'util.dart')))),
+      );
       expect(res, contains(p.join('src', 'util.dart')));
     });
   });
@@ -190,8 +235,9 @@ void main() {
       // ignore: deprecated_member_use_from_same_package
       final formatter = PrettyPrintFormatter(resolver, Loader());
 
-      final res = await formatter
-          .format(hitmap.map((key, value) => MapEntry(key, value.lineHits)));
+      final res = await formatter.format(
+        hitmap.map((key, value) => MapEntry(key, value.lineHits)),
+      );
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_sampleGeneratedPath)));
@@ -201,8 +247,11 @@ void main() {
       // be very careful if you change the test file
       expect(res, contains('      0|  return a - b;'));
 
-      expect(res, contains('|  return withTimeout(() async {'),
-          reason: 'be careful if you change lib/src/util.dart');
+      expect(
+        res,
+        contains('|  return withTimeout(() async {'),
+        reason: 'be careful if you change lib/src/util.dart',
+      );
 
       final hitLineRegexp = RegExp(r'\s+(\d+)\|  return a \+ b;');
       final match = hitLineRegexp.allMatches(res).single;
@@ -225,8 +274,11 @@ void main() {
       // be very careful if you change the test file
       expect(res, contains('      0|  return a - b;'));
 
-      expect(res, contains('|  return withTimeout(() async {'),
-          reason: 'be careful if you change lib/src/util.dart');
+      expect(
+        res,
+        contains('|  return withTimeout(() async {'),
+        reason: 'be careful if you change lib/src/util.dart',
+      );
 
       final hitLineRegexp = RegExp(r'\s+(\d+)\|  return a \+ b;');
       final match = hitLineRegexp.allMatches(res).single;
@@ -239,8 +291,11 @@ void main() {
       final hitmap = await _getHitMap();
 
       final resolver = await Resolver.create(packagePath: '.');
-      final res = await hitmap
-          .prettyPrint(resolver, Loader(), reportOn: ['lib/', 'test/']);
+      final res = await hitmap.prettyPrint(
+        resolver,
+        Loader(),
+        reportOn: ['lib/', 'test/'],
+      );
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_sampleGeneratedPath)));
@@ -252,8 +307,11 @@ void main() {
       final hitmap = await _getHitMap();
 
       final resolver = await Resolver.create(packagePath: '.');
-      final res =
-          await hitmap.prettyPrint(resolver, Loader(), reportOn: ['lib/']);
+      final res = await hitmap.prettyPrint(
+        resolver,
+        Loader(),
+        reportOn: ['lib/'],
+      );
 
       expect(res, isNot(contains(p.absolute(_sampleAppPath))));
       expect(res, isNot(contains(p.absolute(_sampleGeneratedPath))));
@@ -280,8 +338,7 @@ void main() {
       );
     });
 
-    test(
-        'prettyPrint() excludes files matching glob patterns regardless of'
+    test('prettyPrint() excludes files matching glob patterns regardless of'
         'their presence on reportOn list', () async {
       final hitmap = await _getHitMap();
 
@@ -302,8 +359,11 @@ void main() {
       final hitmap = await _getHitMap();
 
       final resolver = await Resolver.create(packagePath: '.');
-      final res =
-          await hitmap.prettyPrint(resolver, Loader(), reportFuncs: true);
+      final res = await hitmap.prettyPrint(
+        resolver,
+        Loader(),
+        reportFuncs: true,
+      );
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_sampleGeneratedPath)));
@@ -321,8 +381,11 @@ void main() {
       final hitmap = await _getHitMap();
 
       final resolver = await Resolver.create(packagePath: '.');
-      final res =
-          await hitmap.prettyPrint(resolver, Loader(), reportBranches: true);
+      final res = await hitmap.prettyPrint(
+        resolver,
+        Loader(),
+        reportBranches: true,
+      );
 
       expect(res, contains(p.absolute(_sampleAppPath)));
       expect(res, contains(p.absolute(_sampleGeneratedPath)));
@@ -349,17 +412,27 @@ Future<Map<String, HitMap>> _createHitMap() async {
     '--pause-isolates-on-exit',
     '--enable-vm-service=0',
     '--branch-coverage',
-    _sampleAppPath
+    _sampleAppPath,
   ];
-  final sampleProcess =
-      await TestProcess.start(Platform.resolvedExecutable, sampleAppArgs);
+  final sampleProcess = await TestProcess.start(
+    Platform.resolvedExecutable,
+    sampleAppArgs,
+  );
 
   final serviceUri = await serviceUriFromProcess(sampleProcess.stdoutStream());
 
   // collect hit map.
-  final coverageJson = (await collect(serviceUri, true, true, false, <String>{},
-      functionCoverage: true,
-      branchCoverage: true))['coverage'] as List<Map<String, dynamic>>;
+  final coverageJson =
+      (await collect(
+            serviceUri,
+            true,
+            true,
+            false,
+            <String>{},
+            functionCoverage: true,
+            branchCoverage: true,
+          ))['coverage']
+          as List<Map<String, dynamic>>;
   final hitMap = HitMap.parseJson(coverageJson);
 
   await sampleProcess.shouldExit(0);

--- a/pkgs/coverage/test/resolver_test.dart
+++ b/pkgs/coverage/test/resolver_test.dart
@@ -12,9 +12,7 @@ void main() {
     setUp(() async {
       final sandboxUriPath = p.toUri(d.sandbox).toString();
       await d.dir('bar', [
-        d.dir('lib', [
-          d.file('bar.dart', 'final fizz = "bar";'),
-        ])
+        d.dir('lib', [d.file('bar.dart', 'final fizz = "bar";')]),
       ]).create();
 
       await d.dir('foo', [
@@ -38,63 +36,79 @@ void main() {
 }
 '''),
         ]),
-        d.dir('lib', [
-          d.file('foo.dart', 'final foo = "bar";'),
-        ]),
+        d.dir('lib', [d.file('foo.dart', 'final foo = "bar";')]),
       ]).create();
 
       await d.dir('sdk', [
-        d.dir('io', [
-          d.file('io.dart', 'final io = "hello";'),
-        ]),
-        d.dir('io_patch', [
-          d.file('io.dart', 'final patch = true;'),
-        ]),
-        d.dir('io_dev', [
-          d.file('io.dart', 'final dev = true;'),
-        ]),
+        d.dir('io', [d.file('io.dart', 'final io = "hello";')]),
+        d.dir('io_patch', [d.file('io.dart', 'final patch = true;')]),
+        d.dir('io_dev', [d.file('io.dart', 'final dev = true;')]),
       ]).create();
     });
 
     test('can be created from a package_config.json', () async {
       final resolver = await Resolver.create(
-          packagesPath:
-              p.join(d.sandbox, 'foo', '.dart_tool', 'package_config.json'));
-      expect(resolver.resolve('package:foo/foo.dart'),
-          p.join(d.sandbox, 'foo', 'lib', 'foo.dart'));
-      expect(resolver.resolve('package:bar/bar.dart'),
-          p.join(d.sandbox, 'bar', 'lib', 'bar.dart'));
+        packagesPath: p.join(
+          d.sandbox,
+          'foo',
+          '.dart_tool',
+          'package_config.json',
+        ),
+      );
+      expect(
+        resolver.resolve('package:foo/foo.dart'),
+        p.join(d.sandbox, 'foo', 'lib', 'foo.dart'),
+      );
+      expect(
+        resolver.resolve('package:bar/bar.dart'),
+        p.join(d.sandbox, 'bar', 'lib', 'bar.dart'),
+      );
     });
 
     test('can be created from a package directory', () async {
-      final resolver =
-          await Resolver.create(packagePath: p.join(d.sandbox, 'foo'));
-      expect(resolver.resolve('package:foo/foo.dart'),
-          p.join(d.sandbox, 'foo', 'lib', 'foo.dart'));
+      final resolver = await Resolver.create(
+        packagePath: p.join(d.sandbox, 'foo'),
+      );
+      expect(
+        resolver.resolve('package:foo/foo.dart'),
+        p.join(d.sandbox, 'foo', 'lib', 'foo.dart'),
+      );
     });
 
     test('errors if the packagesFile is an unknown format', () async {
       expect(
-          () async => await Resolver.create(
-              packagesPath: p.join(
-                  d.sandbox, 'foo', '.dart_tool', 'bad_package_config.json')),
-          throwsA(isA<FormatException>()));
+        () async => await Resolver.create(
+          packagesPath: p.join(
+            d.sandbox,
+            'foo',
+            '.dart_tool',
+            'bad_package_config.json',
+          ),
+        ),
+        throwsA(isA<FormatException>()),
+      );
     });
 
     test('resolves dart: URIs', () async {
       final resolver = await Resolver.create(
-          packagePath: p.join(d.sandbox, 'foo'),
-          sdkRoot: p.join(d.sandbox, 'sdk'));
-      expect(resolver.resolve('dart:io'),
-          p.join(d.sandbox, 'sdk', 'io', 'io.dart'));
+        packagePath: p.join(d.sandbox, 'foo'),
+        sdkRoot: p.join(d.sandbox, 'sdk'),
+      );
+      expect(
+        resolver.resolve('dart:io'),
+        p.join(d.sandbox, 'sdk', 'io', 'io.dart'),
+      );
       expect(resolver.resolve('dart:io-patch/io.dart'), null);
-      expect(resolver.resolve('dart:io-dev/io.dart'),
-          p.join(d.sandbox, 'sdk', 'io_dev', 'io.dart'));
+      expect(
+        resolver.resolve('dart:io-dev/io.dart'),
+        p.join(d.sandbox, 'sdk', 'io_dev', 'io.dart'),
+      );
     });
 
     test('cannot resolve SDK URIs if sdkRoot is null', () async {
-      final resolver =
-          await Resolver.create(packagePath: p.join(d.sandbox, 'foo'));
+      final resolver = await Resolver.create(
+        packagePath: p.join(d.sandbox, 'foo'),
+      );
       expect(resolver.resolve('dart:convert'), null);
     });
 
@@ -105,14 +119,16 @@ void main() {
     });
 
     test('cannot resolve package URIs if packagePath is not found', () async {
-      final resolver =
-          await Resolver.create(packagePath: p.join(d.sandbox, 'foo'));
+      final resolver = await Resolver.create(
+        packagePath: p.join(d.sandbox, 'foo'),
+      );
       expect(resolver.resolve('package:baz/baz.dart'), null);
     });
 
     test('cannot resolve unexpected URI schemes', () async {
-      final resolver =
-          await Resolver.create(packagePath: p.join(d.sandbox, 'foo'));
+      final resolver = await Resolver.create(
+        packagePath: p.join(d.sandbox, 'foo'),
+      );
       expect(resolver.resolve('thing:foo/foo.dart'), null);
     });
   });
@@ -126,86 +142,120 @@ void main() {
     });
 
     test('resolves third-party package URIs', () {
-      expect(resolver.resolve('package:foo/bar.dart'),
-          'third_party/dart/foo/lib/bar.dart');
-      expect(resolver.resolve('package:foo/src/bar.dart'),
-          'third_party/dart/foo/lib/src/bar.dart');
+      expect(
+        resolver.resolve('package:foo/bar.dart'),
+        'third_party/dart/foo/lib/bar.dart',
+      );
+      expect(
+        resolver.resolve('package:foo/src/bar.dart'),
+        'third_party/dart/foo/lib/src/bar.dart',
+      );
     });
 
     test('resolves non-third-party package URIs', () {
       expect(
-          resolver.resolve('package:foo.bar/baz.dart'), 'foo/bar/lib/baz.dart');
-      expect(resolver.resolve('package:foo.bar/src/baz.dart'),
-          'foo/bar/lib/src/baz.dart');
+        resolver.resolve('package:foo.bar/baz.dart'),
+        'foo/bar/lib/baz.dart',
+      );
+      expect(
+        resolver.resolve('package:foo.bar/src/baz.dart'),
+        'foo/bar/lib/src/baz.dart',
+      );
     });
 
     test('resolves file URIs', () {
       expect(
-          resolver
-              .resolve('file://x/y/z.runfiles/$workspace/foo/bar/lib/baz.dart'),
-          'foo/bar/lib/baz.dart');
+        resolver.resolve(
+          'file://x/y/z.runfiles/$workspace/foo/bar/lib/baz.dart',
+        ),
+        'foo/bar/lib/baz.dart',
+      );
       expect(
-          resolver.resolve(
-              'file://x/y/z.runfiles/$workspace/foo/bar/lib/src/baz.dart'),
-          'foo/bar/lib/src/baz.dart');
+        resolver.resolve(
+          'file://x/y/z.runfiles/$workspace/foo/bar/lib/src/baz.dart',
+        ),
+        'foo/bar/lib/src/baz.dart',
+      );
     });
 
     test('resolves HTTPS URIs containing /packages/', () {
-      expect(resolver.resolve('https://host:8080/a/b/packages/foo/bar.dart'),
-          'third_party/dart/foo/lib/bar.dart');
       expect(
-          resolver.resolve('https://host:8080/a/b/packages/foo/src/bar.dart'),
-          'third_party/dart/foo/lib/src/bar.dart');
+        resolver.resolve('https://host:8080/a/b/packages/foo/bar.dart'),
+        'third_party/dart/foo/lib/bar.dart',
+      );
       expect(
-          resolver.resolve('https://host:8080/a/b/packages/foo.bar/baz.dart'),
-          'foo/bar/lib/baz.dart');
+        resolver.resolve('https://host:8080/a/b/packages/foo/src/bar.dart'),
+        'third_party/dart/foo/lib/src/bar.dart',
+      );
       expect(
-          resolver
-              .resolve('https://host:8080/a/b/packages/foo.bar/src/baz.dart'),
-          'foo/bar/lib/src/baz.dart');
+        resolver.resolve('https://host:8080/a/b/packages/foo.bar/baz.dart'),
+        'foo/bar/lib/baz.dart',
+      );
+      expect(
+        resolver.resolve('https://host:8080/a/b/packages/foo.bar/src/baz.dart'),
+        'foo/bar/lib/src/baz.dart',
+      );
     });
 
     test('resolves HTTP URIs containing /packages/', () {
-      expect(resolver.resolve('http://host:8080/a/b/packages/foo/bar.dart'),
-          'third_party/dart/foo/lib/bar.dart');
-      expect(resolver.resolve('http://host:8080/a/b/packages/foo/src/bar.dart'),
-          'third_party/dart/foo/lib/src/bar.dart');
-      expect(resolver.resolve('http://host:8080/a/b/packages/foo.bar/baz.dart'),
-          'foo/bar/lib/baz.dart');
       expect(
-          resolver
-              .resolve('http://host:8080/a/b/packages/foo.bar/src/baz.dart'),
-          'foo/bar/lib/src/baz.dart');
+        resolver.resolve('http://host:8080/a/b/packages/foo/bar.dart'),
+        'third_party/dart/foo/lib/bar.dart',
+      );
+      expect(
+        resolver.resolve('http://host:8080/a/b/packages/foo/src/bar.dart'),
+        'third_party/dart/foo/lib/src/bar.dart',
+      );
+      expect(
+        resolver.resolve('http://host:8080/a/b/packages/foo.bar/baz.dart'),
+        'foo/bar/lib/baz.dart',
+      );
+      expect(
+        resolver.resolve('http://host:8080/a/b/packages/foo.bar/src/baz.dart'),
+        'foo/bar/lib/src/baz.dart',
+      );
     });
 
     test('resolves HTTPS URIs without /packages/', () {
       expect(
-          resolver
-              .resolve('https://host:8080/third_party/dart/foo/lib/bar.dart'),
-          'third_party/dart/foo/lib/bar.dart');
+        resolver.resolve('https://host:8080/third_party/dart/foo/lib/bar.dart'),
+        'third_party/dart/foo/lib/bar.dart',
+      );
       expect(
-          resolver.resolve(
-              'https://host:8080/third_party/dart/foo/lib/src/bar.dart'),
-          'third_party/dart/foo/lib/src/bar.dart');
-      expect(resolver.resolve('https://host:8080/foo/lib/bar.dart'),
-          'foo/lib/bar.dart');
-      expect(resolver.resolve('https://host:8080/foo/lib/src/bar.dart'),
-          'foo/lib/src/bar.dart');
+        resolver.resolve(
+          'https://host:8080/third_party/dart/foo/lib/src/bar.dart',
+        ),
+        'third_party/dart/foo/lib/src/bar.dart',
+      );
+      expect(
+        resolver.resolve('https://host:8080/foo/lib/bar.dart'),
+        'foo/lib/bar.dart',
+      );
+      expect(
+        resolver.resolve('https://host:8080/foo/lib/src/bar.dart'),
+        'foo/lib/src/bar.dart',
+      );
     });
 
     test('resolves HTTP URIs without /packages/', () {
       expect(
-          resolver
-              .resolve('http://host:8080/third_party/dart/foo/lib/bar.dart'),
-          'third_party/dart/foo/lib/bar.dart');
+        resolver.resolve('http://host:8080/third_party/dart/foo/lib/bar.dart'),
+        'third_party/dart/foo/lib/bar.dart',
+      );
       expect(
-          resolver.resolve(
-              'http://host:8080/third_party/dart/foo/lib/src/bar.dart'),
-          'third_party/dart/foo/lib/src/bar.dart');
-      expect(resolver.resolve('http://host:8080/foo/lib/bar.dart'),
-          'foo/lib/bar.dart');
-      expect(resolver.resolve('http://host:8080/foo/lib/src/bar.dart'),
-          'foo/lib/src/bar.dart');
+        resolver.resolve(
+          'http://host:8080/third_party/dart/foo/lib/src/bar.dart',
+        ),
+        'third_party/dart/foo/lib/src/bar.dart',
+      );
+      expect(
+        resolver.resolve('http://host:8080/foo/lib/bar.dart'),
+        'foo/lib/bar.dart',
+      );
+      expect(
+        resolver.resolve('http://host:8080/foo/lib/src/bar.dart'),
+        'foo/lib/src/bar.dart',
+      );
     });
   });
 }

--- a/pkgs/coverage/test/run_and_collect_test.dart
+++ b/pkgs/coverage/test/run_and_collect_test.dart
@@ -36,19 +36,23 @@ void main() {
     checkHitmap(hitMap);
     final resolver = await Resolver.create();
     final ignoredLinesInFilesCache = <String, List<List<int>>?>{};
-    final hitMap2 = HitMap.parseJsonSync(coverage,
-        checkIgnoredLines: true,
-        ignoredLinesInFilesCache: ignoredLinesInFilesCache,
-        resolver: resolver);
+    final hitMap2 = HitMap.parseJsonSync(
+      coverage,
+      checkIgnoredLines: true,
+      ignoredLinesInFilesCache: ignoredLinesInFilesCache,
+      resolver: resolver,
+    );
     checkHitmap(hitMap2);
     checkIgnoredLinesInFilesCache(ignoredLinesInFilesCache);
 
     // Asking again the cache should answer questions about ignored lines,
     // so providing a resolver that throws when asked for files should be ok.
-    final hitMap3 = HitMap.parseJsonSync(coverage,
-        checkIgnoredLines: true,
-        ignoredLinesInFilesCache: ignoredLinesInFilesCache,
-        resolver: ThrowingResolver());
+    final hitMap3 = HitMap.parseJsonSync(
+      coverage,
+      checkIgnoredLines: true,
+      ignoredLinesInFilesCache: ignoredLinesInFilesCache,
+      resolver: ThrowingResolver(),
+    );
     checkHitmap(hitMap3);
     checkIgnoredLinesInFilesCache(ignoredLinesInFilesCache);
   });
@@ -75,22 +79,25 @@ class ThrowingResolver implements Resolver {
 }
 
 void checkIgnoredLinesInFilesCache(
-    Map<String, List<List<int>>?> ignoredLinesInFilesCache) {
+  Map<String, List<List<int>>?> ignoredLinesInFilesCache,
+) {
   final keys = ignoredLinesInFilesCache.keys.toList();
-  final testAppKey =
-      keys.where((element) => element.endsWith('test_app.dart')).single;
-  final testAppIsolateKey =
-      keys.where((element) => element.endsWith('test_app_isolate.dart')).single;
+  final testAppKey = keys
+      .where((element) => element.endsWith('test_app.dart'))
+      .single;
+  final testAppIsolateKey = keys
+      .where((element) => element.endsWith('test_app_isolate.dart'))
+      .single;
   final packageUtilKey = keys
       .where((element) => element.endsWith('package:coverage/src/util.dart'))
       .single;
   expect(ignoredLinesInFilesCache[packageUtilKey], isEmpty);
   expect(ignoredLinesInFilesCache[testAppKey], null /* means whole file */);
   expect(ignoredLinesInFilesCache[testAppIsolateKey], [
-    [52, 52],
-    [54, 58],
-    [63, 66],
-    [67, 73]
+    [54, 54],
+    [56, 60],
+    [65, 68],
+    [69, 75],
   ]);
 }
 
@@ -114,15 +121,16 @@ void checkHitmap(Map<String, HitMap> hitMap) {
     38: 1,
     39: 1,
     41: 1,
-    42: 4,
-    43: 2,
-    44: 1,
-    45: 3,
-    46: 1,
-    49: 1,
-    50: 1,
-    60: 1,
-    61: 1
+    42: 1,
+    43: 3,
+    44: 2,
+    45: 1,
+    46: 3,
+    47: 1,
+    51: 1,
+    52: 1,
+    62: 1,
+    63: 1,
   };
 
   expect(actualLineHits, expectedLineHits);

--- a/pkgs/coverage/test/test_files/test_app.dart
+++ b/pkgs/coverage/test/test_files/test_app.dart
@@ -31,8 +31,11 @@ Future<void> main() async {
 
   final port = ReceivePort();
 
-  final isolate =
-      await Isolate.spawn(isolateTask, [port.sendPort, 1, 2], paused: true);
+  final isolate = await Isolate.spawn(isolateTask, [
+    port.sendPort,
+    1,
+    2,
+  ], paused: true);
   await Service.controlWebServer(enable: true);
   final isolateID = Service.getIsolateID(isolate);
   print('isolateId = $isolateID');

--- a/pkgs/coverage/test/test_files/test_app_isolate.dart
+++ b/pkgs/coverage/test/test_files/test_app_isolate.dart
@@ -39,12 +39,14 @@ void isolateTask(List threeThings) async {
   sleep(const Duration(milliseconds: 500));
 
   fooSync(answer);
-  unawaited(fooAsync(answer).then((_) {
-    RawReceivePort().keepIsolateAlive = true;
-    final port = threeThings.first as SendPort;
-    final sum = (threeThings[1] as int) + (threeThings[2] as int);
-    port.send(sum);
-  }));
+  unawaited(
+    fooAsync(answer).then((_) {
+      RawReceivePort().keepIsolateAlive = true;
+      final port = threeThings.first as SendPort;
+      final sum = (threeThings[1] as int) + (threeThings[2] as int);
+      port.send(sum);
+    }),
+  );
 
   final bar = BarClass(123);
   bar.baz();

--- a/pkgs/coverage/test/test_util.dart
+++ b/pkgs/coverage/test/test_util.dart
@@ -13,15 +13,13 @@ final String testAppPath = p.join('test', 'test_files', 'test_app.dart');
 
 const Duration timeout = Duration(seconds: 60);
 
-Future<TestProcess> runTestApp() => TestProcess.start(
-      Platform.resolvedExecutable,
-      [
-        '--enable-vm-service=0',
-        '--pause_isolates_on_exit',
-        '--branch-coverage',
-        testAppPath
-      ],
-    );
+Future<TestProcess> runTestApp() =>
+    TestProcess.start(Platform.resolvedExecutable, [
+      '--enable-vm-service=0',
+      '--pause_isolates_on_exit',
+      '--branch-coverage',
+      testAppPath,
+    ]);
 
 List<Map<String, dynamic>> coverageDataFromJson(Map<String, dynamic> json) {
   expect(json.keys, unorderedEquals(<String>['type', 'coverage']));
@@ -61,31 +59,28 @@ Map<String, Map<String, int>> functionInfoFromSources(
 
   return {
     for (var entry in sources.entries)
-      entry.key: entry.value.fold(
-        {},
-        (previousValue, element) {
-          expect(element['source'], entry.key);
-          final names = getFuncNames(element['funcNames'] as List);
-          final hits = getFuncHits(element['funcHits'] as List);
+      entry.key: entry.value.fold({}, (previousValue, element) {
+        expect(element['source'], entry.key);
+        final names = getFuncNames(element['funcNames'] as List);
+        final hits = getFuncHits(element['funcHits'] as List);
 
-          for (var pair in hits.entries) {
-            previousValue[names[pair.key]!] =
-                (previousValue[names[pair.key]!] ?? 0) + pair.value;
-          }
+        for (var pair in hits.entries) {
+          previousValue[names[pair.key]!] =
+              (previousValue[names[pair.key]!] ?? 0) + pair.value;
+        }
 
-          return previousValue;
-        },
-      ),
+        return previousValue;
+      }),
   };
 }
 
 extension ListTestExtension on List {
   Map<String, List<Map<dynamic, dynamic>>> sources() => cast<Map>().fold(
-        <String, List<Map>>{},
-        (Map<String, List<Map>> map, value) {
-          final sourceUri = value['source'] as String;
-          map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
-          return map;
-        },
-      );
+    <String, List<Map>>{},
+    (Map<String, List<Map>> map, value) {
+      final sourceUri = value['source'] as String;
+      map.putIfAbsent(sourceUri, () => <Map>[]).add(value);
+      return map;
+    },
+  );
 }

--- a/pkgs/coverage/test/test_with_coverage_test.dart
+++ b/pkgs/coverage/test/test_with_coverage_test.dart
@@ -37,10 +37,8 @@ int _port = 9300;
 Iterable<File> _dartFiles(String dir) =>
     Directory(p.join(_testPkgDirPath, dir)).listSync().whereType<File>();
 
-String _fixTestFile(String content) => content.replaceAll(
-      "import '../lib/",
-      "import 'package:$_testPackageName/",
-    );
+String _fixTestFile(String content) =>
+    content.replaceAll("import '../lib/", "import 'package:$_testPackageName/");
 
 void main() {
   setUpAll(() async {
@@ -54,8 +52,9 @@ void main() {
       ]).create();
     }
 
-    var pubspecContent =
-        File(p.join(_testPkgDirPath, 'pubspec.yaml')).readAsStringSync();
+    var pubspecContent = File(
+      p.join(_testPkgDirPath, 'pubspec.yaml'),
+    ).readAsStringSync();
 
     expect(
       pubspecContent.replaceAll('\r\n', '\n'),
@@ -66,8 +65,10 @@ dependency_overrides:
 '''),
     );
 
-    pubspecContent =
-        pubspecContent.replaceFirst('path: ../../', 'path: $_pkgDir');
+    pubspecContent = pubspecContent.replaceFirst(
+      'path: ../../',
+      'path: $_pkgDir',
+    );
 
     await d.file('pubspec.yaml', pubspecContent).create();
 
@@ -81,14 +82,11 @@ dependency_overrides:
     final sources = list.sources();
     final functionHits = functionInfoFromSources(sources);
 
-    expect(
-      functionHits['package:$_testPackageName/validate_lib.dart'],
-      {
-        'product': 1,
-        'sum': 1,
-        'evaluateScore': 1,
-      },
-    );
+    expect(functionHits['package:$_testPackageName/validate_lib.dart'], {
+      'product': 1,
+      'sum': 1,
+      'evaluateScore': 1,
+    });
   });
 
   test('dart run bin/test_with_coverage.dart -f -- -N sum', () async {
@@ -100,15 +98,11 @@ dependency_overrides:
     final sources = list.sources();
     final functionHits = functionInfoFromSources(sources);
 
-    expect(
-      functionHits['package:$_testPackageName/validate_lib.dart'],
-      {
-        'product': 0,
-        'sum': 1,
-        'evaluateScore': 0,
-      },
-      reason: 'only `sum` tests should be run',
-    );
+    expect(functionHits['package:$_testPackageName/validate_lib.dart'], {
+      'product': 0,
+      'sum': 1,
+      'evaluateScore': 0,
+    }, reason: 'only `sum` tests should be run');
   });
 
   test('dart run coverage:test_with_coverage', () async {
@@ -116,17 +110,20 @@ dependency_overrides:
   });
 
   test('dart pub global run coverage:test_with_coverage', () async {
-    final globalPub =
-        await _run(['pub', 'global', 'activate', '-s', 'path', _pkgDir]);
+    final globalPub = await _run([
+      'pub',
+      'global',
+      'activate',
+      '-s',
+      'path',
+      _pkgDir,
+    ]);
     await globalPub.shouldExit(0);
 
-    await _runTest(
-      ['pub', 'global', 'run', 'coverage:test_with_coverage'],
-    );
+    await _runTest(['pub', 'global', 'run', 'coverage:test_with_coverage']);
   });
 
-  test(
-      'dart run bin/test_with_coverage.dart --fail-under succeeds'
+  test('dart run bin/test_with_coverage.dart --fail-under succeeds'
       'when coverage meets threshold', () async {
     // This should pass as coverage=100% when all tests run.
     final process = await _run([
@@ -138,8 +135,7 @@ dependency_overrides:
     ]);
     await process.shouldExit(0);
   });
-  test(
-      'dart run bin/test_with_coverage.dart --fail-under fails'
+  test('dart run bin/test_with_coverage.dart --fail-under fails'
       'when coverage is below threshold', () async {
     // This should throw an exit(1) as coverage =27.27% when only the `sum` test
     // is run i.e. out of 11 lines only 3 lines i.e. [5,7,8]will have hits>0.
@@ -155,8 +151,7 @@ dependency_overrides:
     ]);
     await process.shouldExit(1);
   });
-  test(
-      'dart run bin/test_with_coverage.dart -b --fail-under succeeds'
+  test('dart run bin/test_with_coverage.dart -b --fail-under succeeds'
       'when coverage meets threshold', () async {
     // This should pass as total lines+branches covered=20 and total lines(11)+
     // branches covered(10)=21 => percentage_covered=95.23.
@@ -170,8 +165,7 @@ dependency_overrides:
     ]);
     await process.shouldExit(0);
   });
-  test(
-      'dart run bin/test_with_coverage.dart -b --fail-under fails'
+  test('dart run bin/test_with_coverage.dart -b --fail-under fails'
       'when coverage is below threshold', () async {
     // This should throw an exit(1) as percentage_covered=95.23 .
     final process = await _run([
@@ -187,11 +181,11 @@ dependency_overrides:
 }
 
 Future<TestProcess> _run(List<String> args) => TestProcess.start(
-      Platform.executable,
-      args,
-      workingDirectory: d.sandbox,
-      environment: _env,
-    );
+  Platform.executable,
+  args,
+  workingDirectory: d.sandbox,
+  environment: _env,
+);
 
 Future<List<Map<String, dynamic>>> _runTest(
   List<String> invokeArgs, {
@@ -206,10 +200,10 @@ Future<List<Map<String, dynamic>>> _runTest(
 
   await process.shouldExit(0);
 
-  await d.dir(
-    'coverage',
-    [d.file('coverage.json', isNotEmpty), d.file('lcov.info', isNotEmpty)],
-  ).validate();
+  await d.dir('coverage', [
+    d.file('coverage.json', isNotEmpty),
+    d.file('lcov.info', isNotEmpty),
+  ]).validate();
 
   final coverageDataFile = File(p.join(d.sandbox, 'coverage', 'coverage.json'));
 

--- a/pkgs/coverage/test/util_test.dart
+++ b/pkgs/coverage/test/util_test.dart
@@ -51,11 +51,9 @@ void main() {
       }
 
       final safeTimoutDuration = _delay * _failCount * 10;
-      final value = await retry(
-        failCountTimes,
-        _delay,
-        timeout: safeTimoutDuration,
-      ) as int;
+      final value =
+          await retry(failCountTimes, _delay, timeout: safeTimoutDuration)
+              as int;
 
       expect(value, 42);
       expect(count, _failCount);
@@ -88,8 +86,11 @@ void main() {
         expect(e.message, 'Failed to complete within 25ms');
         caught = true;
 
-        expect(countAfterError, 0,
-            reason: 'Execution should stop after a timeout');
+        expect(
+          countAfterError,
+          0,
+          reason: 'Execution should stop after a timeout',
+        );
 
         await Future<dynamic>.delayed(_delay * 3);
 
@@ -118,7 +119,9 @@ void main() {
     test('returns URI with auth token at end of string', () {
       const msg = 'Observatory listening on http://foo.bar:9999/cG90YXRv/';
       expect(
-          extractVMServiceUri(msg), Uri.parse('http://foo.bar:9999/cG90YXRv/'));
+        extractVMServiceUri(msg),
+        Uri.parse('http://foo.bar:9999/cG90YXRv/'),
+      );
     });
 
     test('return URI embedded within string', () {
@@ -130,14 +133,18 @@ void main() {
       const msg =
           '1985-10-26 Observatory listening on http://foo.bar:9999/cG90YXRv/ **';
       expect(
-          extractVMServiceUri(msg), Uri.parse('http://foo.bar:9999/cG90YXRv/'));
+        extractVMServiceUri(msg),
+        Uri.parse('http://foo.bar:9999/cG90YXRv/'),
+      );
     });
 
     test('handles new Dart VM service message format', () {
       const msg =
           'The Dart VM service is listening on http://foo.bar:9999/cG90YXRv/';
       expect(
-          extractVMServiceUri(msg), Uri.parse('http://foo.bar:9999/cG90YXRv/'));
+        extractVMServiceUri(msg),
+        Uri.parse('http://foo.bar:9999/cG90YXRv/'),
+      );
     });
   });
 
@@ -205,26 +212,11 @@ void main() {
         'coverage:ignore-start found at content-1.dart:'
         '3 before previous coverage:ignore-start ended',
       );
-      runTest(
-        2,
-        'unmatched coverage:ignore-end found at content-2.dart:5',
-      );
-      runTest(
-        3,
-        'unmatched coverage:ignore-end found at content-3.dart:1',
-      );
-      runTest(
-        4,
-        'unmatched coverage:ignore-end found at content-4.dart:1',
-      );
-      runTest(
-        5,
-        'unmatched coverage:ignore-end found at content-5.dart:1',
-      );
-      runTest(
-        6,
-        'unmatched coverage:ignore-end found at content-6.dart:1',
-      );
+      runTest(2, 'unmatched coverage:ignore-end found at content-2.dart:5');
+      runTest(3, 'unmatched coverage:ignore-end found at content-3.dart:1');
+      runTest(4, 'unmatched coverage:ignore-end found at content-4.dart:1');
+      runTest(5, 'unmatched coverage:ignore-end found at content-5.dart:1');
+      runTest(6, 'unmatched coverage:ignore-end found at content-6.dart:1');
       runTest(
         7,
         'coverage:ignore-start found at content-7.dart:'
@@ -232,8 +224,7 @@ void main() {
       );
     });
 
-    test(
-        'returns null when the annotations are not '
+    test('returns null when the annotations are not '
         'balanced but the whole file is ignored', () {
       for (final content in invalidSources) {
         final lines = content.split('\n');
@@ -243,17 +234,19 @@ void main() {
     });
 
     test('returns null when the whole file is ignored', () {
-      final lines = '''final str = ''; // coverage:ignore-start
+      final lines =
+          '''final str = ''; // coverage:ignore-start
       final str = ''; // coverage:ignore-end
       final str = ''; // coverage:ignore-file
       '''
-          .split('\n');
+              .split('\n');
 
       expect(getIgnoredLines('', lines), null);
     });
 
     test('return the correct range of lines ignored', () {
-      final lines = '''
+      final lines =
+          '''
       final str = ''; // coverage:ignore-start
       final str = ''; // coverage:ignore-line
       final str = ''; // coverage:ignore-end
@@ -261,7 +254,7 @@ void main() {
       final str = ''; // coverage:ignore-line
       final str = ''; // coverage:ignore-end
       '''
-          .split('\n');
+              .split('\n');
 
       expect(getIgnoredLines('', lines), [
         [1, 3],
@@ -270,12 +263,13 @@ void main() {
     });
 
     test('return the correct list of lines ignored', () {
-      final lines = '''
+      final lines =
+          '''
       final str = ''; // coverage:ignore-line
       final str = ''; // coverage:ignore-line
       final str = ''; // coverage:ignore-line
       '''
-          .split('\n');
+              .split('\n');
 
       expect(getIgnoredLines('', lines), [
         [1, 1],
@@ -285,14 +279,15 @@ void main() {
     });
 
     test('ignore comments have no effect inside string literals', () {
-      final lines = '''
+      final lines =
+          '''
       final str = '// coverage:ignore-file';
       final str = '// coverage:ignore-line';
       final str = ''; // coverage:ignore-line
       final str = '// coverage:ignore-start';
       final str = '// coverage:ignore-end';
       '''
-          .split('\n');
+              .split('\n');
 
       expect(getIgnoredLines('', lines), [
         [3, 3],
@@ -362,13 +357,9 @@ void main() {
     //     └── bar
     //         └── bar_example  // Part of bar's workspace.
     expect(
-        getAllWorkspaceNames('test/workspace_names'),
-        unorderedEquals([
-          'workspace_names',
-          'foo',
-          'bar',
-          'bar_example',
-        ]));
+      getAllWorkspaceNames('test/workspace_names'),
+      unorderedEquals(['workspace_names', 'foo', 'bar', 'bar_example']),
+    );
   });
 
   test('IgnoredLinesContains', () {
@@ -391,7 +382,9 @@ void main() {
       final (ranges, end) = createRandomRanges(len);
       for (var line = 0; line < end + 3; ++line) {
         expect(
-            ranges.ignoredContains(line), naiveIgnoredContains(ranges, line));
+          ranges.ignoredContains(line),
+          naiveIgnoredContains(ranges, line),
+        );
       }
     }
   });


### PR DESCRIPTION
- Bump the minimum SDK constraint to ^3.9.0 and the package version to
  1.16.0-wip.
- Apply the Dart 3.9 formatter (tall style) across the package.
- Update line/branch hitmap test expectations shifted by the
  reformatted test fixtures.
- Raise the CI min SDK matrix entry from 3.6 to 3.9.

PR 1 of the review-split plan described in
https://github.com/dart-lang/tools/pull/2448#issuecomment-4871086401;
follows #2452.
