### PR TITLE
Fix trailing comma when adding to flow collections in yaml_edit

### DIFF
--- a/pkgs/yaml_edit/CHANGELOG.md
+++ b/pkgs/yaml_edit/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.2.5-wip
 
+- Fix `YamlEditor.appendToList` when appending to a flow list with a trailing comma.
+
 ## 2.2.4
 
 -  Removes comments associated with a node when `remove` is called.

--- a/pkgs/yaml_edit/CHANGELOG.md
+++ b/pkgs/yaml_edit/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.5-wip
 
-- Fix `YamlEditor.appendToList` when appending to a flow list with a trailing comma.
+- Fix `YamlEditor.appendToList` and map updates when adding to flow collections with a trailing comma.
 
 ## 2.2.4
 

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -112,7 +112,7 @@ SourceEdit _appendToFlowList(
   final lastNode = list.nodes.last;
   final between =
       yaml.substring(lastNode.span.end.offset, list.span.end.offset - 1);
-  final hasTrailing = _betweenHasTrailingComma(between);
+  final hasTrailing = betweenHasTrailingComma(between);
 
   String valueString;
   if (hasTrailing) {
@@ -126,23 +126,6 @@ SourceEdit _appendToFlowList(
   }
 
   return SourceEdit(list.span.end.offset - 1, 0, valueString);
-}
-
-bool _betweenHasTrailingComma(String between) {
-  for (var i = 0; i < between.length; i++) {
-    final char = between[i];
-    if (char == '#') {
-      // skip to next newline
-      final nextNewline = between.indexOf('\n', i);
-      if (nextNewline == -1) break;
-      i = nextNewline;
-      continue;
-    }
-    if (char == ',') {
-      return true;
-    }
-  }
-  return false;
 }
 
 /// Returns a [SourceEdit] describing the change to be made on [yamlEdit] to

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -103,8 +103,46 @@ SourceEdit removeInList(YamlEditor yamlEdit, YamlList list, int index) {
 /// flow list.
 SourceEdit _appendToFlowList(
     YamlEditor yamlEdit, YamlList list, YamlNode item) {
-  final valueString = _formatNewFlow(list, item, true);
+  if (list.isEmpty) {
+    final valueString = _formatNewFlow(list, item, true);
+    return SourceEdit(list.span.end.offset - 1, 0, valueString);
+  }
+
+  final yaml = yamlEdit.toString();
+  final lastNode = list.nodes.last;
+  final between =
+      yaml.substring(lastNode.span.end.offset, list.span.end.offset - 1);
+  final hasTrailing = _betweenHasTrailingComma(between);
+
+  String valueString;
+  if (hasTrailing) {
+    valueString = yamlEncodeFlow(item);
+    if (!RegExp(r'\s$').hasMatch(between)) {
+      valueString = ' $valueString';
+    }
+    valueString += ',';
+  } else {
+    valueString = _formatNewFlow(list, item, true);
+  }
+
   return SourceEdit(list.span.end.offset - 1, 0, valueString);
+}
+
+bool _betweenHasTrailingComma(String between) {
+  for (var i = 0; i < between.length; i++) {
+    final char = between[i];
+    if (char == '#') {
+      // skip to next newline
+      final nextNewline = between.indexOf('\n', i);
+      if (nextNewline == -1) break;
+      i = nextNewline;
+      continue;
+    }
+    if (char == ',') {
+      return true;
+    }
+  }
+  return false;
 }
 
 /// Returns a [SourceEdit] describing the change to be made on [yamlEdit] to

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -110,22 +110,38 @@ SourceEdit _appendToFlowList(
 
   final yaml = yamlEdit.toString();
   final lastNode = list.nodes.last;
-  final between =
-      yaml.substring(lastNode.span.end.offset, list.span.end.offset - 1);
+  final closingOffset = list.span.end.offset - 1;
+  final between = yaml.substring(lastNode.span.end.offset, closingOffset);
   final hasTrailing = betweenHasTrailingComma(between);
 
-  String valueString;
+  final valueString = yamlEncodeFlow(item);
+  String formattedValue;
   if (hasTrailing) {
-    valueString = yamlEncodeFlow(item);
-    if (!RegExp(r'\s$').hasMatch(between)) {
-      valueString = ' $valueString';
+    if (between.contains('\n')) {
+      final lineEnding = getLineEnding(yaml);
+      final lastNodeLineStart =
+          yaml.lastIndexOf('\n', lastNode.span.start.offset) + 1;
+      final lastNodeIndent = lastNode.span.start.offset - lastNodeLineStart;
+      final closingLineStart = yaml.lastIndexOf('\n', closingOffset) + 1;
+      final closingIndent = closingOffset - closingLineStart;
+      final extraIndent = lastNodeIndent > closingIndent
+          ? ' ' * (lastNodeIndent - closingIndent)
+          : '';
+      final closingIndentSpaces = ' ' * closingIndent;
+      formattedValue =
+          '$extraIndent$valueString,$lineEnding$closingIndentSpaces';
+    } else {
+      var v = valueString;
+      if (!RegExp(r'\s$').hasMatch(between)) {
+        v = ' $v';
+      }
+      formattedValue = '$v,';
     }
-    valueString += ',';
   } else {
-    valueString = _formatNewFlow(list, item, true);
+    formattedValue = _formatNewFlow(list, item, true);
   }
 
-  return SourceEdit(list.span.end.offset - 1, 0, valueString);
+  return SourceEdit(closingOffset, 0, formattedValue);
 }
 
 /// Returns a [SourceEdit] describing the change to be made on [yamlEdit] to

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -117,6 +117,9 @@ SourceEdit _appendToFlowList(
   final valueString = yamlEncodeFlow(item);
   String formattedValue;
   if (hasTrailing) {
+    // If there is already a trailing comma in the flow list, do not prepend
+    // another comma. If the flow list spans multiple lines with the closing
+    // bracket on a new line, align the new entry with the previous elements.
     if (between.contains('\n')) {
       formattedValue = formatMultilineFlowTrailingEntry(
         closingOffset: closingOffset,

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -118,18 +118,12 @@ SourceEdit _appendToFlowList(
   String formattedValue;
   if (hasTrailing) {
     if (between.contains('\n')) {
-      final lineEnding = getLineEnding(yaml);
-      final lastNodeLineStart =
-          yaml.lastIndexOf('\n', lastNode.span.start.offset) + 1;
-      final lastNodeIndent = lastNode.span.start.offset - lastNodeLineStart;
-      final closingLineStart = yaml.lastIndexOf('\n', closingOffset) + 1;
-      final closingIndent = closingOffset - closingLineStart;
-      final extraIndent = lastNodeIndent > closingIndent
-          ? ' ' * (lastNodeIndent - closingIndent)
-          : '';
-      final closingIndentSpaces = ' ' * closingIndent;
-      formattedValue =
-          '$extraIndent$valueString,$lineEnding$closingIndentSpaces';
+      formattedValue = formatMultilineFlowTrailingEntry(
+        closingOffset: closingOffset,
+        lastEntryStartOffset: lastNode.span.start.offset,
+        newEntry: valueString,
+        yaml: yaml,
+      );
     } else {
       var v = valueString;
       if (!RegExp(r'\s$').hasMatch(between)) {

--- a/pkgs/yaml_edit/lib/src/map_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/map_mutations.dart
@@ -109,7 +109,23 @@ SourceEdit _addToFlowMap(
   final insertionIndex = getMapInsertionIndex(map, keyString);
 
   if (insertionIndex == map.length) {
-    return SourceEdit(map.span.end.offset - 1, 0, ', $keyString: $valueString');
+    final yaml = yamlEdit.toString();
+    final lastNode = map.nodes.values.last;
+    final between =
+        yaml.substring(lastNode.span.end.offset, map.span.end.offset - 1);
+    final hasTrailing = betweenHasTrailingComma(between);
+
+    var formattedValue = '$keyString: $valueString';
+    if (hasTrailing) {
+      if (!RegExp(r'\s$').hasMatch(between)) {
+        formattedValue = ' $formattedValue';
+      }
+      formattedValue += ',';
+    } else {
+      formattedValue = ', $formattedValue';
+    }
+
+    return SourceEdit(map.span.end.offset - 1, 0, formattedValue);
   }
 
   final insertionOffset =

--- a/pkgs/yaml_edit/lib/src/map_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/map_mutations.dart
@@ -119,19 +119,13 @@ SourceEdit _addToFlowMap(
     String formattedValue;
     if (hasTrailing) {
       if (between.contains('\n')) {
-        final lineEnding = getLineEnding(yaml);
         final lastKey = map.nodes.keys.last as YamlNode;
-        final lastKeyLineStart =
-            yaml.lastIndexOf('\n', lastKey.span.start.offset) + 1;
-        final lastKeyIndent = lastKey.span.start.offset - lastKeyLineStart;
-        final closingLineStart = yaml.lastIndexOf('\n', closingOffset) + 1;
-        final closingIndent = closingOffset - closingLineStart;
-        final extraIndent = lastKeyIndent > closingIndent
-            ? ' ' * (lastKeyIndent - closingIndent)
-            : '';
-        final closingIndentSpaces = ' ' * closingIndent;
-        formattedValue =
-            '$extraIndent$entryString,$lineEnding$closingIndentSpaces';
+        formattedValue = formatMultilineFlowTrailingEntry(
+          closingOffset: closingOffset,
+          lastEntryStartOffset: lastKey.span.start.offset,
+          newEntry: entryString,
+          yaml: yaml,
+        );
       } else {
         var v = entryString;
         if (!RegExp(r'\s$').hasMatch(between)) {

--- a/pkgs/yaml_edit/lib/src/map_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/map_mutations.dart
@@ -111,21 +111,39 @@ SourceEdit _addToFlowMap(
   if (insertionIndex == map.length) {
     final yaml = yamlEdit.toString();
     final lastNode = map.nodes.values.last;
-    final between =
-        yaml.substring(lastNode.span.end.offset, map.span.end.offset - 1);
+    final closingOffset = map.span.end.offset - 1;
+    final between = yaml.substring(lastNode.span.end.offset, closingOffset);
     final hasTrailing = betweenHasTrailingComma(between);
 
-    var formattedValue = '$keyString: $valueString';
+    final entryString = '$keyString: $valueString';
+    String formattedValue;
     if (hasTrailing) {
-      if (!RegExp(r'\s$').hasMatch(between)) {
-        formattedValue = ' $formattedValue';
+      if (between.contains('\n')) {
+        final lineEnding = getLineEnding(yaml);
+        final lastKey = map.nodes.keys.last as YamlNode;
+        final lastKeyLineStart =
+            yaml.lastIndexOf('\n', lastKey.span.start.offset) + 1;
+        final lastKeyIndent = lastKey.span.start.offset - lastKeyLineStart;
+        final closingLineStart = yaml.lastIndexOf('\n', closingOffset) + 1;
+        final closingIndent = closingOffset - closingLineStart;
+        final extraIndent = lastKeyIndent > closingIndent
+            ? ' ' * (lastKeyIndent - closingIndent)
+            : '';
+        final closingIndentSpaces = ' ' * closingIndent;
+        formattedValue =
+            '$extraIndent$entryString,$lineEnding$closingIndentSpaces';
+      } else {
+        var v = entryString;
+        if (!RegExp(r'\s$').hasMatch(between)) {
+          v = ' $v';
+        }
+        formattedValue = '$v,';
       }
-      formattedValue += ',';
     } else {
-      formattedValue = ', $formattedValue';
+      formattedValue = ', $entryString';
     }
 
-    return SourceEdit(map.span.end.offset - 1, 0, formattedValue);
+    return SourceEdit(closingOffset, 0, formattedValue);
   }
 
   final insertionOffset =

--- a/pkgs/yaml_edit/lib/src/map_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/map_mutations.dart
@@ -118,6 +118,9 @@ SourceEdit _addToFlowMap(
     final entryString = '$keyString: $valueString';
     String formattedValue;
     if (hasTrailing) {
+      // If there is already a trailing comma in the flow map, do not prepend
+      // another comma. If the flow map spans multiple lines with the closing
+      // brace on a new line, align the new entry with the previous elements.
       if (between.contains('\n')) {
         final lastKey = map.nodes.keys.last as YamlNode;
         formattedValue = formatMultilineFlowTrailingEntry(

--- a/pkgs/yaml_edit/lib/src/utils.dart
+++ b/pkgs/yaml_edit/lib/src/utils.dart
@@ -586,3 +586,21 @@ extension YamlNodeExtension on YamlNode {
     return null;
   }
 }
+
+/// Checks if [between] contains a comma that is not part of a comment.
+bool betweenHasTrailingComma(String between) {
+  for (var i = 0; i < between.length; i++) {
+    final char = between[i];
+    if (char == '#') {
+      // Skip to next newline.
+      final nextNewline = between.indexOf('\n', i);
+      if (nextNewline == -1) break;
+      i = nextNewline;
+      continue;
+    }
+    if (char == ',') {
+      return true;
+    }
+  }
+  return false;
+}

--- a/pkgs/yaml_edit/lib/src/utils.dart
+++ b/pkgs/yaml_edit/lib/src/utils.dart
@@ -604,3 +604,24 @@ bool betweenHasTrailingComma(String between) {
   }
   return false;
 }
+
+/// Formats a new entry [newEntry] for a multiline flow collection with a
+/// trailing comma.
+String formatMultilineFlowTrailingEntry({
+  required int closingOffset,
+  required int lastEntryStartOffset,
+  required String newEntry,
+  required String yaml,
+}) {
+  final lineEnding = getLineEnding(yaml);
+  final lastEntryLineStart = yaml.lastIndexOf('\n', lastEntryStartOffset) + 1;
+  final lastEntryIndent = lastEntryStartOffset - lastEntryLineStart;
+  final closingLineStart = yaml.lastIndexOf('\n', closingOffset) + 1;
+  final closingIndent = closingOffset - closingLineStart;
+  final extraIndent = lastEntryIndent > closingIndent
+      ? ' ' * (lastEntryIndent - closingIndent)
+      : '';
+  final closingIndentSpaces = ' ' * closingIndent;
+
+  return '$extraIndent$newEntry,$lineEnding$closingIndentSpaces';
+}

--- a/pkgs/yaml_edit/lib/src/utils.dart
+++ b/pkgs/yaml_edit/lib/src/utils.dart
@@ -592,7 +592,7 @@ bool betweenHasTrailingComma(String between) {
   for (var i = 0; i < between.length; i++) {
     final char = between[i];
     if (char == '#') {
-      // Skip to next newline.
+      // Skip comments up to the next newline.
       final nextNewline = between.indexOf('\n', i);
       if (nextNewline == -1) break;
       i = nextNewline;
@@ -607,6 +607,10 @@ bool betweenHasTrailingComma(String between) {
 
 /// Formats a new entry [newEntry] for a multiline flow collection with a
 /// trailing comma.
+///
+/// Ensures the new entry matches the indentation of the previous entry and
+/// that the closing delimiter (closing bracket/brace) remains on its own line
+/// with its original indentation.
 String formatMultilineFlowTrailingEntry({
   required int closingOffset,
   required int lastEntryStartOffset,

--- a/pkgs/yaml_edit/test/append_test.dart
+++ b/pkgs/yaml_edit/test/append_test.dart
@@ -278,7 +278,8 @@ a:
 [
   0,
   1,
-2,]
+  2,
+]
 '''));
       expectYamlBuilderValue(doc, [0, 1, 2]);
     });
@@ -295,9 +296,36 @@ a:
 [
   0,
   1, # comment
-2,]
+  2,
+]
 '''));
       expectYamlBuilderValue(doc, [0, 1, 2]);
+    });
+
+    test('nested flow list spanning multiple lines with trailing comma', () {
+      final doc = YamlEditor('''
+analyzer:
+  exclude:
+    [
+      foo/**,
+      build/**,
+    ]
+''');
+      doc.appendToList(['analyzer', 'exclude'], 'android/**');
+      expect(doc.toString(), equals('''
+analyzer:
+  exclude:
+    [
+      foo/**,
+      build/**,
+      android/**,
+    ]
+'''));
+      expectYamlBuilderValue(doc, {
+        'analyzer': {
+          'exclude': ['foo/**', 'build/**', 'android/**']
+        }
+      });
     });
 
     test('spanning multiple lines without trailing comma', () {

--- a/pkgs/yaml_edit/test/append_test.dart
+++ b/pkgs/yaml_edit/test/append_test.dart
@@ -265,5 +265,70 @@ a:
       expect(doc.toString(), equals('[0]'));
       expectYamlBuilderValue(doc, [0]);
     });
+
+    test('spanning multiple lines with trailing comma', () {
+      final doc = YamlEditor('''
+[
+  0,
+  1,
+]
+''');
+      doc.appendToList([], 2);
+      expect(doc.toString(), equals('''
+[
+  0,
+  1,
+2,]
+'''));
+      expectYamlBuilderValue(doc, [0, 1, 2]);
+    });
+
+    test('spanning multiple lines with trailing comma and comment', () {
+      final doc = YamlEditor('''
+[
+  0,
+  1, # comment
+]
+''');
+      doc.appendToList([], 2);
+      expect(doc.toString(), equals('''
+[
+  0,
+  1, # comment
+2,]
+'''));
+      expectYamlBuilderValue(doc, [0, 1, 2]);
+    });
+
+    test('spanning multiple lines without trailing comma', () {
+      final doc = YamlEditor('''
+[
+  0,
+  1
+]
+''');
+      doc.appendToList([], 2);
+      expect(doc.toString(), equals('''
+[
+  0,
+  1
+, 2]
+'''));
+      expectYamlBuilderValue(doc, [0, 1, 2]);
+    });
+
+    test('single line with trailing comma', () {
+      final doc = YamlEditor('[0, 1, ]');
+      doc.appendToList([], 2);
+      expect(doc.toString(), equals('[0, 1, 2,]'));
+      expectYamlBuilderValue(doc, [0, 1, 2]);
+    });
+
+    test('single line with trailing comma (no space)', () {
+      final doc = YamlEditor('[0,1,]');
+      doc.appendToList([], 2);
+      expect(doc.toString(), equals('[0,1, 2,]'));
+      expectYamlBuilderValue(doc, [0, 1, 2]);
+    });
   });
 }

--- a/pkgs/yaml_edit/test/update_test.dart
+++ b/pkgs/yaml_edit/test/update_test.dart
@@ -736,7 +736,8 @@ c: 3
 {
   a: 1,
   b: 2,
-c: 3,}
+  c: 3,
+}
 '''));
         expectYamlBuilderValue(doc, {'a': 1, 'b': 2, 'c': 3});
       });
@@ -753,9 +754,36 @@ c: 3,}
 {
   a: 1,
   b: 2, # comment
-c: 3,}
+  c: 3,
+}
 '''));
         expectYamlBuilderValue(doc, {'a': 1, 'b': 2, 'c': 3});
+      });
+
+      test('nested flow map spanning multiple lines with trailing comma', () {
+        final doc = YamlEditor('''
+analyzer:
+  exclude:
+    {
+      foo: 1,
+      build: 2,
+    }
+''');
+        doc.update(['analyzer', 'exclude', 'android'], 3);
+        expect(doc.toString(), equals('''
+analyzer:
+  exclude:
+    {
+      foo: 1,
+      build: 2,
+      android: 3,
+    }
+'''));
+        expectYamlBuilderValue(doc, {
+          'analyzer': {
+            'exclude': {'foo': 1, 'build': 2, 'android': 3}
+          }
+        });
       });
 
       test('spanning multiple lines without trailing comma', () {

--- a/pkgs/yaml_edit/test/update_test.dart
+++ b/pkgs/yaml_edit/test/update_test.dart
@@ -723,6 +723,71 @@ c: 3
           'YAML': "YAML Ain't Markup Language",
         });
       });
+
+      test('spanning multiple lines with trailing comma', () {
+        final doc = YamlEditor('''
+{
+  a: 1,
+  b: 2,
+}
+''');
+        doc.update(['c'], 3);
+        expect(doc.toString(), equals('''
+{
+  a: 1,
+  b: 2,
+c: 3,}
+'''));
+        expectYamlBuilderValue(doc, {'a': 1, 'b': 2, 'c': 3});
+      });
+
+      test('spanning multiple lines with trailing comma and comment', () {
+        final doc = YamlEditor('''
+{
+  a: 1,
+  b: 2, # comment
+}
+''');
+        doc.update(['c'], 3);
+        expect(doc.toString(), equals('''
+{
+  a: 1,
+  b: 2, # comment
+c: 3,}
+'''));
+        expectYamlBuilderValue(doc, {'a': 1, 'b': 2, 'c': 3});
+      });
+
+      test('spanning multiple lines without trailing comma', () {
+        final doc = YamlEditor('''
+{
+  a: 1,
+  b: 2
+}
+''');
+        doc.update(['c'], 3);
+        expect(doc.toString(), equals('''
+{
+  a: 1,
+  b: 2
+, c: 3}
+'''));
+        expectYamlBuilderValue(doc, {'a': 1, 'b': 2, 'c': 3});
+      });
+
+      test('single line with trailing comma', () {
+        final doc = YamlEditor('{a: 1, b: 2, }');
+        doc.update(['c'], 3);
+        expect(doc.toString(), equals('{a: 1, b: 2, c: 3,}'));
+        expectYamlBuilderValue(doc, {'a': 1, 'b': 2, 'c': 3});
+      });
+
+      test('single line with trailing comma (no space)', () {
+        final doc = YamlEditor('{a: 1, b: 2,}');
+        doc.update(['c'], 3);
+        expect(doc.toString(), equals('{a: 1, b: 2, c: 3,}'));
+        expectYamlBuilderValue(doc, {'a': 1, 'b': 2, 'c': 3});
+      });
     });
 
     group('block map', () {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/tools/issues/2532

### Problem
When appending elements to a flow list (`[...]`) or adding keys to a flow map (`{...}`) that contains a trailing comma, `yaml_edit` unconditionally prepended a comma without checking for the existing trailing comma. This produced invalid double-comma syntax (e.g. `, \n , android/**]`), failing internal YAML parsing validation with an assertion error.

Furthermore, multiline flow collections with trailing commas had their newly appended elements and closing delimiters misaligned on column 0.

### Solution
1. **Trailing Comma Detection**:
   - Added `betweenHasTrailingComma` in `pkgs/yaml_edit/lib/src/utils.dart` to check if a comma exists between the last element and the closing delimiter while ignoring comments (`# ...`).
   - If a trailing comma is present, `_appendToFlowList` and `_addToFlowMap` avoid prepending an extra comma and preserve the trailing comma style.
2. **Multiline Indentation Alignment**:
   - Added `formatMultilineFlowTrailingEntry` in `pkgs/yaml_edit/lib/src/utils.dart` to calculate the indentation difference between collection elements and the closing delimiter.
   - Newly appended items in multiline flow lists and maps are now indented to match preceding entries, with the closing delimiter remaining on its own indented line.
3. **Tests**:
   - Added unit tests covering multiline flow lists/maps with and without trailing commas, comments, and nested structures in `pkgs/yaml_edit/test/append_test.dart` and `pkgs/yaml_edit/test/update_test.dart`.
4. **Changelog**:
   - Updated `pkgs/yaml_edit/CHANGELOG.md`.
