### PR TITLE
[markdown] Fix setext heading precedence over lists in gitHubFlavored

### DIFF
--- a/pkgs/markdown/CHANGELOG.md
+++ b/pkgs/markdown/CHANGELOG.md
@@ -13,6 +13,9 @@
   quantifiers to RFC limits, improving performance on inputs with long sequences
   of dots or alphanumeric characters.
 * Escape image description text when assigning it to the `alt` attribute.
+* Fixes `ExtensionSet.gitHubFlavored` so a lone `-` (or `=`) line that
+  continues a paragraph is parsed as a setext heading underline instead of
+  an empty list item.
 
 ## 7.3.1
 

--- a/pkgs/markdown/lib/src/extension_set.dart
+++ b/pkgs/markdown/lib/src/extension_set.dart
@@ -4,6 +4,7 @@ import 'block_syntaxes/fenced_code_block_syntax.dart';
 import 'block_syntaxes/footnote_def_syntax.dart';
 import 'block_syntaxes/header_with_id_syntax.dart';
 import 'block_syntaxes/ordered_list_with_checkbox_syntax.dart';
+import 'block_syntaxes/setext_header_syntax.dart';
 import 'block_syntaxes/setext_header_with_id_syntax.dart';
 import 'block_syntaxes/table_syntax.dart';
 import 'block_syntaxes/unordered_list_with_checkbox_syntax.dart';
@@ -75,6 +76,10 @@ class ExtensionSet {
     List<BlockSyntax>.unmodifiable(<BlockSyntax>[
       const FencedCodeBlockSyntax(),
       const TableSyntax(),
+      // Must precede the list syntaxes below: a lone `-` (or `=`) line
+      // continuing a paragraph is a setext heading underline, not an empty
+      // list item. See https://github.com/dart-lang/tools/issues/2108.
+      const SetextHeaderSyntax(),
       const UnorderedListWithCheckboxSyntax(),
       const OrderedListWithCheckboxSyntax(),
       const FootnoteDefSyntax(),

--- a/pkgs/markdown/test/regression_test.dart
+++ b/pkgs/markdown/test/regression_test.dart
@@ -53,4 +53,17 @@ a <!--
     final html = markdownToHtml(input);
     expect(html, '<p>$input</p>\n');
   });
+
+  test('setext heading underline is not an empty list item, GFM #2108', () {
+    // See https://github.com/dart-lang/tools/issues/2108.
+    // With `ExtensionSet.gitHubFlavored`, `UnorderedListWithCheckboxSyntax`
+    // used to be checked before `SetextHeaderSyntax`, so a lone `-` line
+    // continuing a paragraph was parsed as an empty list item instead of a
+    // setext H2 underline.
+    final html = markdownToHtml(
+      'I am paragraph\n-',
+      extensionSet: ExtensionSet.gitHubFlavored,
+    );
+    expect(html, '<h2>I am paragraph</h2>\n');
+  });
 }


### PR DESCRIPTION
## Summary
`ExtensionSet.gitHubFlavored`'s block syntax list checked `UnorderedListWithCheckboxSyntax` before `SetextHeaderSyntax`. Since custom `document.blockSyntaxes` are always tried before the standard ones in `BlockParser.parseLines`, a lone `-`/`=` line continuing a paragraph was parsed as an empty list item instead of a setext heading underline — unlike the default parser (which orders `SetextHeaderSyntax` first) and `ExtensionSet.gitHubWeb` (which already puts `SetextHeaderWithIdSyntax` before its list syntaxes).

```dart
import 'package:markdown/markdown.dart' as md;

void main() {
  final doc = md.Document(blockSyntaxes: [const md.UnorderedListSyntax()]);
  print((doc.parseLines('I am paragraph\n-')[0] as md.Element).tag);
  // actual: ul   expected: h2
}
```

This matches CommonMark / GitHub's own rendering (confirmed in the issue by @lrhn) — see https://spec.commonmark.org/dingus/?text=I%20am%20paragraph%0A-.

Fixes #2108 (duplicate of #1953).

## Changes
- Adds `SetextHeaderSyntax` to `ExtensionSet.gitHubFlavored`'s block syntax list, ordered before the list syntaxes.
- Adds a regression test in `test/regression_test.dart`.
- Adds a changelog entry under the unreleased `7.4.0` section.

## Test plan
- [x] `dart test` — full `markdown` suite passes (2763 passed, 1 pre-existing skip, 0 failures)
- [x] `dart analyze --fatal-infos .` — no issues
- [x] `dart format --output=none --set-exit-if-changed` on changed files — no changes needed