### PR TITLE
Fix UNC path injection vulnerability

### DIFF
--- a/pkgs/package_config/CHANGELOG.md
+++ b/pkgs/package_config/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.0.1-wip
 
+- Enforce a "Same-Origin Policy" on `rootUri` to mitigate UNC path injection ([SMB NTLM leak](https://attack.mitre.org/techniques/T1187/)) on Windows.
+
 ## 3.0.0
 
 - Adds discovery API to find both a configuration and its location:

--- a/pkgs/package_config/lib/src/package_config_json.dart
+++ b/pkgs/package_config/lib/src/package_config_json.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 
 import 'errors.dart';
 import 'package_config.dart';
+import 'platform.dart' if (dart.library.io) 'platform_io.dart';
 import 'util.dart';
 
 const String _configVersionKey = 'configVersion';
@@ -154,6 +155,27 @@ PackageConfig parsePackageConfigJson(
     var parsedRootUri = Uri.parse(rootUri!);
     var relativeRoot = !hasAbsolutePath(parsedRootUri);
     var root = baseLocation.resolveUri(parsedRootUri);
+
+    if (root.hasAuthority && root.host != baseLocation.host) {
+      String errorMessage;
+      if (isWindows) {
+        var expected =
+            baseLocation.hasAuthority ? '"${baseLocation.host}"' : 'empty';
+        errorMessage = 'Package root URIs cannot contain a different host (authority) '
+            'than the workspace.\n'
+            'Expected host to be $expected, but found "${root.host}".\n'
+            'If you are using a network share for your dependencies or '
+            'PUB_CACHE, please mount that share as a local drive letter '
+            '(e.g., Z:\\).';
+      } else {
+        errorMessage = 'Package root URIs cannot contain a host (authority) component. '
+            'The rootUri must be a local file path. '
+            'Found invalid host: "${root.host}".';
+      }
+      onError(PackageConfigFormatException(errorMessage, entry));
+      return null;
+    }
+
     if (!root.path.endsWith('/')) root = root.replace(path: '${root.path}/');
     var packageRoot = root;
     if (packageUri != null) packageRoot = root.resolve(packageUri!);

--- a/pkgs/package_config/lib/src/package_config_json.dart
+++ b/pkgs/package_config/lib/src/package_config_json.dart
@@ -160,7 +160,7 @@ PackageConfig parsePackageConfigJson(
       String errorMessage;
       if (isWindows) {
         var expected =
-            baseLocation.hasAuthority ? '"${baseLocation.host}"' : 'empty';
+            baseLocation.host.isNotEmpty ? '"${baseLocation.host}"' : 'empty';
         errorMessage = 'Package root URIs cannot contain a different host (authority) '
             'than the workspace.\n'
             'Expected host to be $expected, but found "${root.host}".\n'

--- a/pkgs/package_config/lib/src/platform.dart
+++ b/pkgs/package_config/lib/src/platform.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Whether the current operating system is Windows.
+/// 
+/// Used to provide OS-tailored error messages for package configuration issues.
+/// This acts as a platform-agnostic fallback when `dart:io` is unavailable.
+bool get isWindows => false;

--- a/pkgs/package_config/lib/src/platform_io.dart
+++ b/pkgs/package_config/lib/src/platform_io.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+/// Whether the current operating system is Windows.
+/// 
+/// Used to provide OS-tailored error messages for package configuration issues.
+bool get isWindows => Platform.isWindows;


### PR DESCRIPTION
On Windows a `package_config.json`, crafted by a malicious actor, can point to an external UNC network share (e.g. `"rootUri": "//attacker.example.com/share/"`). 

Downstream tools (`analyzer`, `pub`, etc) that attempt to read from such a path (or just `File.statSync`) may trigger Windows to initiate an SMB request which the attacker can use to [record the user's account hashes](https://attack.mitre.org/techniques/T1187/).

To mitigate this issue, we require that URIs inside `package_config.json` must be a local file path, or point to a location within the same network share that the `package_config.json` is stored on.

This means that `package_config.json` on a local file path, cannot reference external network shares. And a `package_config.json` on one network share cannot reference a different external network share. Mimicking the "Same-Origin Policy" browsers implement.

For users who legitimately have `package_config.json` on one network share and their `PUB_CACHE` on a different network share, the solution is to mount these network shares as local drive letters (like `Z:\`).


BUG=536309083
