### PR TITLE
Use `-wip` version for markdown

### DIFF
--- a/pkgs/markdown/CHANGELOG.md
+++ b/pkgs/markdown/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 7.4.1-wip
+
 ## 7.4.0
 
 * Adds `linkBuilder`/`imageLinkBuilder` alternatives to `linkResolver`/  

--- a/pkgs/markdown/lib/src/version.dart
+++ b/pkgs/markdown/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '7.4.0';
+const packageVersion = '7.4.1-wip';

--- a/pkgs/markdown/pubspec.yaml
+++ b/pkgs/markdown/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 7.4.0
+version: 7.4.1-wip
 description: >-
   A portable Markdown library written in Dart that can parse Markdown into HTML.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/markdown


### PR DESCRIPTION
Indicates that the package has had edits to published files since the
last publish. No user facing changes so no changelog entries.
