### PR TITLE
refactor(api_summary): remove pubspec_parse dependency

### DIFF
--- a/pkgs/api_summary/lib/api_summary.dart
+++ b/pkgs/api_summary/lib/api_summary.dart
@@ -68,41 +68,63 @@ _PubspecDetails _extractPubspecDetails(String packagePath) {
   final YamlMap yaml;
   try {
     final parsed = loadYaml(content, sourceUrl: pubspecFile.uri);
-    if (parsed is! YamlMap) {
+    if (parsed case final YamlMap map) {
+      yaml = map;
+    } else {
       throw Exception('Expected pubspec to be a YAML map.');
     }
-    yaml = parsed;
   } on Exception catch (e) {
     throw ArgumentError(
       'Failed to parse pubspec.yaml at ${pubspecFile.path}: $e',
     );
   }
 
-  final name = yaml['name'];
-  if (name is! String) {
+  final String name;
+  if (yaml['name'] case final String parsedName) {
+    name = parsedName;
+  } else {
     throw ArgumentError(
       'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
       'Expected pubspec to contain a "name" string.',
     );
   }
 
-  final environment = <String, String>{};
-  final environmentNode = yaml['environment'];
-  if (environmentNode is YamlMap) {
-    for (final entry in environmentNode.entries) {
-      if (entry.value != null) {
-        environment[entry.key as String] = entry.value.toString();
-      }
-    }
+  final Map<String, String> environment;
+  if (yaml['environment'] case final Map<dynamic, dynamic> envMap) {
+    environment = {
+      for (final MapEntry(:key, :value) in envMap.entries)
+        if (key case final String k when value != null) k: value.toString(),
+    };
+  } else if (yaml['environment'] == null) {
+    environment = const {};
+  } else {
+    throw ArgumentError(
+      'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
+      'Expected "environment" to be a YAML map.',
+    );
   }
 
-  final executables = <String, String?>{};
-  final executablesNode = yaml['executables'];
-  if (executablesNode is YamlMap) {
-    for (final entry in executablesNode.entries) {
-      final value = entry.value;
-      executables[entry.key as String] = value is String ? value : null;
-    }
+  final Map<String, String?> executables;
+  if (yaml['executables'] case final Map<dynamic, dynamic> execMap) {
+    executables = {
+      for (final MapEntry(:key, :value) in execMap.entries)
+        if (key case final String k)
+          k: switch (value) {
+            final String s => s,
+            null => null,
+            _ => throw ArgumentError(
+              'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
+              'Expected executable target for "$k" to be a string or null.',
+            ),
+          },
+    };
+  } else if (yaml['executables'] == null) {
+    executables = const {};
+  } else {
+    throw ArgumentError(
+      'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
+      'Expected "executables" to be a YAML map.',
+    );
   }
 
   return (name: name, environment: environment, executables: executables);

--- a/pkgs/api_summary/lib/api_summary.dart
+++ b/pkgs/api_summary/lib/api_summary.dart
@@ -67,65 +67,61 @@ _PubspecDetails _extractPubspecDetails(String packagePath) {
   final content = pubspecFile.readAsStringSync();
   final YamlMap yaml;
   try {
-    final parsed = loadYaml(content, sourceUrl: pubspecFile.uri);
-    if (parsed case final YamlMap map) {
-      yaml = map;
-    } else {
-      throw Exception('Expected pubspec to be a YAML map.');
-    }
-  } on Exception catch (e) {
-    throw ArgumentError(
-      'Failed to parse pubspec.yaml at ${pubspecFile.path}: $e',
+    yaml = switch (loadYaml(content, sourceUrl: pubspecFile.uri)) {
+      final YamlMap map => map,
+      _ => throw FormatException('Expected pubspec to be a YAML map.', content),
+    };
+  } on FormatException catch (e) {
+    throw FormatException(
+      'Failed to parse pubspec.yaml at ${pubspecFile.path}: ${e.message}',
+      content,
+      e.offset,
     );
   }
 
-  final String name;
-  if (yaml['name'] case final String parsedName) {
-    name = parsedName;
-  } else {
-    throw ArgumentError(
+  final name = switch (yaml['name']) {
+    final String name => name,
+    _ => throw FormatException(
       'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
       'Expected pubspec to contain a "name" string.',
-    );
-  }
+      content,
+    ),
+  };
 
-  final Map<String, String> environment;
-  if (yaml['environment'] case final Map<dynamic, dynamic> envMap) {
-    environment = {
+  final environment = switch (yaml['environment']) {
+    final Map<dynamic, dynamic> envMap => {
       for (final MapEntry(:key, :value) in envMap.entries)
         if (key case final String k when value != null) k: value.toString(),
-    };
-  } else if (yaml['environment'] == null) {
-    environment = const {};
-  } else {
-    throw ArgumentError(
+    },
+    null => const <String, String>{},
+    _ => throw FormatException(
       'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
       'Expected "environment" to be a YAML map.',
-    );
-  }
+      content,
+    ),
+  };
 
-  final Map<String, String?> executables;
-  if (yaml['executables'] case final Map<dynamic, dynamic> execMap) {
-    executables = {
+  final executables = switch (yaml['executables']) {
+    final Map<dynamic, dynamic> execMap => {
       for (final MapEntry(:key, :value) in execMap.entries)
         if (key case final String k)
           k: switch (value) {
             final String s => s,
             null => null,
-            _ => throw ArgumentError(
+            _ => throw FormatException(
               'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
               'Expected executable target for "$k" to be a string or null.',
+              content,
             ),
           },
-    };
-  } else if (yaml['executables'] == null) {
-    executables = const {};
-  } else {
-    throw ArgumentError(
+    },
+    null => const <String, String?>{},
+    _ => throw FormatException(
       'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
       'Expected "executables" to be a YAML map.',
-    );
-  }
+      content,
+    ),
+  };
 
   return (name: name, environment: environment, executables: executables);
 }

--- a/pkgs/api_summary/lib/api_summary.dart
+++ b/pkgs/api_summary/lib/api_summary.dart
@@ -91,14 +91,14 @@ _PubspecDetails _extractPubspecDetails(String packagePath) {
   final environment = switch (yaml['environment']) {
     final Map<dynamic, dynamic> envMap => {
       for (final MapEntry(:key, :value) in envMap.entries)
-        if (key case final String k when value != null)
-          k: switch (value) {
+        if (key is String && value != null)
+          key: switch (value) {
             final String s => s,
             final num n => n.toString(),
             final bool b => b.toString(),
             _ => throw FormatException(
               'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
-              'Expected environment constraint for "$k" to be a string or '
+              'Expected environment constraint for "$key" to be a string or '
               'scalar.',
               content,
             ),
@@ -115,13 +115,12 @@ _PubspecDetails _extractPubspecDetails(String packagePath) {
   final executables = switch (yaml['executables']) {
     final Map<dynamic, dynamic> execMap => {
       for (final MapEntry(:key, :value) in execMap.entries)
-        if (key case final String k)
-          k: switch (value) {
-            final String s => s,
-            null => null,
+        if (key is String)
+          key: switch (value) {
+            final String? s => s,
             _ => throw FormatException(
               'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
-              'Expected executable target for "$k" to be a string or null.',
+              'Expected executable target for "$key" to be a string or null.',
               content,
             ),
           },

--- a/pkgs/api_summary/lib/api_summary.dart
+++ b/pkgs/api_summary/lib/api_summary.dart
@@ -91,7 +91,18 @@ _PubspecDetails _extractPubspecDetails(String packagePath) {
   final environment = switch (yaml['environment']) {
     final Map<dynamic, dynamic> envMap => {
       for (final MapEntry(:key, :value) in envMap.entries)
-        if (key case final String k when value != null) k: value.toString(),
+        if (key case final String k when value != null)
+          k: switch (value) {
+            final String s => s,
+            final num n => n.toString(),
+            final bool b => b.toString(),
+            _ => throw FormatException(
+              'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
+              'Expected environment constraint for "$k" to be a string or '
+              'scalar.',
+              content,
+            ),
+          },
     },
     null => const <String, String>{},
     _ => throw FormatException(

--- a/pkgs/api_summary/lib/api_summary.dart
+++ b/pkgs/api_summary/lib/api_summary.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:path/path.dart' as p;
-import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:yaml/yaml.dart';
 
 import 'src/api_builder.dart';
 import 'src/api_declaration.dart';
@@ -65,23 +65,45 @@ _PubspecDetails _extractPubspecDetails(String packagePath) {
     throw ArgumentError('No pubspec.yaml found at "$packagePath".');
   }
   final content = pubspecFile.readAsStringSync();
-  final Pubspec pubspec;
+  final YamlMap yaml;
   try {
-    pubspec = Pubspec.parse(content, sourceUrl: pubspecFile.uri);
+    final parsed = loadYaml(content, sourceUrl: pubspecFile.uri);
+    if (parsed is! YamlMap) {
+      throw Exception('Expected pubspec to be a YAML map.');
+    }
+    yaml = parsed;
   } on Exception catch (e) {
     throw ArgumentError(
       'Failed to parse pubspec.yaml at ${pubspecFile.path}: $e',
     );
   }
 
-  final environment = <String, String>{
-    for (final entry in pubspec.environment.entries)
-      if (entry.value case final constraint?) entry.key: constraint.toString(),
-  };
+  final name = yaml['name'];
+  if (name is! String) {
+    throw ArgumentError(
+      'Failed to parse pubspec.yaml at ${pubspecFile.path}: '
+      'Expected pubspec to contain a "name" string.',
+    );
+  }
 
-  return (
-    name: pubspec.name,
-    environment: environment,
-    executables: pubspec.executables,
-  );
+  final environment = <String, String>{};
+  final environmentNode = yaml['environment'];
+  if (environmentNode is YamlMap) {
+    for (final entry in environmentNode.entries) {
+      if (entry.value != null) {
+        environment[entry.key as String] = entry.value.toString();
+      }
+    }
+  }
+
+  final executables = <String, String?>{};
+  final executablesNode = yaml['executables'];
+  if (executablesNode is YamlMap) {
+    for (final entry in executablesNode.entries) {
+      final value = entry.value;
+      executables[entry.key as String] = value is String ? value : null;
+    }
+  }
+
+  return (name: name, environment: environment, executables: executables);
 }

--- a/pkgs/api_summary/pubspec.yaml
+++ b/pkgs/api_summary/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
   analyzer_testing: '>=0.2.6 <0.4.0'
   dart_flutter_team_lints: ^3.0.0
   test: ^1.28.0
+  test_descriptor: ^2.0.1
   test_reflective_loader: ^0.4.0
 
 executables:

--- a/pkgs/api_summary/pubspec.yaml
+++ b/pkgs/api_summary/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   args: ^2.6.0
   collection: ^1.19.0
   path: ^1.9.0
-  pubspec_parse: ^1.5.0
+  yaml: ^3.1.2
   yaml_edit: ^2.2.0
 
 dev_dependencies:

--- a/pkgs/api_summary/test/app_test.dart
+++ b/pkgs/api_summary/test/app_test.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 import 'package:api_summary/api_summary.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:yaml_edit/yaml_edit.dart';
 
 void main() {
@@ -68,10 +69,25 @@ void main() {
     expect(result.stderr, contains('Usage: api_summary'));
   });
   test('exits with code 64 on invalid pubspec.yaml', () async {
-    final tempDir = await Directory.systemTemp.createTemp('api_summary_test');
-    try {
-      final pubspec = File(p.join(tempDir.path, 'pubspec.yaml'));
-      await pubspec.writeAsString('not_a_map');
+    await d.file('pubspec.yaml', 'not_a_map').create();
+
+    final packageDir = p.current;
+    final result = await Process.run(Platform.resolvedExecutable, [
+      if (Platform.packageConfig != null)
+        '--packages=${Platform.packageConfig}',
+      p.join(packageDir, 'bin', 'api_summary.dart'),
+      '-p',
+      d.sandbox,
+    ], workingDirectory: packageDir);
+
+    expect(result.exitCode, equals(64));
+    expect(result.stderr, contains('Failed to parse pubspec.yaml'));
+  });
+
+  test(
+    'exits with code 64 when no analysis context is found (missing lib/)',
+    () async {
+      await d.file('pubspec.yaml', 'name: foo\n').create();
 
       final packageDir = p.current;
       final result = await Process.run(Platform.resolvedExecutable, [
@@ -79,39 +95,11 @@ void main() {
           '--packages=${Platform.packageConfig}',
         p.join(packageDir, 'bin', 'api_summary.dart'),
         '-p',
-        tempDir.path,
+        d.sandbox,
       ], workingDirectory: packageDir);
 
       expect(result.exitCode, equals(64));
-      expect(result.stderr, contains('Failed to parse pubspec.yaml'));
-    } finally {
-      await tempDir.delete(recursive: true);
-    }
-  });
-
-  test(
-    'exits with code 64 when no analysis context is found (missing lib/)',
-    () async {
-      final tempDir = await Directory.systemTemp.createTemp('api_summary_test');
-      ProcessResult? result;
-      try {
-        final pubspec = File(p.join(tempDir.path, 'pubspec.yaml'));
-        await pubspec.writeAsString('name: foo\n');
-
-        final packageDir = p.current;
-        result = await Process.run(Platform.resolvedExecutable, [
-          if (Platform.packageConfig != null)
-            '--packages=${Platform.packageConfig}',
-          p.join(packageDir, 'bin', 'api_summary.dart'),
-          '-p',
-          tempDir.path,
-        ], workingDirectory: packageDir);
-
-        expect(result.exitCode, equals(64));
-        expect(result.stderr, contains('No "lib" directory found'));
-      } finally {
-        await tempDir.delete(recursive: true);
-      }
+      expect(result.stderr, contains('No "lib" directory found'));
     },
   );
 }

--- a/pkgs/api_summary/test/pubspec_metadata_test.dart
+++ b/pkgs/api_summary/test/pubspec_metadata_test.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:api_summary/api_summary.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
@@ -128,5 +131,194 @@ void main() {
       expect(yaml, contains('environment:\n  sdk: ^3.12.0'));
       expect(yaml, contains('executables:\n  my_tool: null'));
     });
+  });
+
+  group('pubspec.yaml parsing in apiSummary', () {
+    Future<void> withTempPkg(
+      String pubspecContent,
+      Future<void> Function(String pkgPath) fn,
+    ) async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'api_summary_pubspec_test_',
+      );
+      try {
+        File(
+          p.join(tempDir.path, 'pubspec.yaml'),
+        ).writeAsStringSync(pubspecContent);
+        Directory(p.join(tempDir.path, 'lib')).createSync();
+        File(
+          p.join(tempDir.path, 'lib', 'foo.dart'),
+        ).writeAsStringSync('void foo() {}');
+        await fn(tempDir.path);
+      } finally {
+        await tempDir.delete(recursive: true);
+      }
+    }
+
+    test('extracts environment and executables successfully', () async {
+      await withTempPkg(
+        '''
+name: sample_pkg
+environment:
+  sdk: ^3.12.0
+  flutter: ">=3.2.0 <3.9.0"
+executables:
+  tool_a:
+  tool_b: custom_b
+''',
+        (pkgPath) async {
+          final summary = await apiSummary(pkgPath);
+          expect(summary.name, equals('sample_pkg'));
+          expect(
+            summary.environment,
+            equals({'flutter': '>=3.2.0 <3.9.0', 'sdk': '^3.12.0'}),
+          );
+          expect(
+            summary.executables,
+            equals({'tool_a': null, 'tool_b': 'custom_b'}),
+          );
+        },
+      );
+    });
+
+    test('handles omitted and null environment and executables', () async {
+      await withTempPkg(
+        '''
+name: minimal_pkg
+environment:
+executables:
+''',
+        (pkgPath) async {
+          final summary = await apiSummary(pkgPath);
+          expect(summary.name, equals('minimal_pkg'));
+          expect(summary.environment, isEmpty);
+          expect(summary.executables, isEmpty);
+        },
+      );
+    });
+
+    test('ignores null environment constraints', () async {
+      await withTempPkg(
+        '''
+name: sample_pkg
+environment:
+  sdk: ^3.12.0
+  flutter:
+''',
+        (pkgPath) async {
+          final summary = await apiSummary(pkgPath);
+          expect(summary.environment, equals({'sdk': '^3.12.0'}));
+        },
+      );
+    });
+
+    test('throws ArgumentError when pubspec is not a YAML map', () async {
+      await withTempPkg('- item1\n- item2', (pkgPath) async {
+        await expectLater(
+          apiSummary(pkgPath),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Expected pubspec to be a YAML map'),
+            ),
+          ),
+        );
+      });
+    });
+
+    test('throws ArgumentError when name is missing or not a string', () async {
+      await withTempPkg(
+        '''
+environment:
+  sdk: ^3.12.0
+''',
+        (pkgPath) async {
+          await expectLater(
+            apiSummary(pkgPath),
+            throwsA(
+              isA<ArgumentError>().having(
+                (e) => e.message,
+                'message',
+                contains('Expected pubspec to contain a "name" string'),
+              ),
+            ),
+          );
+        },
+      );
+
+      await withTempPkg('name: 12345', (pkgPath) async {
+        await expectLater(
+          apiSummary(pkgPath),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Expected pubspec to contain a "name" string'),
+            ),
+          ),
+        );
+      });
+    });
+
+    test('throws ArgumentError when environment is not a map', () async {
+      await withTempPkg('name: foo\nenvironment: "sdk ^3.12.0"', (
+        pkgPath,
+      ) async {
+        await expectLater(
+          apiSummary(pkgPath),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Expected "environment" to be a YAML map'),
+            ),
+          ),
+        );
+      });
+    });
+
+    test('throws ArgumentError when executables is not a map', () async {
+      await withTempPkg('name: foo\nexecutables: "my_tool"', (pkgPath) async {
+        await expectLater(
+          apiSummary(pkgPath),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Expected "executables" to be a YAML map'),
+            ),
+          ),
+        );
+      });
+    });
+
+    test(
+      'throws ArgumentError when executable target is not string or null',
+      () async {
+        await withTempPkg(
+          '''
+name: foo
+executables:
+  my_tool: [invalid, target]
+''',
+          (pkgPath) async {
+            await expectLater(
+              apiSummary(pkgPath),
+              throwsA(
+                isA<ArgumentError>().having(
+                  (e) => e.message,
+                  'message',
+                  contains(
+                    'Expected executable target for "my_tool" '
+                    'to be a string or null',
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
   });
 }

--- a/pkgs/api_summary/test/pubspec_metadata_test.dart
+++ b/pkgs/api_summary/test/pubspec_metadata_test.dart
@@ -270,6 +270,58 @@ environment:
       });
     });
 
+    test(
+      'throws FormatException when environment constraint is not a scalar',
+      () async {
+        await withTempPkg(
+          '''
+name: foo
+environment:
+  sdk: [3, 0]
+''',
+          (pkgPath) async {
+            await expectLater(
+              apiSummary(pkgPath),
+              throwsA(
+                isA<FormatException>().having(
+                  (e) => e.message,
+                  'message',
+                  contains(
+                    'Expected environment constraint for "sdk" '
+                    'to be a string or scalar',
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+
+        await withTempPkg(
+          '''
+name: foo
+environment:
+  sdk:
+    major: 3
+''',
+          (pkgPath) async {
+            await expectLater(
+              apiSummary(pkgPath),
+              throwsA(
+                isA<FormatException>().having(
+                  (e) => e.message,
+                  'message',
+                  contains(
+                    'Expected environment constraint for "sdk" '
+                    'to be a string or scalar',
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+
     test('throws FormatException when executables is not a map', () async {
       await withTempPkg('name: foo\nexecutables: "my_tool"', (pkgPath) async {
         await expectLater(

--- a/pkgs/api_summary/test/pubspec_metadata_test.dart
+++ b/pkgs/api_summary/test/pubspec_metadata_test.dart
@@ -2,11 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:api_summary/api_summary.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:yaml_edit/yaml_edit.dart';
 
 void main() {
@@ -138,21 +136,12 @@ void main() {
       String pubspecContent,
       Future<void> Function(String pkgPath) fn,
     ) async {
-      final tempDir = await Directory.systemTemp.createTemp(
-        'api_summary_pubspec_test_',
-      );
-      try {
-        File(
-          p.join(tempDir.path, 'pubspec.yaml'),
-        ).writeAsStringSync(pubspecContent);
-        Directory(p.join(tempDir.path, 'lib')).createSync();
-        File(
-          p.join(tempDir.path, 'lib', 'foo.dart'),
-        ).writeAsStringSync('void foo() {}');
-        await fn(tempDir.path);
-      } finally {
-        await tempDir.delete(recursive: true);
-      }
+      await d.dir('pkg', [
+        d.file('pubspec.yaml', pubspecContent),
+        d.dir('lib', [d.file('foo.dart', 'void foo() {}')]),
+      ]).create();
+
+      await fn(d.path('pkg'));
     }
 
     test('extracts environment and executables successfully', () async {

--- a/pkgs/api_summary/test/pubspec_metadata_test.dart
+++ b/pkgs/api_summary/test/pubspec_metadata_test.dart
@@ -212,12 +212,12 @@ environment:
       );
     });
 
-    test('throws ArgumentError when pubspec is not a YAML map', () async {
+    test('throws FormatException when pubspec is not a YAML map', () async {
       await withTempPkg('- item1\n- item2', (pkgPath) async {
         await expectLater(
           apiSummary(pkgPath),
           throwsA(
-            isA<ArgumentError>().having(
+            isA<FormatException>().having(
               (e) => e.message,
               'message',
               contains('Expected pubspec to be a YAML map'),
@@ -227,48 +227,51 @@ environment:
       });
     });
 
-    test('throws ArgumentError when name is missing or not a string', () async {
-      await withTempPkg(
-        '''
+    test(
+      'throws FormatException when name is missing or not a string',
+      () async {
+        await withTempPkg(
+          '''
 environment:
   sdk: ^3.12.0
 ''',
-        (pkgPath) async {
+          (pkgPath) async {
+            await expectLater(
+              apiSummary(pkgPath),
+              throwsA(
+                isA<FormatException>().having(
+                  (e) => e.message,
+                  'message',
+                  contains('Expected pubspec to contain a "name" string'),
+                ),
+              ),
+            );
+          },
+        );
+
+        await withTempPkg('name: 12345', (pkgPath) async {
           await expectLater(
             apiSummary(pkgPath),
             throwsA(
-              isA<ArgumentError>().having(
+              isA<FormatException>().having(
                 (e) => e.message,
                 'message',
                 contains('Expected pubspec to contain a "name" string'),
               ),
             ),
           );
-        },
-      );
+        });
+      },
+    );
 
-      await withTempPkg('name: 12345', (pkgPath) async {
-        await expectLater(
-          apiSummary(pkgPath),
-          throwsA(
-            isA<ArgumentError>().having(
-              (e) => e.message,
-              'message',
-              contains('Expected pubspec to contain a "name" string'),
-            ),
-          ),
-        );
-      });
-    });
-
-    test('throws ArgumentError when environment is not a map', () async {
+    test('throws FormatException when environment is not a map', () async {
       await withTempPkg('name: foo\nenvironment: "sdk ^3.12.0"', (
         pkgPath,
       ) async {
         await expectLater(
           apiSummary(pkgPath),
           throwsA(
-            isA<ArgumentError>().having(
+            isA<FormatException>().having(
               (e) => e.message,
               'message',
               contains('Expected "environment" to be a YAML map'),
@@ -278,12 +281,12 @@ environment:
       });
     });
 
-    test('throws ArgumentError when executables is not a map', () async {
+    test('throws FormatException when executables is not a map', () async {
       await withTempPkg('name: foo\nexecutables: "my_tool"', (pkgPath) async {
         await expectLater(
           apiSummary(pkgPath),
           throwsA(
-            isA<ArgumentError>().having(
+            isA<FormatException>().having(
               (e) => e.message,
               'message',
               contains('Expected "executables" to be a YAML map'),
@@ -294,7 +297,7 @@ environment:
     });
 
     test(
-      'throws ArgumentError when executable target is not string or null',
+      'throws FormatException when executable target is not string or null',
       () async {
         await withTempPkg(
           '''
@@ -306,7 +309,7 @@ executables:
             await expectLater(
               apiSummary(pkgPath),
               throwsA(
-                isA<ArgumentError>().having(
+                isA<FormatException>().having(
                   (e) => e.message,
                   'message',
                   contains(


### PR DESCRIPTION
Replaces pubspec_parse with package:yaml to avoid transitive
dependency issues with checked_yaml and json_annotation when rolling
api_summary into the Dart SDK. Resolves #WR6GT.
