### PR TITLE
[markdown] Track offset/length for inline `code` spans

### DIFF
--- a/pkgs/markdown/CHANGELOG.md
+++ b/pkgs/markdown/CHANGELOG.md
@@ -4,6 +4,9 @@
   example a single very long word). The plain-text accelerator regex required
   a trailing whitespace, so a run reaching the end of a line without one
   backtracked across the whole run at every position.
+* Adds `offset`/`length` to `Element`, populated for inline code spans
+  (`` `code` ``) parsed from a top-level paragraph or atx header, so that
+  their location in the original source can be recovered (#1287).
 
 ## 7.4.0
 

--- a/pkgs/markdown/lib/markdown.dart
+++ b/pkgs/markdown/lib/markdown.dart
@@ -48,6 +48,7 @@ import 'src/version.dart';
 
 export 'src/ast.dart'
     show
+        ContentOffsetMapper,
         Element,
         LinkBuilder,
         Node,

--- a/pkgs/markdown/lib/src/ast.dart
+++ b/pkgs/markdown/lib/src/ast.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'line.dart';
+
 /// A resolver for reference links that do not resolve to a declaration.
 ///
 /// Does not have access to the link text. Use a [LinkBuilder] instead.
@@ -61,6 +63,14 @@ class Element implements Node {
   final Map<String, String> attributes;
   String? generatedId;
   String? footnoteLabel;
+
+  /// The offset of this element in the original source document, or `null`
+  /// if it is not tracked for this kind of element.
+  int? offset;
+
+  /// The length, in the original source document, of the text that produced
+  /// this element, or `null` if it is not tracked for this kind of element.
+  int? length;
 
   /// Instantiates a [tag] Element with [children].
   Element(this.tag, this.children, [Map<String, String>? attributes])
@@ -128,10 +138,42 @@ class UnparsedContent implements Node {
   @override
   final String textContent;
 
-  UnparsedContent(this.textContent);
+  /// Maps offsets within [textContent] back to offsets in the original source
+  /// document, when available.
+  final ContentOffsetMapper? offsetMapper;
+
+  UnparsedContent(this.textContent, [this.offsetMapper]);
 
   @override
   void accept(NodeVisitor visitor) {}
+}
+
+/// Maps offsets within a string of content, built by joining the [Line.content]
+/// of a sequence of [Line]s with `\n`, back to offsets in the original source
+/// document.
+class ContentOffsetMapper {
+  final List<Line> _lines;
+
+  ContentOffsetMapper(this._lines);
+
+  /// Returns the offset in the original source document corresponding to
+  /// [localOffset] within the joined content, or `null` if it cannot be
+  /// determined, for example because a contributing [Line] does not have a
+  /// known [Line.offset].
+  int? map(int localOffset) {
+    var remaining = localOffset;
+    for (final line in _lines) {
+      final offset = line.offset;
+      if (offset == null) return null;
+      final lineLength = line.content.length;
+      if (remaining <= lineLength) {
+        return offset + remaining;
+      }
+      // Account for the `\n` joining this line to the next.
+      remaining -= lineLength + 1;
+    }
+    return null;
+  }
 }
 
 /// Visitor pattern for the AST.

--- a/pkgs/markdown/lib/src/ast.dart
+++ b/pkgs/markdown/lib/src/ast.dart
@@ -154,6 +154,7 @@ class UnparsedContent implements Node {
 class ContentOffsetMapper {
   final List<Line> _lines;
 
+  /// Constructs a [ContentOffsetMapper] with the given [_lines].
   ContentOffsetMapper(this._lines);
 
   /// Returns the offset in the original source document corresponding to

--- a/pkgs/markdown/lib/src/ast.dart
+++ b/pkgs/markdown/lib/src/ast.dart
@@ -142,7 +142,7 @@ class UnparsedContent implements Node {
   /// document, when available.
   final ContentOffsetMapper? offsetMapper;
 
-  UnparsedContent(this.textContent, [this.offsetMapper]);
+  UnparsedContent(this.textContent, {this.offsetMapper});
 
   @override
   void accept(NodeVisitor visitor) {}

--- a/pkgs/markdown/lib/src/block_syntaxes/header_syntax.dart
+++ b/pkgs/markdown/lib/src/block_syntaxes/header_syntax.dart
@@ -4,6 +4,7 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
+import '../line.dart';
 import '../patterns.dart';
 import 'block_syntax.dart';
 
@@ -16,7 +17,8 @@ class HeaderSyntax extends BlockSyntax {
 
   @override
   Node parse(BlockParser parser) {
-    final match = pattern.firstMatch(parser.current.content)!;
+    final currentLine = parser.current;
+    final match = pattern.firstMatch(currentLine.content)!;
     final matchedText = match[0]!;
     final openMarker = match[1]!;
     final closeMarker = match[2];
@@ -24,17 +26,18 @@ class HeaderSyntax extends BlockSyntax {
     final openMarkerStart = matchedText.indexOf(openMarker);
     final openMarkerEnd = openMarkerStart + level;
 
-    String? content;
+    String rawContent;
     if (closeMarker == null) {
-      content = parser.current.content.substring(openMarkerEnd);
+      rawContent = currentLine.content.substring(openMarkerEnd);
     } else {
       final closeMarkerStart = matchedText.lastIndexOf(closeMarker);
-      content = parser.current.content.substring(
+      rawContent = currentLine.content.substring(
         openMarkerEnd,
         closeMarkerStart,
       );
     }
-    content = content.trim();
+    final leadingWhitespace = rawContent.length - rawContent.trimLeft().length;
+    String? content = rawContent.trim();
 
     // https://spec.commonmark.org/0.30/#example-79
     if (closeMarker == null && RegExp(r'^#+$').hasMatch(content)) {
@@ -42,6 +45,20 @@ class HeaderSyntax extends BlockSyntax {
     }
 
     parser.advance();
-    return Element('h$level', [if (content != null) UnparsedContent(content)]);
+
+    if (content == null) {
+      return Element('h$level', const []);
+    }
+
+    final currentOffset = currentLine.offset;
+    final contentOffsetMapper = currentOffset == null
+        ? null
+        : ContentOffsetMapper([
+            Line(
+              content,
+              offset: currentOffset + openMarkerEnd + leadingWhitespace,
+            ),
+          ]);
+    return Element('h$level', [UnparsedContent(content, contentOffsetMapper)]);
   }
 }

--- a/pkgs/markdown/lib/src/block_syntaxes/header_syntax.dart
+++ b/pkgs/markdown/lib/src/block_syntaxes/header_syntax.dart
@@ -59,6 +59,8 @@ class HeaderSyntax extends BlockSyntax {
               offset: currentOffset + openMarkerEnd + leadingWhitespace,
             ),
           ]);
-    return Element('h$level', [UnparsedContent(content, contentOffsetMapper)]);
+    return Element('h$level', [
+      UnparsedContent(content, offsetMapper: contentOffsetMapper),
+    ]);
   }
 }

--- a/pkgs/markdown/lib/src/block_syntaxes/paragraph_syntax.dart
+++ b/pkgs/markdown/lib/src/block_syntaxes/paragraph_syntax.dart
@@ -4,6 +4,7 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
+import '../line.dart';
 import '../patterns.dart';
 import 'block_syntax.dart';
 import 'setext_header_syntax.dart';
@@ -23,7 +24,7 @@ class ParagraphSyntax extends BlockSyntax {
 
   @override
   Node? parse(BlockParser parser) {
-    final childLines = <String>[parser.current.content];
+    final childLines = <Line>[parser.current];
 
     parser.advance();
     var interruptedBySetextHeading = false;
@@ -34,7 +35,7 @@ class ParagraphSyntax extends BlockSyntax {
         interruptedBySetextHeading = syntax is SetextHeaderSyntax;
         break;
       }
-      childLines.add(parser.current.content);
+      childLines.add(parser.current);
       parser.advance();
     }
 
@@ -43,7 +44,11 @@ class ParagraphSyntax extends BlockSyntax {
       return null;
     }
 
-    final contents = UnparsedContent(childLines.join('\n').trimRight());
+    final text = childLines.map((line) => line.content).join('\n');
+    final contents = UnparsedContent(
+      text.trimRight(),
+      ContentOffsetMapper(childLines),
+    );
     return Element('p', [contents]);
   }
 }

--- a/pkgs/markdown/lib/src/block_syntaxes/paragraph_syntax.dart
+++ b/pkgs/markdown/lib/src/block_syntaxes/paragraph_syntax.dart
@@ -47,7 +47,7 @@ class ParagraphSyntax extends BlockSyntax {
     final text = childLines.map((line) => line.content).join('\n');
     final contents = UnparsedContent(
       text.trimRight(),
-      ContentOffsetMapper(childLines),
+      offsetMapper: ContentOffsetMapper(childLines),
     );
     return Element('p', [contents]);
   }

--- a/pkgs/markdown/lib/src/document.dart
+++ b/pkgs/markdown/lib/src/document.dart
@@ -101,13 +101,17 @@ class Document {
   }
 
   /// Parses the given inline Markdown [text] to a series of AST nodes.
-  List<Node> parseInline(String text) => InlineParser(text, this).parse();
+  List<Node> parseInline(String text, {ContentOffsetMapper? offsetMapper}) =>
+      InlineParser(text, this, offsetMapper: offsetMapper).parse();
 
   void _parseInlineContent(List<Node> nodes) {
     for (var i = 0; i < nodes.length; i++) {
       final node = nodes[i];
       if (node is UnparsedContent) {
-        final inlineNodes = parseInline(node.textContent);
+        final inlineNodes = parseInline(
+          node.textContent,
+          offsetMapper: node.offsetMapper,
+        );
         nodes.removeAt(i);
         nodes.insertAll(i, inlineNodes);
         i += inlineNodes.length - 1;

--- a/pkgs/markdown/lib/src/inline_parser.dart
+++ b/pkgs/markdown/lib/src/inline_parser.dart
@@ -43,6 +43,10 @@ class InlineParser {
   /// The Markdown document this parser is parsing.
   final Document document;
 
+  /// Maps offsets within [source] back to offsets in the original source
+  /// document, when available.
+  final ContentOffsetMapper? offsetMapper;
+
   final syntaxes = <InlineSyntax>[];
 
   /// The current read position.
@@ -58,7 +62,7 @@ class InlineParser {
   /// The tree of parsed HTML nodes.
   final _tree = <Node>[];
 
-  InlineParser(this.source, this.document) {
+  InlineParser(this.source, this.document, {this.offsetMapper}) {
     // User specified syntaxes are the first syntaxes to be evaluated.
     syntaxes.addAll(document.inlineSyntaxes);
 

--- a/pkgs/markdown/lib/src/inline_syntaxes/code_syntax.dart
+++ b/pkgs/markdown/lib/src/inline_syntaxes/code_syntax.dart
@@ -61,7 +61,19 @@ class CodeSyntax extends InlineSyntax {
       code = escapeHtml(code, escapeApos: false);
     }
 
-    parser.addNode(Element.text('code', code));
+    final element = Element.text('code', code);
+    final offsetMapper = parser.offsetMapper;
+    if (offsetMapper != null) {
+      final matchStart = parser.pos;
+      final matchEnd = matchStart + match.match.length;
+      final start = offsetMapper.map(matchStart);
+      final end = offsetMapper.map(matchEnd);
+      if (start != null && end != null) {
+        element.offset = start;
+        element.length = end - start;
+      }
+    }
+    parser.addNode(element);
     return true;
   }
 

--- a/pkgs/markdown/lib/src/line.dart
+++ b/pkgs/markdown/lib/src/line.dart
@@ -40,6 +40,12 @@ class Line {
   // https://spec.commonmark.org/0.30/#blank-line
   final bool isBlankLine;
 
-  Line(this.content, {this.tabRemaining})
+  /// The offset of the start of this line in the original source document,
+  /// or `null` if this line was constructed from content that has already
+  /// been transformed (for example with a block marker stripped), such that
+  /// its position in the original source is no longer known.
+  final int? offset;
+
+  Line(this.content, {this.tabRemaining, this.offset})
     : isBlankLine = emptyPattern.hasMatch(content);
 }

--- a/pkgs/markdown/lib/src/line.dart
+++ b/pkgs/markdown/lib/src/line.dart
@@ -40,10 +40,10 @@ class Line {
   // https://spec.commonmark.org/0.30/#blank-line
   final bool isBlankLine;
 
-  /// The offset of the start of this line in the original source document,
-  /// or `null` if this line was constructed from content that has already
-  /// been transformed (for example with a block marker stripped), such that
-  /// its position in the original source is no longer known.
+  /// The 0-indexed offset of the start of this line in the original source
+  /// document, or `null` if this line was constructed from content that has
+  /// already been transformed (for example with a block marker stripped),
+  /// such that its position in the original source is no longer known.
   final int? offset;
 
   Line(this.content, {this.tabRemaining, this.offset})

--- a/pkgs/markdown/lib/src/util.dart
+++ b/pkgs/markdown/lib/src/util.dart
@@ -205,8 +205,35 @@ extension StringExtensions on String {
   /// Whether this string contains only whitespaces.
   bool get isBlank => trim().isEmpty;
 
-  /// Converts this string to a list of [Line].
-  List<Line> toLines() => LineSplitter.split(this).map(Line.new).toList();
+  /// Converts this string to a list of [Line], tracking the offset of each line
+  /// in this original source string.
+  List<Line> toLines() {
+    final lines = <Line>[];
+    var start = 0;
+    var i = 0;
+    final length = this.length;
+    while (i < length) {
+      final char = codeUnitAt(i);
+      if (char == $lf) {
+        lines.add(Line(substring(start, i), offset: start));
+        i++;
+        start = i;
+      } else if (char == $cr) {
+        lines.add(Line(substring(start, i), offset: start));
+        i++;
+        if (i < length && codeUnitAt(i) == $lf) {
+          i++;
+        }
+        start = i;
+      } else {
+        i++;
+      }
+    }
+    if (start < length) {
+      lines.add(Line(substring(start), offset: start));
+    }
+    return lines;
+  }
 
   /// Returns the last character.
   String last([int n = 1]) => substring(length - n);

--- a/pkgs/markdown/test/code_span_offset_test.dart
+++ b/pkgs/markdown/test/code_span_offset_test.dart
@@ -1,0 +1,179 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:markdown/markdown.dart';
+import 'package:test/test.dart';
+
+List<Element> _findCodes(String source) {
+  final nodes = Document().parse(source);
+  final found = <Element>[];
+  void visit(List<Node> nodes) {
+    for (final node in nodes) {
+      if (node is Element) {
+        if (node.tag == 'code') {
+          found.add(node);
+        }
+        final children = node.children;
+        if (children != null) visit(children);
+      }
+    }
+  }
+
+  visit(nodes);
+  return found;
+}
+
+Element _findCode(String source) => _findCodes(source).first;
+
+void main() {
+  group('inline code span offset/length', () {
+    test('is tracked for a single-line paragraph', () {
+      const source = 'Just a `single` line.';
+      final code = _findCode(source);
+      expect(code.offset, 7);
+      expect(code.length, 8);
+      expect(
+        source.substring(code.offset!, code.offset! + code.length!),
+        '`single`',
+      );
+    });
+
+    test('is tracked across a soft line break', () {
+      const source = 'Hello `world` and\nsome `more code` here.';
+      final codes = _findCodes(source);
+      expect(codes, hasLength(2));
+
+      final first = codes[0];
+      expect(first.offset, 6);
+      expect(first.length, 7);
+      expect(
+        source.substring(first.offset!, first.offset! + first.length!),
+        '`world`',
+      );
+
+      // The second span isn't skipped or mis-tracked just because it's not
+      // the first match in the block.
+      final second = codes[1];
+      expect(second.offset, 23);
+      expect(second.length, 11);
+      expect(
+        source.substring(second.offset!, second.offset! + second.length!),
+        '`more code`',
+      );
+    });
+
+    test('is tracked across a line break using CRLF line endings', () {
+      const source = 'Hello `world\r\nmore` text.';
+      final code = _findCode(source);
+      expect(code.textContent, 'world more');
+      expect(
+        source.substring(code.offset!, code.offset! + code.length!),
+        '`world\r\nmore`',
+      );
+    });
+
+    test('is tracked for spans delimited by multiple backticks', () {
+      const source = 'A code span with `` embedded ` backtick ``.';
+      final code = _findCode(source);
+      expect(
+        source.substring(code.offset!, code.offset! + code.length!),
+        '`` embedded ` backtick ``',
+      );
+    });
+
+    test('is null when not computable, such as inside a blockquote', () {
+      const source = '> A `blockquote code` span.';
+      final code = _findCode(source);
+      expect(code.offset, isNull);
+      expect(code.length, isNull);
+    });
+
+    test('produces no code element when a continuation line is interpreted '
+        'as a new block', () {
+      // The second line starts with `+ `, a valid unordered list marker,
+      // so it ends the paragraph before the closing backtick is reached.
+      const source = 'something `here\n+ there` like this?';
+      expect(_findCodes(source), isEmpty);
+      expect(
+        markdownToHtml(source),
+        '<p>something `here</p>\n<ul>\n<li>there` like this?</li>\n</ul>\n',
+      );
+    });
+
+    test('is tracked when a continuation line is not a block marker', () {
+      // Without the space after `+`, the second line is not a list marker,
+      // so the paragraph (and the code span within it) stays intact.
+      const source = 'something `here\n+there` like this?';
+      final code = _findCode(source);
+      expect(code.textContent, 'here +there');
+      expect(
+        source.substring(code.offset!, code.offset! + code.length!),
+        '`here\n+there`',
+      );
+    });
+
+    test('produces no code element for an unclosed backtick', () {
+      const source = 'something `here with no closing backtick at all';
+      expect(_findCodes(source), isEmpty);
+      expect(
+        markdownToHtml(source),
+        '<p>something `here with no closing backtick at all</p>\n',
+      );
+    });
+
+    test('ignores a backslash-escaped backtick, and still tracks a real span '
+        'that follows it', () {
+      const source = r'a \` and a `code` span';
+      final codes = _findCodes(source);
+      expect(codes, hasLength(1));
+      final code = codes.single;
+      expect(code.textContent, 'code');
+      expect(
+        source.substring(code.offset!, code.offset! + code.length!),
+        '`code`',
+      );
+    });
+
+    test('is tracked inside an atx header', () {
+      const source = '## The `foo` method';
+      final code = _findCode(source);
+      expect(code.textContent, 'foo');
+      expect(
+        source.substring(code.offset!, code.offset! + code.length!),
+        '`foo`',
+      );
+    });
+
+    test('is tracked inside an atx header with extra whitespace and a '
+        'closing marker', () {
+      const source = '##   The `foo` method   ##';
+      final code = _findCode(source);
+      expect(code.textContent, 'foo');
+      expect(
+        source.substring(code.offset!, code.offset! + code.length!),
+        '`foo`',
+      );
+    });
+
+    test('is tracked for every span in a header, not just the first', () {
+      const source = '# `foo` and `bar` in one header';
+      final codes = _findCodes(source);
+      expect(codes, hasLength(2));
+
+      final first = codes[0];
+      expect(first.textContent, 'foo');
+      expect(
+        source.substring(first.offset!, first.offset! + first.length!),
+        '`foo`',
+      );
+
+      final second = codes[1];
+      expect(second.textContent, 'bar');
+      expect(
+        source.substring(second.offset!, second.offset! + second.length!),
+        '`bar`',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes part of https://github.com/dart-lang/tools/issues/1287.

This is the initial work that covers tracking the offset/length of inline code spans. See what is missing at https://github.com/dart-lang/tools/issues/1287#issuecomment-5319312539.

Replaces the incorrectly based PR: https://github.com/dart-lang/tools/pull/2529

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
