### PR TITLE
fix(markdown): avoid quadratic parse time on long unbroken words

### DIFF
--- a/pkgs/markdown/CHANGELOG.md
+++ b/pkgs/markdown/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 7.4.1-wip
 
+* Fix quadratic parsing time on a long unbroken run of word characters (for
+  example a single very long word). The plain-text accelerator regex required
+  a trailing whitespace, so a run reaching the end of a line without one
+  backtracked across the whole run at every position.
+
 ## 7.4.0
 
 * Adds `linkBuilder`/`imageLinkBuilder` alternatives to `linkResolver`/  

--- a/pkgs/markdown/lib/src/inline_parser.dart
+++ b/pkgs/markdown/lib/src/inline_parser.dart
@@ -67,11 +67,18 @@ class InlineParser {
     // Markdown is plain text, so it's faster to match one RegExp per 'word'
     // rather than fail to match all the following RegExps at each non-syntax
     // character position.
+    // The `(?=\s|$)` lookahead lets the run stop before whitespace or at the
+    // end of a line. Without the `$` alternative a run that reaches the end of
+    // a line without a trailing whitespace (for example a single long word)
+    // fails the lookahead only after the greedy `*`/`+` has consumed the rest
+    // of the line, then backtracks one character at a time, and the parser
+    // retries from the next position, giving quadratic behavior on long
+    // unbroken runs. Allowing the run to end at `$` makes it match in one step.
     if (document.hasCustomInlineSyntaxes) {
       // We should be less aggressive in blowing past "words".
-      syntaxes.add(TextSyntax(r'[A-Za-z0-9]+(?=\s)'));
+      syntaxes.add(TextSyntax(r'[A-Za-z0-9]+(?=\s|$)'));
     } else {
-      syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s)'));
+      syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s|$)'));
     }
 
     if (document.withDefaultInlineSyntaxes) {

--- a/pkgs/markdown/test/regression_test.dart
+++ b/pkgs/markdown/test/regression_test.dart
@@ -66,4 +66,18 @@ a <!--
     );
     expect(html, '<h2>I am paragraph</h2>\n');
   });
+
+  test('long unbroken word does not take quadratic time', () {
+    // The plain-text accelerator regex required a trailing whitespace, so a
+    // long run of word characters that reached the end of a line without one
+    // (a single long word) forced the regex to backtrack across the whole run
+    // at every position, giving quadratic parse time. A ~200k character word
+    // used to take tens of seconds; it should now be effectively instant.
+    final input = '${'a' * 200000}\n';
+
+    final time = Stopwatch()..start();
+    final html = markdownToHtml(input); // Should not hang.
+    expect(html, isNotNull); // To use the output.
+    expect(time.elapsedMilliseconds, lessThan(10000));
+  });
 }


### PR DESCRIPTION
The inline parser adds a plain-text "accelerator" regex that fast-forwards runs of word characters. Both variants require a trailing whitespace:

```dart
if (document.hasCustomInlineSyntaxes) {
  syntaxes.add(TextSyntax(r'[A-Za-z0-9]+(?=\s)'));
} else {
  syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s)'));
}
```

When a run of word characters reaches the end of a line without a trailing whitespace, for example a single long word, the greedy `*`/`+` consumes the whole run, the `(?=\s)` lookahead fails, and the engine backtracks one character at a time. The parser then advances one position and repeats the full scan, so parsing is quadratic in the length of the run.

`markdownToHtml` on a single long word, no spaces:

```
32,000 chars  : 12,926 ms
16,000 chars  :  3,131 ms
 8,000 chars  :    823 ms
```

The same character count split into short words is under 1 ms, confirming it is the unbroken run, not the length, that is slow. This is easy to reach with untrusted input (a long URL, a base64 blob, or any unbroken token in user-supplied markdown), so it is a denial-of-service risk for anything rendering markdown it did not author.

The fix lets the run also end at `$`, so it matches in a single step when it reaches the end of a line:

```dart
syntaxes.add(TextSyntax(r'[A-Za-z0-9]+(?=\s|$)'));
...
syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s|$)'));
```

The match content is unchanged. A trailing word with no following whitespace was already emitted as plain text, just one character at a time. After the fix a 2,000,000-character word parses in 35 ms.

The full suite (2763 tests, including the CommonMark and GFM conformance suites) passes unchanged, and a regression test in `test/regression_test.dart` parses a 200k-character word and asserts it finishes well under the old timings. `dart analyze --fatal-infos` and `dart format --set-exit-if-changed` are clean.
