### PR TITLE
fix(coverage): reject file: URIs outside known roots in Resolver

### DIFF
--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -8,9 +8,7 @@
   collection, matching the existing `RPCError` handling there.
 - `Resolver.resolve` now rejects `file:` URIs that fall outside the known
   package/SDK roots or the current directory, instead of resolving them
-  unconditionally. A `source` entry in coverage data pointing at an arbitrary
-  file (for example `file:///etc/passwd`) previously had its contents read
-  and printed by `format_coverage --pretty-print`.
+  unconditionally.
 
 ## 1.15.1
 

--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -6,6 +6,11 @@
   completing and the resume request reaching the VM service.
 - Also ignore `SentinelException` when resuming the main isolate after
   collection, matching the existing `RPCError` handling there.
+- `Resolver.resolve` now rejects `file:` URIs that fall outside the known
+  package/SDK roots or the current directory, instead of resolving them
+  unconditionally. A `source` entry in coverage data pointing at an arbitrary
+  file (for example `file:///etc/passwd`) previously had its contents read
+  and printed by `format_coverage --pretty-print`.
 
 ## 1.15.1
 

--- a/pkgs/coverage/lib/src/resolver.dart
+++ b/pkgs/coverage/lib/src/resolver.dart
@@ -119,8 +119,8 @@ class Resolver {
 
   bool _isWithinKnownRoots(String path) {
     final roots = _knownRoots ??= [
-      if (packagePath != null) packagePath!,
-      if (sdkRoot != null) sdkRoot!,
+      ?packagePath,
+      ?sdkRoot,
       ...?_packages?.values.map(p.fromUri),
       Directory.current.path,
     ].map(p.normalize).toList();

--- a/pkgs/coverage/lib/src/resolver.dart
+++ b/pkgs/coverage/lib/src/resolver.dart
@@ -89,7 +89,9 @@ class Resolver {
       return resolveSymbolicLinks(p.join(packagePath, pathInPackage));
     }
     if (uri.scheme == 'file') {
-      return resolveSymbolicLinks(p.fromUri(uri));
+      final resolved = resolveSymbolicLinks(p.fromUri(uri));
+      if (resolved == null || !_isWithinKnownRoots(resolved)) return null;
+      return resolved;
     }
     // We cannot deal with anything else.
     failed.add('$uri');
@@ -102,6 +104,30 @@ class Resolver {
     final type = FileSystemEntity.typeSync(normalizedPath, followLinks: true);
     if (type == FileSystemEntityType.notFound) return null;
     return File(normalizedPath).resolveSymbolicLinksSync();
+  }
+
+  /// The directories a `file:` URI is allowed to resolve into.
+  ///
+  /// `source` entries in coverage data are supplied by whatever produced the
+  /// coverage JSON, which this library treats as untrusted input: nothing
+  /// stops a crafted `file://` URI from pointing anywhere on disk, and
+  /// callers (`format_coverage --pretty-print`, `filterIgnored`) read the
+  /// resolved path's contents into their output. Without this check, a
+  /// coverage.json with `"source": "file:///etc/passwd"` gets that file's
+  /// contents printed straight into the coverage report.
+  List<String>? _knownRoots;
+
+  bool _isWithinKnownRoots(String path) {
+    final roots = _knownRoots ??= [
+      ?packagePath,
+      ?sdkRoot,
+      ...?_packages?.values.map(p.fromUri),
+      Directory.current.path,
+    ].map(p.normalize).toList();
+    final normalized = p.normalize(path);
+    return roots.any(
+      (root) => normalized == root || p.isWithin(root, normalized),
+    );
   }
 
   static Map<String, Uri> _parsePackages(String packagesPath) {

--- a/pkgs/coverage/lib/src/resolver.dart
+++ b/pkgs/coverage/lib/src/resolver.dart
@@ -119,8 +119,8 @@ class Resolver {
 
   bool _isWithinKnownRoots(String path) {
     final roots = _knownRoots ??= [
-      ?packagePath,
-      ?sdkRoot,
+      if (packagePath != null) packagePath!,
+      if (sdkRoot != null) sdkRoot!,
       ...?_packages?.values.map(p.fromUri),
       Directory.current.path,
     ].map(p.normalize).toList();

--- a/pkgs/coverage/test/resolver_test.dart
+++ b/pkgs/coverage/test/resolver_test.dart
@@ -142,6 +142,41 @@ void main() {
       expect(resolver.resolve(p.toUri(fooDartPath).toString()), fooDartPath);
     });
 
+    test('resolves file URIs within sdkRoot', () async {
+      final resolver = await Resolver.create(
+        packagePath: p.join(d.sandbox, 'foo'),
+        sdkRoot: p.join(d.sandbox, 'sdk'),
+      );
+      final ioDartPath = p.join(d.sandbox, 'sdk', 'io', 'io.dart');
+      expect(resolver.resolve(p.toUri(ioDartPath).toString()), ioDartPath);
+    });
+
+    test('resolves file URIs within a known package root', () async {
+      final resolver = await Resolver.create(
+        packagesPath: p.join(
+          d.sandbox,
+          'foo',
+          '.dart_tool',
+          'package_config.json',
+        ),
+      );
+      final barDartPath = p.join(d.sandbox, 'bar', 'lib', 'bar.dart');
+      expect(resolver.resolve(p.toUri(barDartPath).toString()), barDartPath);
+    });
+
+    test('resolves file URIs within the current directory', () async {
+      final resolver = await Resolver.create();
+      final currentDirFile = File(
+        p.join(Directory.current.path, 'resolver_test_current_dir_probe.txt'),
+      )..writeAsStringSync('inside cwd');
+      addTearDown(currentDirFile.deleteSync);
+
+      expect(
+        resolver.resolve(p.toUri(currentDirFile.path).toString()),
+        currentDirFile.path,
+      );
+    });
+
     test('does not resolve file URIs outside every known root', () async {
       final resolver = await Resolver.create(
         packagePath: p.join(d.sandbox, 'foo'),

--- a/pkgs/coverage/test/resolver_test.dart
+++ b/pkgs/coverage/test/resolver_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:coverage/src/resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -130,6 +132,30 @@ void main() {
         packagePath: p.join(d.sandbox, 'foo'),
       );
       expect(resolver.resolve('thing:foo/foo.dart'), null);
+    });
+
+    test('resolves file URIs within a known root', () async {
+      final resolver = await Resolver.create(
+        packagePath: p.join(d.sandbox, 'foo'),
+      );
+      final fooDartPath = p.join(d.sandbox, 'foo', 'lib', 'foo.dart');
+      expect(resolver.resolve(p.toUri(fooDartPath).toString()), fooDartPath);
+    });
+
+    test('does not resolve file URIs outside every known root', () async {
+      final resolver = await Resolver.create(
+        packagePath: p.join(d.sandbox, 'foo'),
+        sdkRoot: p.join(d.sandbox, 'sdk'),
+      );
+      final outsideFile = File(
+        p.join(
+          Directory.systemTemp.createTempSync('coverage_test_').path,
+          'secret.txt',
+        ),
+      )..writeAsStringSync('should not leak');
+      addTearDown(() => outsideFile.parent.deleteSync(recursive: true));
+
+      expect(resolver.resolve(p.toUri(outsideFile.path).toString()), null);
     });
   });
 

--- a/pkgs/coverage/test/resolver_test.dart
+++ b/pkgs/coverage/test/resolver_test.dart
@@ -147,13 +147,8 @@ void main() {
         packagePath: p.join(d.sandbox, 'foo'),
         sdkRoot: p.join(d.sandbox, 'sdk'),
       );
-      final outsideFile = File(
-        p.join(
-          Directory.systemTemp.createTempSync('coverage_test_').path,
-          'secret.txt',
-        ),
-      )..writeAsStringSync('should not leak');
-      addTearDown(() => outsideFile.parent.deleteSync(recursive: true));
+      final outsideFile = File(p.join(d.sandbox, 'outside.txt'))
+        ..writeAsStringSync('should not leak');
 
       expect(resolver.resolve(p.toUri(outsideFile.path).toString()), null);
     });


### PR DESCRIPTION
`Resolver.resolve` handled the `file:` scheme by resolving the URI straight to a path and returning it, with no check that the path was anywhere near the project being covered:

```dart
if (uri.scheme == 'file') {
  return resolveSymbolicLinks(p.fromUri(uri));
}
```

The `source` field in coverage data is supplied by whatever produced the coverage JSON, and `format_coverage --pretty-print` (`formatter.dart`) reads the resolved path's content into its output:

```dart
final source = resolver.resolve(entry.key);
...
final lines = await loader.load(source);
...
buf.writeln('$prefix|${lines[line - 1]}');
```

So a coverage.json containing `"source": "file:///etc/passwd"` gets that file's content read and printed straight into the generated coverage report. I verified this by running the real `format_coverage` CLI against a crafted coverage.json pointing at a file outside the project. The file's content appeared in the pretty-printed report, unmodified.

The `package:` and `dart:` branches aren't affected. They resolve relative to a known package or SDK root, and a `package:` URI can't traverse out either, since `Uri.parse` already collapses `..` segments in the path before `Resolver` ever sees them (`Uri.parse('package:foo/../../bar.dart').pathSegments` is `[bar.dart]`, not `[.., .., bar.dart]`).

The fix adds a containment check for the `file:` branch, allowing a resolved path only if it falls under `packagePath`, `sdkRoot`, one of the known package roots, or the current working directory:

```dart
if (uri.scheme == 'file') {
  final resolved = resolveSymbolicLinks(p.fromUri(uri));
  if (resolved == null || !_isWithinKnownRoots(resolved)) return null;
  return resolved;
}
```

`null` is already an existing, handled outcome elsewhere in this method for URIs it can't resolve, so callers don't need any changes.

Added a test that constructs a file outside every one of those roots and confirms it no longer resolves, and a companion test confirming a `file:` URI inside `packagePath` still resolves normally. I confirmed the new rejection test fails without the fix and passes with it, by temporarily reverting just the `resolve` method and rerunning.

`dart analyze` and `dart format --set-exit-if-changed` are clean on both touched files, and the full `pkgs/coverage` test suite (139 tests) passes.
