### PR TITLE
[api_summary] Alphabetize meta annotation getters, models, and JSON serialization

### DIFF
--- a/pkgs/api_summary/api.json
+++ b/pkgs/api_summary/api.json
@@ -3892,9 +3892,9 @@
                 "name": "ApiClassModifier",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "isBase",
@@ -3905,9 +3905,9 @@
                 "name": "ApiClassModifier",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "isFinal",
@@ -3918,9 +3918,9 @@
                 "name": "ApiClassModifier",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "isInterface",
@@ -3931,9 +3931,9 @@
                 "name": "ApiClassModifier",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "isMixin",
@@ -3944,9 +3944,9 @@
                 "name": "ApiClassModifier",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "isSealed",
@@ -3957,9 +3957,9 @@
                 "name": "ApiClassModifier",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "jsonName",
@@ -4009,8 +4009,8 @@
                   }
                 ]
               },
-              "isStatic": true,
-              "isConst": true
+              "isConst": true,
+              "isStatic": true
             }
           ]
         },
@@ -4027,9 +4027,9 @@
                 "name": "ApiDeclarationStatus",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "public",
@@ -4040,9 +4040,9 @@
                 "name": "ApiDeclarationStatus",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "referenced",
@@ -4053,9 +4053,9 @@
                 "name": "ApiDeclarationStatus",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "values",
@@ -4073,8 +4073,8 @@
                   }
                 ]
               },
-              "isStatic": true,
-              "isConst": true
+              "isConst": true,
+              "isStatic": true
             }
           ]
         },
@@ -4091,9 +4091,9 @@
                 "name": "ApiExecutableKind",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "function",
@@ -4104,9 +4104,9 @@
                 "name": "ApiExecutableKind",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "getter",
@@ -4117,9 +4117,9 @@
                 "name": "ApiExecutableKind",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "method",
@@ -4130,9 +4130,9 @@
                 "name": "ApiExecutableKind",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "setter",
@@ -4143,9 +4143,9 @@
                 "name": "ApiExecutableKind",
                 "libraryUri": "package:api_summary/src/api_declaration.dart"
               },
-              "isStatic": true,
               "isConst": true,
-              "isEnumConstant": true
+              "isEnumConstant": true,
+              "isStatic": true
             },
             {
               "name": "values",
@@ -4163,8 +4163,8 @@
                   }
                 ]
               },
-              "isStatic": true,
-              "isConst": true
+              "isConst": true,
+              "isStatic": true
             }
           ]
         }

--- a/pkgs/api_summary/api.yaml
+++ b/pkgs/api_summary/api.yaml
@@ -2539,9 +2539,9 @@ libraries:
               kind: interface
               name: ApiClassModifier
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: isBase
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2549,9 +2549,9 @@ libraries:
               kind: interface
               name: ApiClassModifier
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: isFinal
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2559,9 +2559,9 @@ libraries:
               kind: interface
               name: ApiClassModifier
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: isInterface
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2569,9 +2569,9 @@ libraries:
               kind: interface
               name: ApiClassModifier
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: isMixin
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2579,9 +2579,9 @@ libraries:
               kind: interface
               name: ApiClassModifier
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: isSealed
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2589,9 +2589,9 @@ libraries:
               kind: interface
               name: ApiClassModifier
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: jsonName
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2625,8 +2625,8 @@ libraries:
                 - kind: interface
                   name: ApiClassModifier
                   libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
+            isStatic: true
       - name: ApiDeclarationStatus
         locationUri: package:api_summary/src/api_declaration.dart
         methods:
@@ -2637,9 +2637,9 @@ libraries:
               kind: interface
               name: ApiDeclarationStatus
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: public
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2647,9 +2647,9 @@ libraries:
               kind: interface
               name: ApiDeclarationStatus
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: referenced
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2657,9 +2657,9 @@ libraries:
               kind: interface
               name: ApiDeclarationStatus
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: values
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2671,8 +2671,8 @@ libraries:
                 - kind: interface
                   name: ApiDeclarationStatus
                   libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
+            isStatic: true
       - name: ApiExecutableKind
         locationUri: package:api_summary/src/api_declaration.dart
         methods:
@@ -2683,9 +2683,9 @@ libraries:
               kind: interface
               name: ApiExecutableKind
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: function
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2693,9 +2693,9 @@ libraries:
               kind: interface
               name: ApiExecutableKind
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: getter
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2703,9 +2703,9 @@ libraries:
               kind: interface
               name: ApiExecutableKind
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: method
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2713,9 +2713,9 @@ libraries:
               kind: interface
               name: ApiExecutableKind
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: setter
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2723,9 +2723,9 @@ libraries:
               kind: interface
               name: ApiExecutableKind
               libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
             isEnumConstant: true
+            isStatic: true
           - name: values
             locationUri: package:api_summary/src/api_declaration.dart
             kind: getter
@@ -2737,8 +2737,8 @@ libraries:
                 - kind: interface
                   name: ApiExecutableKind
                   libraryUri: package:api_summary/src/api_declaration.dart
-            isStatic: true
             isConst: true
+            isStatic: true
     functions:
       - name: apiSummary
         locationUri: package:api_summary/api_summary.dart

--- a/pkgs/api_summary/lib/src/api_builder.dart
+++ b/pkgs/api_summary/lib/src/api_builder.dart
@@ -422,11 +422,11 @@ final class _ApiBuilder {
       immediateSubtypes: immediateSubtypes,
       constructors: constructors,
       methods: methods,
-      isExperimental: element.nonSynthetic.metadata.hasExperimental,
       isDeprecated: element.nonSynthetic.metadata.hasDeprecated,
-      isVisibleForTesting: element.nonSynthetic.metadata.hasVisibleForTesting,
-      isInternal: element.nonSynthetic.metadata.hasInternal,
+      isExperimental: element.nonSynthetic.metadata.hasExperimental,
       isImmutable: element.nonSynthetic.metadata.hasImmutable,
+      isInternal: element.nonSynthetic.metadata.hasInternal,
+      isVisibleForTesting: element.nonSynthetic.metadata.hasVisibleForTesting,
     );
   }
 
@@ -452,10 +452,10 @@ final class _ApiBuilder {
       extendedType: _describeType(element.extendedType),
       typeParameters: _extractTypeParameters(element.typeParameters),
       methods: methods,
-      isExperimental: element.nonSynthetic.metadata.hasExperimental,
       isDeprecated: element.nonSynthetic.metadata.hasDeprecated,
-      isVisibleForTesting: element.nonSynthetic.metadata.hasVisibleForTesting,
+      isExperimental: element.nonSynthetic.metadata.hasExperimental,
       isInternal: element.nonSynthetic.metadata.hasInternal,
+      isVisibleForTesting: element.nonSynthetic.metadata.hasVisibleForTesting,
     );
   }
 
@@ -486,10 +486,10 @@ final class _ApiBuilder {
       interfaces: element.interfaces.map(_describeType).toList(),
       constructors: constructors,
       methods: methods,
-      isExperimental: element.nonSynthetic.metadata.hasExperimental,
       isDeprecated: element.nonSynthetic.metadata.hasDeprecated,
-      isVisibleForTesting: element.nonSynthetic.metadata.hasVisibleForTesting,
+      isExperimental: element.nonSynthetic.metadata.hasExperimental,
       isInternal: element.nonSynthetic.metadata.hasInternal,
+      isVisibleForTesting: element.nonSynthetic.metadata.hasVisibleForTesting,
     );
   }
 
@@ -547,23 +547,23 @@ final class _ApiBuilder {
           .toList(),
       isStatic: element.isStatic,
       isConst: isConst,
+      isDeprecated: _hasAnnotation(element, (m) => m.hasDeprecated),
       isEnumConstant: isEnumConstant,
-      isProtected: _hasAnnotation(element, (m) => m.hasProtected),
+      isExperimental: _hasAnnotation(element, (m) => m.hasExperimental),
+      isInternal: _hasAnnotation(element, (m) => m.hasInternal),
+      isMustBeOverridden: _hasAnnotation(element, (m) => m.hasMustBeOverridden),
       isMustCallSuper: _hasAnnotation(element, (m) => m.hasMustCallSuper),
+      isNonVirtual: _hasAnnotation(element, (m) => m.hasNonVirtual),
+      isProtected: _hasAnnotation(element, (m) => m.hasProtected),
+      isUseResult: _hasAnnotation(element, (m) => m.hasUseResult),
       isVisibleForOverriding: _hasAnnotation(
         element,
         (m) => m.hasVisibleForOverriding,
       ),
-      isNonVirtual: _hasAnnotation(element, (m) => m.hasNonVirtual),
-      isMustBeOverridden: _hasAnnotation(element, (m) => m.hasMustBeOverridden),
-      isUseResult: _hasAnnotation(element, (m) => m.hasUseResult),
-      isDeprecated: _hasAnnotation(element, (m) => m.hasDeprecated),
-      isExperimental: _hasAnnotation(element, (m) => m.hasExperimental),
       isVisibleForTesting: _hasAnnotation(
         element,
         (m) => m.hasVisibleForTesting,
       ),
-      isInternal: _hasAnnotation(element, (m) => m.hasInternal),
     );
   }
 
@@ -578,8 +578,8 @@ final class _ApiBuilder {
     aliasedType: _describeType(element.aliasedType),
     isDeprecated: element.nonSynthetic.metadata.hasDeprecated,
     isExperimental: element.nonSynthetic.metadata.hasExperimental,
-    isVisibleForTesting: element.nonSynthetic.metadata.hasVisibleForTesting,
     isInternal: element.nonSynthetic.metadata.hasInternal,
+    isVisibleForTesting: element.nonSynthetic.metadata.hasVisibleForTesting,
   );
 }
 

--- a/pkgs/api_summary/lib/src/api_declaration.dart
+++ b/pkgs/api_summary/lib/src/api_declaration.dart
@@ -167,10 +167,11 @@ sealed class ApiDeclaration {
   final ApiDeclarationStatus status;
   final bool isDeprecated;
   final bool isExperimental;
-  final bool isVisibleForTesting;
 
   /// Whether this declaration is annotated with `@internal`.
   final bool isInternal;
+
+  final bool isVisibleForTesting;
 
   const ApiDeclaration({
     required this.name,
@@ -178,8 +179,8 @@ sealed class ApiDeclaration {
     this.status = ApiDeclarationStatus.public,
     this.isDeprecated = false,
     this.isExperimental = false,
-    this.isVisibleForTesting = false,
     this.isInternal = false,
+    this.isVisibleForTesting = false,
   });
 }
 
@@ -216,9 +217,9 @@ final class ApiClass extends ApiDeclaration {
     required this.methods,
     super.isDeprecated,
     super.isExperimental,
-    super.isVisibleForTesting,
-    super.isInternal,
     this.isImmutable = false,
+    super.isInternal,
+    super.isVisibleForTesting,
   });
 
   factory ApiClass.fromJson(Map<String, dynamic> json) => ApiClass(
@@ -245,9 +246,9 @@ final class ApiClass extends ApiDeclaration {
     methods: parseList(json, 'methods', ApiExecutable.fromJson),
     isDeprecated: json['isDeprecated'] as bool? ?? false,
     isExperimental: json['isExperimental'] as bool? ?? false,
-    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
-    isInternal: json['isInternal'] as bool? ?? false,
     isImmutable: json['isImmutable'] as bool? ?? false,
+    isInternal: json['isInternal'] as bool? ?? false,
+    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
   );
 
   Map<String, dynamic> toJson() => {
@@ -275,9 +276,9 @@ final class ApiClass extends ApiDeclaration {
     if (methods.isNotEmpty) 'methods': methods.map((e) => e.toJson()).toList(),
     if (isDeprecated) 'isDeprecated': isDeprecated,
     if (isExperimental) 'isExperimental': isExperimental,
-    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
-    if (isInternal) 'isInternal': isInternal,
     if (isImmutable) 'isImmutable': isImmutable,
+    if (isInternal) 'isInternal': isInternal,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
   };
 }
 
@@ -298,8 +299,8 @@ final class ApiExtension extends ApiDeclaration {
     required this.methods,
     super.isDeprecated,
     super.isExperimental,
-    super.isVisibleForTesting,
     super.isInternal,
+    super.isVisibleForTesting,
   });
 
   factory ApiExtension.fromJson(Map<String, dynamic> json) => ApiExtension(
@@ -313,8 +314,8 @@ final class ApiExtension extends ApiDeclaration {
     methods: parseList(json, 'methods', ApiExecutable.fromJson),
     isDeprecated: json['isDeprecated'] as bool? ?? false,
     isExperimental: json['isExperimental'] as bool? ?? false,
-    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
     isInternal: json['isInternal'] as bool? ?? false,
+    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
   );
 
   Map<String, dynamic> toJson() => {
@@ -330,8 +331,8 @@ final class ApiExtension extends ApiDeclaration {
     if (methods.isNotEmpty) 'methods': methods.map((e) => e.toJson()).toList(),
     if (isDeprecated) 'isDeprecated': isDeprecated,
     if (isExperimental) 'isExperimental': isExperimental,
-    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
     if (isInternal) 'isInternal': isInternal,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
   };
 }
 
@@ -356,8 +357,8 @@ final class ApiExtensionType extends ApiDeclaration {
     required this.methods,
     super.isDeprecated,
     super.isExperimental,
-    super.isVisibleForTesting,
     super.isInternal,
+    super.isVisibleForTesting,
   });
 
   factory ApiExtensionType.fromJson(Map<String, dynamic> json) =>
@@ -374,8 +375,8 @@ final class ApiExtensionType extends ApiDeclaration {
         methods: parseList(json, 'methods', ApiExecutable.fromJson),
         isDeprecated: json['isDeprecated'] as bool? ?? false,
         isExperimental: json['isExperimental'] as bool? ?? false,
-        isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
         isInternal: json['isInternal'] as bool? ?? false,
+        isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
       );
 
   Map<String, dynamic> toJson() => {
@@ -395,8 +396,8 @@ final class ApiExtensionType extends ApiDeclaration {
     if (methods.isNotEmpty) 'methods': methods.map((e) => e.toJson()).toList(),
     if (isDeprecated) 'isDeprecated': isDeprecated,
     if (isExperimental) 'isExperimental': isExperimental,
-    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
     if (isInternal) 'isInternal': isInternal,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
   };
 }
 
@@ -410,32 +411,28 @@ final class ApiExecutable extends ApiDeclaration {
   final Map<String, ApiType?> typeParameters;
   final ApiType returnType;
   final List<ApiParameter> parameters;
-  final bool isStatic;
-
-  /// Whether this executable is a const constructor, field, or top-level
-  /// variable.
   final bool isConst;
-
-  /// Whether this executable represents an enum constant.
   final bool isEnumConstant;
-
-  /// Whether this executable is annotated with `@protected`.
-  final bool isProtected;
-
-  /// Whether this executable is annotated with `@mustCallSuper`.
-  final bool isMustCallSuper;
-
-  /// Whether this executable is annotated with `@visibleForOverriding`.
-  final bool isVisibleForOverriding;
-
-  /// Whether this executable is annotated with `@nonVirtual`.
-  final bool isNonVirtual;
 
   /// Whether this executable is annotated with `@mustBeOverridden`.
   final bool isMustBeOverridden;
 
+  /// Whether this executable is annotated with `@mustCallSuper`.
+  final bool isMustCallSuper;
+
+  /// Whether this executable is annotated with `@nonVirtual`.
+  final bool isNonVirtual;
+
+  /// Whether this executable is annotated with `@protected`.
+  final bool isProtected;
+
+  final bool isStatic;
+
   /// Whether this executable is annotated with `@useResult`.
   final bool isUseResult;
+
+  /// Whether this executable is annotated with `@visibleForOverriding`.
+  final bool isVisibleForOverriding;
 
   ApiExecutable({
     required super.name,
@@ -448,16 +445,16 @@ final class ApiExecutable extends ApiDeclaration {
     required this.isStatic,
     this.isConst = false,
     this.isEnumConstant = false,
-    this.isProtected = false,
-    this.isMustCallSuper = false,
-    this.isVisibleForOverriding = false,
-    this.isNonVirtual = false,
     this.isMustBeOverridden = false,
+    this.isMustCallSuper = false,
+    this.isNonVirtual = false,
+    this.isProtected = false,
     this.isUseResult = false,
+    this.isVisibleForOverriding = false,
     super.isDeprecated,
     super.isExperimental,
-    super.isVisibleForTesting,
     super.isInternal,
+    super.isVisibleForTesting,
   });
 
   factory ApiExecutable.fromJson(Map<String, dynamic> json) => ApiExecutable(
@@ -472,17 +469,17 @@ final class ApiExecutable extends ApiDeclaration {
     parameters: parseList(json, 'parameters', ApiParameter.fromJson),
     isStatic: json['isStatic'] as bool? ?? false,
     isConst: json['isConst'] as bool? ?? false,
-    isEnumConstant: json['isEnumConstant'] as bool? ?? false,
-    isProtected: json['isProtected'] as bool? ?? false,
-    isMustCallSuper: json['isMustCallSuper'] as bool? ?? false,
-    isVisibleForOverriding: json['isVisibleForOverriding'] as bool? ?? false,
-    isNonVirtual: json['isNonVirtual'] as bool? ?? false,
-    isMustBeOverridden: json['isMustBeOverridden'] as bool? ?? false,
-    isUseResult: json['isUseResult'] as bool? ?? false,
     isDeprecated: json['isDeprecated'] as bool? ?? false,
+    isEnumConstant: json['isEnumConstant'] as bool? ?? false,
     isExperimental: json['isExperimental'] as bool? ?? false,
-    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
     isInternal: json['isInternal'] as bool? ?? false,
+    isMustBeOverridden: json['isMustBeOverridden'] as bool? ?? false,
+    isMustCallSuper: json['isMustCallSuper'] as bool? ?? false,
+    isNonVirtual: json['isNonVirtual'] as bool? ?? false,
+    isProtected: json['isProtected'] as bool? ?? false,
+    isUseResult: json['isUseResult'] as bool? ?? false,
+    isVisibleForOverriding: json['isVisibleForOverriding'] as bool? ?? false,
+    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
   );
 
   Map<String, dynamic> toJson() => {
@@ -498,20 +495,20 @@ final class ApiExecutable extends ApiDeclaration {
     'returnType': returnType.toJson(),
     if (parameters.isNotEmpty)
       'parameters': parameters.map((e) => e.toJson()).toList(),
-    if (isStatic) 'isStatic': isStatic,
     if (isConst) 'isConst': isConst,
+    if (isDeprecated) 'isDeprecated': isDeprecated,
     if (isEnumConstant) 'isEnumConstant': isEnumConstant,
-    if (isProtected) 'isProtected': isProtected,
+    if (isExperimental) 'isExperimental': isExperimental,
+    if (isInternal) 'isInternal': isInternal,
+    if (isMustBeOverridden) 'isMustBeOverridden': isMustBeOverridden,
     if (isMustCallSuper) 'isMustCallSuper': isMustCallSuper,
+    if (isNonVirtual) 'isNonVirtual': isNonVirtual,
+    if (isProtected) 'isProtected': isProtected,
+    if (isStatic) 'isStatic': isStatic,
+    if (isUseResult) 'isUseResult': isUseResult,
     if (isVisibleForOverriding)
       'isVisibleForOverriding': isVisibleForOverriding,
-    if (isNonVirtual) 'isNonVirtual': isNonVirtual,
-    if (isMustBeOverridden) 'isMustBeOverridden': isMustBeOverridden,
-    if (isUseResult) 'isUseResult': isUseResult,
-    if (isDeprecated) 'isDeprecated': isDeprecated,
-    if (isExperimental) 'isExperimental': isExperimental,
     if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
-    if (isInternal) 'isInternal': isInternal,
   };
 }
 
@@ -530,8 +527,8 @@ final class ApiTypeAlias extends ApiDeclaration {
     required this.aliasedType,
     super.isDeprecated,
     super.isExperimental,
-    super.isVisibleForTesting,
     super.isInternal,
+    super.isVisibleForTesting,
   });
 
   factory ApiTypeAlias.fromJson(Map<String, dynamic> json) => ApiTypeAlias(
@@ -542,8 +539,8 @@ final class ApiTypeAlias extends ApiDeclaration {
     aliasedType: ApiType.fromJson(json['aliasedType'] as Map<String, dynamic>),
     isDeprecated: json['isDeprecated'] as bool? ?? false,
     isExperimental: json['isExperimental'] as bool? ?? false,
-    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
     isInternal: json['isInternal'] as bool? ?? false,
+    isVisibleForTesting: json['isVisibleForTesting'] as bool? ?? false,
   );
 
   Map<String, dynamic> toJson() => {
@@ -558,8 +555,8 @@ final class ApiTypeAlias extends ApiDeclaration {
     'aliasedType': aliasedType.toJson(),
     if (isDeprecated) 'isDeprecated': isDeprecated,
     if (isExperimental) 'isExperimental': isExperimental,
-    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
     if (isInternal) 'isInternal': isInternal,
+    if (isVisibleForTesting) 'isVisibleForTesting': isVisibleForTesting,
   };
 }
 

--- a/pkgs/api_summary/lib/src/api_declaration.dart
+++ b/pkgs/api_summary/lib/src/api_declaration.dart
@@ -411,7 +411,12 @@ final class ApiExecutable extends ApiDeclaration {
   final Map<String, ApiType?> typeParameters;
   final ApiType returnType;
   final List<ApiParameter> parameters;
+
+  /// Whether this executable is a const constructor, field, or top-level
+  /// variable.
   final bool isConst;
+
+  /// Whether this executable represents an enum constant.
   final bool isEnumConstant;
 
   /// Whether this executable is annotated with `@mustBeOverridden`.

--- a/pkgs/api_summary/lib/src/extensions.dart
+++ b/pkgs/api_summary/lib/src/extensions.dart
@@ -24,27 +24,27 @@ extension FormalParameterElementExtension on FormalParameterElement {
 }
 
 extension ElementAnnotationListExtension on List<ElementAnnotation> {
-  bool get hasVisibleForTesting => any((a) => a.isVisibleForTesting);
-  bool get hasProtected => any((a) => a.isProtected);
-  bool get hasMustCallSuper => any((a) => a.isMustCallSuper);
-  bool get hasVisibleForOverriding => any((a) => a.isVisibleForOverriding);
-  bool get hasNonVirtual => any((a) => a.isNonVirtual);
-  bool get hasMustBeOverridden => any((a) => a.isMustBeOverridden);
-  bool get hasUseResult => any((a) => a.isUseResult);
-  bool get hasInternal => any((a) => a.isInternal);
   bool get hasImmutable => any((a) => a.isImmutable);
+  bool get hasInternal => any((a) => a.isInternal);
+  bool get hasMustBeOverridden => any((a) => a.isMustBeOverridden);
+  bool get hasMustCallSuper => any((a) => a.isMustCallSuper);
+  bool get hasNonVirtual => any((a) => a.isNonVirtual);
+  bool get hasProtected => any((a) => a.isProtected);
+  bool get hasUseResult => any((a) => a.isUseResult);
+  bool get hasVisibleForOverriding => any((a) => a.isVisibleForOverriding);
+  bool get hasVisibleForTesting => any((a) => a.isVisibleForTesting);
 }
 
 extension MetadataExtension on Metadata {
-  bool get hasVisibleForTesting => annotations.hasVisibleForTesting;
-  bool get hasProtected => annotations.hasProtected;
-  bool get hasMustCallSuper => annotations.hasMustCallSuper;
-  bool get hasVisibleForOverriding => annotations.hasVisibleForOverriding;
-  bool get hasNonVirtual => annotations.hasNonVirtual;
-  bool get hasMustBeOverridden => annotations.hasMustBeOverridden;
-  bool get hasUseResult => annotations.hasUseResult;
-  bool get hasInternal => annotations.hasInternal;
   bool get hasImmutable => annotations.hasImmutable;
+  bool get hasInternal => annotations.hasInternal;
+  bool get hasMustBeOverridden => annotations.hasMustBeOverridden;
+  bool get hasMustCallSuper => annotations.hasMustCallSuper;
+  bool get hasNonVirtual => annotations.hasNonVirtual;
+  bool get hasProtected => annotations.hasProtected;
+  bool get hasUseResult => annotations.hasUseResult;
+  bool get hasVisibleForOverriding => annotations.hasVisibleForOverriding;
+  bool get hasVisibleForTesting => annotations.hasVisibleForTesting;
 }
 
 extension IterableIterableExtension on Iterable<Iterable<Object?>> {

--- a/pkgs/api_summary/lib/src/text_renderer.dart
+++ b/pkgs/api_summary/lib/src/text_renderer.dart
@@ -623,18 +623,18 @@ final class _ApiTextRenderer {
     required Node<MemberSortKey> node,
   }) {
     parentheticals.addAll([
-      if (element.isInternal) ['internal'],
-      if (element is ApiClass && element.isImmutable) ['immutable'],
-      if (element is ApiExecutable) ...[
-        if (element.isProtected) ['protected'],
-        if (element.isVisibleForOverriding) ['visible for overriding'],
-        if (element.isNonVirtual) ['non-virtual'],
-        if (element.isMustCallSuper) ['must call super'],
-        if (element.isMustBeOverridden) ['must be overridden'],
-        if (element.isUseResult) ['use result'],
-      ],
       if (element.isDeprecated) ['deprecated'],
       if (element.isExperimental) ['experimental'],
+      if (element is ApiClass && element.isImmutable) ['immutable'],
+      if (element.isInternal) ['internal'],
+      if (element is ApiExecutable) ...[
+        if (element.isMustBeOverridden) ['must be overridden'],
+        if (element.isMustCallSuper) ['must call super'],
+        if (element.isNonVirtual) ['non-virtual'],
+        if (element.isProtected) ['protected'],
+        if (element.isUseResult) ['use result'],
+        if (element.isVisibleForOverriding) ['visible for overriding'],
+      ],
       if (element.isVisibleForTesting) ['visible for testing'],
     ]);
     if (parentheticals.isNotEmpty) {


### PR DESCRIPTION
Alphabetize contractual `package:meta` annotation getters, models, `toJson` serialization keys, and `api.txt` parentheticals for consistency and canonical output.