### PR TITLE
[yaml] Export ErrorListener and ErrorCollector

### DIFF
--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.4-wip
 
+* Export `ErrorListener` and `ErrorCollector` from `package:yaml/yaml.dart`.
 * Improve recovery for list entries without `-` prefix. When recovering, provide
   a more helpful error message suggesting the missing prefix.
 * Fix parsing of plain scalars starting with indicator characters (`?`, `:`, and `-`).

--- a/pkgs/yaml/lib/yaml.dart
+++ b/pkgs/yaml/lib/yaml.dart
@@ -12,6 +12,7 @@ import 'src/yaml_document.dart';
 import 'src/yaml_exception.dart';
 import 'src/yaml_node.dart';
 
+export 'src/error_listener.dart';
 export 'src/style.dart';
 export 'src/utils.dart' show YamlWarningCallback, yamlWarningCallback;
 export 'src/yaml_document.dart';

--- a/pkgs/yaml/test/yaml_test.dart
+++ b/pkgs/yaml/test/yaml_test.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: avoid_dynamic_calls
 
 import 'package:test/test.dart';
-import 'package:yaml/src/error_listener.dart';
 import 'package:yaml/yaml.dart';
 
 import 'utils.dart';
@@ -16,6 +15,23 @@ import 'utils.dart';
 void main() {
   var infinity = double.parse('Infinity');
   var nan = double.parse('NaN');
+
+  group('exports', () {
+    // Regression test for #2336: ErrorListener and ErrorCollector must be
+    // usable without importing package:yaml/src/error_listener.dart.
+    test('ErrorListener and ErrorCollector from package:yaml/yaml.dart', () {
+      var collector = ErrorCollector();
+      expect(collector, isA<ErrorListener>());
+
+      final yaml = cleanUpLiteral(r'''
+        dependencies:
+          six: 5.4.3
+          seven
+          ''');
+      loadYaml(yaml, recover: true, errorListener: collector);
+      expect(collector.errors, isNotEmpty);
+    });
+  });
 
   group('has a friendly error message for', () {
     var tabError = predicate((e) =>


### PR DESCRIPTION
`load*` functions in `package:yaml` take an `ErrorListener`, but the type was never exported from `package:yaml/yaml.dart` — you had to reach into `package:yaml/src/error_listener.dart` to use it. Even this package's own tests did that.

Exports `ErrorListener` and `ErrorCollector`, updates the test import, and adds a small regression test.

Fixes #2336