### PR TITLE
feat(cli_util): support AOT SDK discovery with nullable getters

### DIFF
--- a/pkgs/cli_util/CHANGELOG.md
+++ b/pkgs/cli_util/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.6.0-wip
+
+- **Breaking Change**: `sdkPath` now returns `String?` (returning `null` if no
+  valid Dart SDK can be located).
+- Support robust SDK discovery for AOT-compiled tools (`dart install`,
+  `dart build cli`) probing `Platform.resolvedExecutable`, `DART_ROOT`,
+  `DART_SDK`, system `PATH` (with Flutter wrapper layout awareness), and
+  `FLUTTER_ROOT`.
+- Add `dartExecutable` getter (`String?`) to locate the `dart` binary.
+- Add `isValidSdkPath(String candidatePath)` validation helper.
+
 ## 0.5.2
 
 - Add a legend to multiselect dialogs to make the usage more obvious.

--- a/pkgs/cli_util/lib/cli_util.dart
+++ b/pkgs/cli_util/lib/cli_util.dart
@@ -59,6 +59,7 @@ String? getSdkPath() => sdkPath;
 
 /// Checks whether [candidatePath] represents a valid Dart SDK directory layout.
 bool isValidSdkPath(String candidatePath) {
+  if (candidatePath.isEmpty) return false;
   final hasLibrariesJson =
       File(path.join(candidatePath, 'lib', 'libraries.json')).existsSync();
   final hasAllowedExperiments =
@@ -88,12 +89,12 @@ String? _resolveSdkPath() {
   // Tier 1: DART_ROOT and DART_SDK environment variables (explicit overrides)
   final dartRoot = _env['DART_ROOT'];
   if (dartRoot != null && dartRoot.isNotEmpty && isValidSdkPath(dartRoot)) {
-    return dartRoot;
+    return path.absolute(dartRoot);
   }
 
   final dartSdk = _env['DART_SDK'];
   if (dartSdk != null && dartSdk.isNotEmpty && isValidSdkPath(dartSdk)) {
-    return dartSdk;
+    return path.absolute(dartSdk);
   }
 
   // Tier 2: Platform.resolvedExecutable (Fast path for JIT VM)
@@ -102,55 +103,36 @@ String? _resolveSdkPath() {
   if (executablePath.isNotEmpty) {
     final candidate = path.dirname(path.dirname(executablePath));
     if (isValidSdkPath(candidate)) {
-      return candidate;
+      return path.absolute(candidate);
     }
   }
 
   // Tier 3: PATH traversal with Flutter cache awareness
-  final pathEnv = _env['PATH'];
-  if (pathEnv != null && pathEnv.isNotEmpty) {
-    final separator = Platform.isWindows ? ';' : ':';
-    final entries = pathEnv.split(separator);
+  for (final candidateExe in _getExecutablePaths('dart')) {
+    final file = File(candidateExe);
+    if (file.existsSync()) {
+      String resolved;
+      try {
+        resolved = file.resolveSymbolicLinksSync();
+      } on FileSystemException {
+        resolved = candidateExe;
+      }
 
-    final extensions =
-        Platform.isWindows
-            ? (_env['PATHEXT']
-                    ?.split(';')
-                    .where((e) => e.isNotEmpty)
-                    .toList() ??
-                const ['.exe', '.bat', '.cmd'])
-            : const [''];
+      // Direct SDK root check
+      final candidateSdk = path.dirname(path.dirname(resolved));
+      if (isValidSdkPath(candidateSdk)) {
+        return path.absolute(candidateSdk);
+      }
 
-    for (final entry in entries) {
-      if (entry.isEmpty) continue;
-      for (final ext in extensions) {
-        final candidateExe = path.join(entry, 'dart$ext');
-        final file = File(candidateExe);
-        if (file.existsSync()) {
-          String resolved;
-          try {
-            resolved = file.resolveSymbolicLinksSync();
-          } on FileSystemException {
-            resolved = candidateExe;
-          }
-
-          // Direct SDK root check
-          final candidateSdk = path.dirname(path.dirname(resolved));
-          if (isValidSdkPath(candidateSdk)) {
-            return candidateSdk;
-          }
-
-          // Flutter wrapper check (e.g. flutter/bin/dart -> flutter/bin/cache/dart-sdk)
-          final flutterCacheSdk = path.join(
-            candidateSdk,
-            'bin',
-            'cache',
-            'dart-sdk',
-          );
-          if (isValidSdkPath(flutterCacheSdk)) {
-            return flutterCacheSdk;
-          }
-        }
+      // Flutter wrapper check (e.g. flutter/bin/dart -> flutter/bin/cache/dart-sdk)
+      final flutterCacheSdk = path.join(
+        candidateSdk,
+        'bin',
+        'cache',
+        'dart-sdk',
+      );
+      if (isValidSdkPath(flutterCacheSdk)) {
+        return path.absolute(flutterCacheSdk);
       }
     }
   }
@@ -160,7 +142,7 @@ String? _resolveSdkPath() {
   if (flutterRoot != null && flutterRoot.isNotEmpty) {
     final flutterSdk = path.join(flutterRoot, 'bin', 'cache', 'dart-sdk');
     if (isValidSdkPath(flutterSdk)) {
-      return flutterSdk;
+      return path.absolute(flutterSdk);
     }
   }
 
@@ -172,36 +154,46 @@ String? _resolveDartExecutable() {
   if (sdk != null) {
     final exe = path.join(sdk, 'bin', Platform.isWindows ? 'dart.exe' : 'dart');
     if (File(exe).existsSync()) {
-      return exe;
+      return path.absolute(exe);
     }
   }
 
   // Fallback: search PATH directly if SDK structure wasn't complete
-  final pathEnv = _env['PATH'];
-  if (pathEnv != null && pathEnv.isNotEmpty) {
-    final separator = Platform.isWindows ? ';' : ':';
-    final entries = pathEnv.split(separator);
-    final extensions =
-        Platform.isWindows
-            ? (_env['PATHEXT']
-                    ?.split(';')
-                    .where((e) => e.isNotEmpty)
-                    .toList() ??
-                const ['.exe', '.bat', '.cmd'])
-            : const [''];
-
-    for (final entry in entries) {
-      if (entry.isEmpty) continue;
-      for (final ext in extensions) {
-        final candidate = path.join(entry, 'dart$ext');
-        if (File(candidate).existsSync()) {
-          return candidate;
-        }
-      }
+  for (final candidate in _getExecutablePaths('dart')) {
+    if (File(candidate).existsSync()) {
+      return path.absolute(candidate);
     }
   }
 
   return null;
+}
+
+Iterable<String> _getExecutablePaths(String executableName) sync* {
+  final pathEnv = _env['PATH'];
+  if (pathEnv == null || pathEnv.isEmpty) return;
+
+  final separator = Platform.isWindows ? ';' : ':';
+  final entries = pathEnv.split(separator);
+
+  final extensions =
+      Platform.isWindows
+          ? (_env['PATHEXT']?.split(';').where((e) => e.isNotEmpty).toList() ??
+              const ['.exe', '.bat', '.cmd', ''])
+          : const [''];
+
+  for (final entry in entries) {
+    if (entry.isEmpty) continue;
+    var cleanEntry = entry.trim();
+    if (cleanEntry.startsWith('"') &&
+        cleanEntry.endsWith('"') &&
+        cleanEntry.length >= 2) {
+      cleanEntry = cleanEntry.substring(1, cleanEntry.length - 1).trim();
+    }
+    if (cleanEntry.isEmpty) continue;
+    for (final ext in extensions) {
+      yield path.join(cleanEntry, '$executableName$ext');
+    }
+  }
 }
 
 /// The user-specific application configuration folder for the current platform.

--- a/pkgs/cli_util/lib/cli_util.dart
+++ b/pkgs/cli_util/lib/cli_util.dart
@@ -12,12 +12,197 @@ import 'package:path/path.dart' as path;
 
 export 'src/base_directories.dart';
 
-/// The path to the current Dart SDK.
-String get sdkPath => path.dirname(path.dirname(Platform.resolvedExecutable));
+/// The path to the root of the Dart SDK, or `null` if no SDK could be located.
+///
+/// Probes the host environment across four tiers (memoized on first access):
+/// 1. `Platform.resolvedExecutable` (active JIT VM runtime)
+/// 2. `DART_ROOT` and `DART_SDK` environment variables
+/// 3. `PATH` environment variable traversal (dereferencing symlinks and
+///    checking Flutter cache layouts)
+/// 4. `FLUTTER_ROOT/bin/cache/dart-sdk` fallback
+String? get sdkPath {
+  if (Zone.current[#environmentOverrides] != null) {
+    return _resolveSdkPath();
+  }
+  if (!_sdkPathResolved) {
+    _cachedSdkPath = _resolveSdkPath();
+    _sdkPathResolved = true;
+  }
+  return _cachedSdkPath;
+}
+
+String? _cachedSdkPath;
+bool _sdkPathResolved = false;
+
+/// The path to the `dart` executable, or `null` if no executable could be
+/// located.
+///
+/// If a valid [sdkPath] is found, returns `<sdkPath>/bin/dart` (`dart.exe` on
+/// Windows). Otherwise, attempts direct `PATH` resolution for `dart`.
+String? get dartExecutable {
+  if (Zone.current[#environmentOverrides] != null) {
+    return _resolveDartExecutable();
+  }
+  if (!_dartExecutableResolved) {
+    _cachedDartExecutable = _resolveDartExecutable();
+    _dartExecutableResolved = true;
+  }
+  return _cachedDartExecutable;
+}
+
+String? _cachedDartExecutable;
+bool _dartExecutableResolved = false;
 
 /// Returns the path to the current Dart SDK.
 @Deprecated("Use 'sdkPath' instead")
-String getSdkPath() => sdkPath;
+String? getSdkPath() => sdkPath;
+
+/// Checks whether [candidatePath] represents a valid Dart SDK directory layout.
+bool isValidSdkPath(String candidatePath) {
+  final hasLibrariesJson =
+      File(path.join(candidatePath, 'lib', 'libraries.json')).existsSync();
+  final hasAllowedExperiments =
+      File(
+        path.join(
+          candidatePath,
+          'lib',
+          '_internal',
+          'allowed_experiments.json',
+        ),
+      ).existsSync();
+  final hasDartBin =
+      File(
+        path.join(
+          candidatePath,
+          'bin',
+          Platform.isWindows ? 'dart.exe' : 'dart',
+        ),
+      ).existsSync();
+  final hasVersion = File(path.join(candidatePath, 'version')).existsSync();
+
+  return (hasLibrariesJson || hasAllowedExperiments) &&
+      (hasDartBin || hasVersion);
+}
+
+String? _resolveSdkPath() {
+  // Tier 1: DART_ROOT and DART_SDK environment variables (explicit overrides)
+  final dartRoot = _env['DART_ROOT'];
+  if (dartRoot != null && dartRoot.isNotEmpty && isValidSdkPath(dartRoot)) {
+    return dartRoot;
+  }
+
+  final dartSdk = _env['DART_SDK'];
+  if (dartSdk != null && dartSdk.isNotEmpty && isValidSdkPath(dartSdk)) {
+    return dartSdk;
+  }
+
+  // Tier 2: Platform.resolvedExecutable (Fast path for JIT VM)
+  final executablePath =
+      _env['_DART_RESOLVED_EXECUTABLE'] ?? Platform.resolvedExecutable;
+  if (executablePath.isNotEmpty) {
+    final candidate = path.dirname(path.dirname(executablePath));
+    if (isValidSdkPath(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Tier 3: PATH traversal with Flutter cache awareness
+  final pathEnv = _env['PATH'];
+  if (pathEnv != null && pathEnv.isNotEmpty) {
+    final separator = Platform.isWindows ? ';' : ':';
+    final entries = pathEnv.split(separator);
+
+    final extensions =
+        Platform.isWindows
+            ? (_env['PATHEXT']
+                    ?.split(';')
+                    .where((e) => e.isNotEmpty)
+                    .toList() ??
+                const ['.exe', '.bat', '.cmd'])
+            : const [''];
+
+    for (final entry in entries) {
+      if (entry.isEmpty) continue;
+      for (final ext in extensions) {
+        final candidateExe = path.join(entry, 'dart$ext');
+        final file = File(candidateExe);
+        if (file.existsSync()) {
+          String resolved;
+          try {
+            resolved = file.resolveSymbolicLinksSync();
+          } on FileSystemException {
+            resolved = candidateExe;
+          }
+
+          // Direct SDK root check
+          final candidateSdk = path.dirname(path.dirname(resolved));
+          if (isValidSdkPath(candidateSdk)) {
+            return candidateSdk;
+          }
+
+          // Flutter wrapper check (e.g. flutter/bin/dart -> flutter/bin/cache/dart-sdk)
+          final flutterCacheSdk = path.join(
+            candidateSdk,
+            'bin',
+            'cache',
+            'dart-sdk',
+          );
+          if (isValidSdkPath(flutterCacheSdk)) {
+            return flutterCacheSdk;
+          }
+        }
+      }
+    }
+  }
+
+  // Tier 4: FLUTTER_ROOT fallback
+  final flutterRoot = _env['FLUTTER_ROOT'];
+  if (flutterRoot != null && flutterRoot.isNotEmpty) {
+    final flutterSdk = path.join(flutterRoot, 'bin', 'cache', 'dart-sdk');
+    if (isValidSdkPath(flutterSdk)) {
+      return flutterSdk;
+    }
+  }
+
+  return null;
+}
+
+String? _resolveDartExecutable() {
+  final sdk = sdkPath;
+  if (sdk != null) {
+    final exe = path.join(sdk, 'bin', Platform.isWindows ? 'dart.exe' : 'dart');
+    if (File(exe).existsSync()) {
+      return exe;
+    }
+  }
+
+  // Fallback: search PATH directly if SDK structure wasn't complete
+  final pathEnv = _env['PATH'];
+  if (pathEnv != null && pathEnv.isNotEmpty) {
+    final separator = Platform.isWindows ? ';' : ':';
+    final entries = pathEnv.split(separator);
+    final extensions =
+        Platform.isWindows
+            ? (_env['PATHEXT']
+                    ?.split(';')
+                    .where((e) => e.isNotEmpty)
+                    .toList() ??
+                const ['.exe', '.bat', '.cmd'])
+            : const [''];
+
+    for (final entry in entries) {
+      if (entry.isEmpty) continue;
+      for (final ext in extensions) {
+        final candidate = path.join(entry, 'dart$ext');
+        if (File(candidate).existsSync()) {
+          return candidate;
+        }
+      }
+    }
+  }
+
+  return null;
+}
 
 /// The user-specific application configuration folder for the current platform.
 ///

--- a/pkgs/cli_util/lib/cli_util.dart
+++ b/pkgs/cli_util/lib/cli_util.dart
@@ -8,6 +8,7 @@ library;
 import 'dart:async';
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 export 'src/base_directories.dart';
@@ -21,7 +22,7 @@ export 'src/base_directories.dart';
 ///    checking Flutter cache layouts)
 /// 4. `FLUTTER_ROOT/bin/cache/dart-sdk` fallback
 String? get sdkPath {
-  if (Zone.current[#environmentOverrides] != null) {
+  if (Zone.current[environmentOverridesKey] != null) {
     return _resolveSdkPath();
   }
   if (!_sdkPathResolved) {
@@ -40,7 +41,7 @@ bool _sdkPathResolved = false;
 /// If a valid [sdkPath] is found, returns `<sdkPath>/bin/dart` (`dart.exe` on
 /// Windows). Otherwise, attempts direct `PATH` resolution for `dart`.
 String? get dartExecutable {
-  if (Zone.current[#environmentOverrides] != null) {
+  if (Zone.current[environmentOverridesKey] != null) {
     return _resolveDartExecutable();
   }
   if (!_dartExecutableResolved) {
@@ -58,6 +59,15 @@ bool _dartExecutableResolved = false;
 String? getSdkPath() => sdkPath;
 
 /// Checks whether [candidatePath] represents a valid Dart SDK directory layout.
+///
+/// Validates that [candidatePath] contains the required file markers of a Dart
+/// SDK:
+/// - A libraries configuration (`lib/libraries.json` or
+///   `lib/_internal/allowed_experiments.json`), AND
+/// - An executable or version file (`bin/dart` / `bin/dart.exe` or `version`).
+///
+/// Returns `false` if [candidatePath] is empty. Relative paths (such as `.` or
+/// subdirectories) are evaluated relative to the current working directory.
 bool isValidSdkPath(String candidatePath) {
   if (candidatePath.isEmpty) return false;
   final hasLibrariesJson =
@@ -187,7 +197,7 @@ Iterable<String> _getExecutablePaths(String executableName) sync* {
     if (cleanEntry.startsWith('"') &&
         cleanEntry.endsWith('"') &&
         cleanEntry.length >= 2) {
-      cleanEntry = cleanEntry.substring(1, cleanEntry.length - 1).trim();
+      cleanEntry = cleanEntry.substring(1, cleanEntry.length - 1);
     }
     if (cleanEntry.isEmpty) continue;
     for (final ext in extensions) {
@@ -264,7 +274,11 @@ class EnvironmentNotFoundException implements Exception {
   String toString() => message;
 }
 
+/// Zone value key used for testing environment overrides.
+@visibleForTesting
+const environmentOverridesKey = #_environmentOverrides;
+
 // This zone override exists solely for testing (see lib/cli_util_test.dart).
 Map<String, String> get _env =>
-    (Zone.current[#environmentOverrides] as Map<String, String>?) ??
+    (Zone.current[environmentOverridesKey] as Map<String, String>?) ??
     Platform.environment;

--- a/pkgs/cli_util/pubspec.yaml
+++ b/pkgs/cli_util/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.5.2
+version: 0.6.0-wip
 description: A library to help in building Dart command-line apps.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/cli_util
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acli_util

--- a/pkgs/cli_util/test/cli_util_test.dart
+++ b/pkgs/cli_util/test/cli_util_test.dart
@@ -23,6 +23,7 @@ void main() {
     });
 
     test('isValidSdkPath validation', () {
+      expect(isValidSdkPath(''), isFalse);
       expect(isValidSdkPath(sdkPath!), isTrue);
 
       final tempDir = Directory.systemTemp.createTempSync('invalid_sdk_test');
@@ -99,6 +100,8 @@ void main() {
         File(p.join(mockDartSdk.path, 'version')).writeAsStringSync('3.8.0');
 
         File(p.join(mockFlutterBin.path, 'dart')).createSync();
+        File(p.join(mockFlutterBin.path, 'dart.bat')).createSync();
+        File(p.join(mockFlutterBin.path, 'dart.exe')).createSync();
 
         runZoned(
           () {
@@ -111,6 +114,40 @@ void main() {
               'FLUTTER_ROOT': '',
               '_DART_RESOLVED_EXECUTABLE': '',
               'PATH': mockFlutterBin.path,
+            },
+          },
+        );
+      } finally {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('PATH traversal handles quoted directory entries', () {
+      final tempDir = Directory.systemTemp.createTempSync('mock_path_quoted');
+      try {
+        final mockSdk = Directory(p.join(tempDir.path, 'dart-sdk'))
+          ..createSync();
+        Directory(p.join(mockSdk.path, 'lib')).createSync();
+        File(
+          p.join(mockSdk.path, 'lib', 'libraries.json'),
+        ).writeAsStringSync('{}');
+        File(p.join(mockSdk.path, 'version')).writeAsStringSync('3.8.0');
+        final binDir = Directory(p.join(mockSdk.path, 'bin'))..createSync();
+        File(p.join(binDir.path, 'dart')).createSync();
+        File(p.join(binDir.path, 'dart.bat')).createSync();
+        File(p.join(binDir.path, 'dart.exe')).createSync();
+
+        runZoned(
+          () {
+            expect(sdkPath, mockSdk.path);
+          },
+          zoneValues: {
+            #environmentOverrides: <String, String>{
+              'DART_ROOT': '',
+              'DART_SDK': '',
+              'FLUTTER_ROOT': '',
+              '_DART_RESOLVED_EXECUTABLE': '',
+              'PATH': '"${binDir.path}"',
             },
           },
         );

--- a/pkgs/cli_util/test/cli_util_test.dart
+++ b/pkgs/cli_util/test/cli_util_test.dart
@@ -60,7 +60,7 @@ void main() {
             expect(sdkPath, mockSdk.path);
           },
           zoneValues: {
-            #environmentOverrides: <String, String>{
+            environmentOverridesKey: <String, String>{
               'DART_ROOT': mockSdk.path,
               '_DART_RESOLVED_EXECUTABLE': '',
             },
@@ -72,7 +72,7 @@ void main() {
             expect(sdkPath, mockSdk.path);
           },
           zoneValues: {
-            #environmentOverrides: <String, String>{
+            environmentOverridesKey: <String, String>{
               'DART_SDK': mockSdk.path,
               '_DART_RESOLVED_EXECUTABLE': '',
             },
@@ -108,7 +108,7 @@ void main() {
             expect(sdkPath, mockDartSdk.resolveSymbolicLinksSync());
           },
           zoneValues: {
-            #environmentOverrides: <String, String>{
+            environmentOverridesKey: <String, String>{
               'DART_ROOT': '',
               'DART_SDK': '',
               'FLUTTER_ROOT': '',
@@ -142,12 +142,12 @@ void main() {
             expect(sdkPath, mockSdk.resolveSymbolicLinksSync());
           },
           zoneValues: {
-            #environmentOverrides: <String, String>{
+            environmentOverridesKey: <String, String>{
               'DART_ROOT': '',
               'DART_SDK': '',
               'FLUTTER_ROOT': '',
               '_DART_RESOLVED_EXECUTABLE': '',
-              'PATH': '"${binDir.path}"',
+              'PATH': '  "${binDir.path}"  ',
             },
           },
         );
@@ -173,7 +173,7 @@ void main() {
             expect(sdkPath, mockDartSdk.path);
           },
           zoneValues: {
-            #environmentOverrides: <String, String>{
+            environmentOverridesKey: <String, String>{
               'DART_ROOT': '',
               'DART_SDK': '',
               '_DART_RESOLVED_EXECUTABLE': '',
@@ -194,7 +194,7 @@ void main() {
           expect(dartExecutable, isNull);
         },
         zoneValues: {
-          #environmentOverrides: <String, String>{
+          environmentOverridesKey: <String, String>{
             'DART_ROOT': '',
             'DART_SDK': '',
             'FLUTTER_ROOT': '',
@@ -222,7 +222,7 @@ void main() {
       expect(() {
         runZoned(
           () => applicationConfigHome('dart'),
-          zoneValues: {#environmentOverrides: <String, String>{}},
+          zoneValues: {environmentOverridesKey: <String, String>{}},
         );
       }, throwsA(isA<EnvironmentNotFoundException>()));
     });

--- a/pkgs/cli_util/test/cli_util_test.dart
+++ b/pkgs/cli_util/test/cli_util_test.dart
@@ -12,9 +12,160 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
-  group('sdkPath', () {
-    test('sdkPath', () {
+  group('sdkPath & dartExecutable', () {
+    test('resolves in active VM environment', () {
       expect(sdkPath, isNotNull);
+      expect(Directory(sdkPath!).existsSync(), isTrue);
+      expect(isValidSdkPath(sdkPath!), isTrue);
+
+      expect(dartExecutable, isNotNull);
+      expect(File(dartExecutable!).existsSync(), isTrue);
+    });
+
+    test('isValidSdkPath validation', () {
+      expect(isValidSdkPath(sdkPath!), isTrue);
+
+      final tempDir = Directory.systemTemp.createTempSync('invalid_sdk_test');
+      try {
+        expect(isValidSdkPath(tempDir.path), isFalse);
+
+        // Add dummy libraries.json
+        final libDir = Directory(p.join(tempDir.path, 'lib'))..createSync();
+        File(p.join(libDir.path, 'libraries.json')).writeAsStringSync('{}');
+        expect(
+          isValidSdkPath(tempDir.path),
+          isFalse,
+        ); // Missing bin/dart or version
+
+        // Add dummy version file
+        File(p.join(tempDir.path, 'version')).writeAsStringSync('3.8.0');
+        expect(isValidSdkPath(tempDir.path), isTrue);
+      } finally {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('DART_ROOT / DART_SDK environment overrides', () {
+      final mockSdk = Directory.systemTemp.createTempSync('mock_sdk');
+      try {
+        Directory(p.join(mockSdk.path, 'lib')).createSync();
+        File(
+          p.join(mockSdk.path, 'lib', 'libraries.json'),
+        ).writeAsStringSync('{}');
+        File(p.join(mockSdk.path, 'version')).writeAsStringSync('3.8.0');
+
+        runZoned(
+          () {
+            expect(sdkPath, mockSdk.path);
+          },
+          zoneValues: {
+            #environmentOverrides: <String, String>{
+              'DART_ROOT': mockSdk.path,
+              '_DART_RESOLVED_EXECUTABLE': '',
+            },
+          },
+        );
+
+        runZoned(
+          () {
+            expect(sdkPath, mockSdk.path);
+          },
+          zoneValues: {
+            #environmentOverrides: <String, String>{
+              'DART_SDK': mockSdk.path,
+              '_DART_RESOLVED_EXECUTABLE': '',
+            },
+          },
+        );
+      } finally {
+        mockSdk.deleteSync(recursive: true);
+      }
+    });
+
+    test('PATH traversal with Flutter wrapper structure', () {
+      final tempDir = Directory.systemTemp.createTempSync('mock_path');
+      try {
+        final mockFlutter = Directory(p.join(tempDir.path, 'flutter'))
+          ..createSync();
+        final mockFlutterBin = Directory(p.join(mockFlutter.path, 'bin'))
+          ..createSync();
+        final mockDartSdk = Directory(
+          p.join(mockFlutter.path, 'bin', 'cache', 'dart-sdk'),
+        )..createSync(recursive: true);
+        Directory(p.join(mockDartSdk.path, 'lib')).createSync();
+        File(
+          p.join(mockDartSdk.path, 'lib', 'libraries.json'),
+        ).writeAsStringSync('{}');
+        File(p.join(mockDartSdk.path, 'version')).writeAsStringSync('3.8.0');
+
+        File(p.join(mockFlutterBin.path, 'dart')).createSync();
+
+        runZoned(
+          () {
+            expect(sdkPath, mockDartSdk.path);
+          },
+          zoneValues: {
+            #environmentOverrides: <String, String>{
+              'DART_ROOT': '',
+              'DART_SDK': '',
+              'FLUTTER_ROOT': '',
+              '_DART_RESOLVED_EXECUTABLE': '',
+              'PATH': mockFlutterBin.path,
+            },
+          },
+        );
+      } finally {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('FLUTTER_ROOT fallback override', () {
+      final mockFlutter = Directory.systemTemp.createTempSync('mock_flutter');
+      try {
+        final mockDartSdk = Directory(
+          p.join(mockFlutter.path, 'bin', 'cache', 'dart-sdk'),
+        )..createSync(recursive: true);
+        Directory(p.join(mockDartSdk.path, 'lib')).createSync();
+        File(
+          p.join(mockDartSdk.path, 'lib', 'libraries.json'),
+        ).writeAsStringSync('{}');
+        File(p.join(mockDartSdk.path, 'version')).writeAsStringSync('3.8.0');
+
+        runZoned(
+          () {
+            expect(sdkPath, mockDartSdk.path);
+          },
+          zoneValues: {
+            #environmentOverrides: <String, String>{
+              'DART_ROOT': '',
+              'DART_SDK': '',
+              '_DART_RESOLVED_EXECUTABLE': '',
+              'PATH': '',
+              'FLUTTER_ROOT': mockFlutter.path,
+            },
+          },
+        );
+      } finally {
+        mockFlutter.deleteSync(recursive: true);
+      }
+    });
+
+    test('returns null when SDK is not found and environment is empty', () {
+      runZoned(
+        () {
+          expect(sdkPath, isNull);
+          expect(dartExecutable, isNull);
+        },
+        zoneValues: {
+          #environmentOverrides: <String, String>{
+            'DART_ROOT': '',
+            'DART_SDK': '',
+            'FLUTTER_ROOT': '',
+            'PATH': '',
+            '_DART_RESOLVED_EXECUTABLE': '',
+          },
+        },
+      );
     });
   });
 

--- a/pkgs/cli_util/test/cli_util_test.dart
+++ b/pkgs/cli_util/test/cli_util_test.dart
@@ -105,7 +105,7 @@ void main() {
 
         runZoned(
           () {
-            expect(sdkPath, mockDartSdk.path);
+            expect(sdkPath, mockDartSdk.resolveSymbolicLinksSync());
           },
           zoneValues: {
             #environmentOverrides: <String, String>{
@@ -139,7 +139,7 @@ void main() {
 
         runZoned(
           () {
-            expect(sdkPath, mockSdk.path);
+            expect(sdkPath, mockSdk.resolveSymbolicLinksSync());
           },
           zoneValues: {
             #environmentOverrides: <String, String>{


### PR DESCRIPTION
- Supports robust SDK discovery for AOT-compiled tools (`dart install`, `dart build cli`) probing `DART_ROOT`, `DART_SDK`, `Platform.resolvedExecutable`, system `PATH` (with Flutter wrapper layout awareness), and `FLUTTER_ROOT`.
- Breaking Change: transitions `sdkPath` to `String?` (returning `null` when no SDK is located).
- Adds `dartExecutable` getter (`String?`) to locate the `dart` binary.
- Adds `isValidSdkPath(String candidatePath)` validation helper.
- Caches discovery results on first access.
- Adds comprehensive unit tests for all probe tiers and validation.

Fixes #2504