### PR TITLE
Add a field to Event.dartMCPEvent to track plugin usage

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.17
+- Added optional `agentPlugin` parameter to the `Event.dartMCPEvent` constructor to identify 
+agent plugin usage.
+
 ## 8.0.16
 
 - Added `Event.packageSkillsEvent` to track events from package:skills.

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -1105,7 +1105,7 @@ final class Event {
            'clientVersion': clientVersion,
            'serverVersion': serverVersion,
            'type': type,
-           'agentPlugin': agentPlugin,
+           'agentPlugin': ?agentPlugin,
            ...?additionalData?.toMap(),
          },
        );

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -1088,11 +1088,15 @@ final class Event {
   ///
   /// The [type] identifies the kind of event this is, and [additionalData] is
   /// the actual data for the event.
+  ///
+  /// The [agentPlugin] is optional and is the name of the agent plugin that is
+  /// using the MCP server.
   Event.dartMCPEvent({
     required String client,
     required String clientVersion,
     required String serverVersion,
     required String type,
+    String? agentPlugin,
     CustomMetrics? additionalData,
   }) : this._(
          eventName: DashEvent.dartMCPEvent,
@@ -1101,6 +1105,7 @@ final class Event {
            'clientVersion': clientVersion,
            'serverVersion': serverVersion,
            'type': type,
+           'agentPlugin': agentPlugin,
            ...?additionalData?.toMap(),
          },
        );


### PR DESCRIPTION
Add a field to the dart MCP event to track events from plugin installs.
