### PR TITLE
[code_builder] Add MixinBuilder.onTypes for multiple superclass constraints

### DIFF
--- a/pkgs/code_builder/CHANGELOG.md
+++ b/pkgs/code_builder/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.12.0-wip
 
+- Add `MixinBuilder.onTypes` to support a mixin `on` clause with multiple
+  superclass constraints (e.g. `mixin Foo on A, B {}`). Takes precedence over
+  the existing single-type `on` field when non-empty.
 - Ensure scoped lint ignores
   (such as `// ignore_for_file: no_leading_underscores_for_library_prefixes`)
   are emitted at the top of the file before library annotations and directives.

--- a/pkgs/code_builder/lib/src/emitter.dart
+++ b/pkgs/code_builder/lib/src/emitter.dart
@@ -189,12 +189,10 @@ class DartEmitter extends Object
     out.write('mixin ${spec.name}');
     visitTypeParameters(spec.types.map((r) => r.type), out);
     if (spec.onTypes.isNotEmpty) {
-      out
-        ..write(' on ')
-        ..writeAll(
-          spec.onTypes.map<StringSink>((m) => m.type.accept(this)),
-          ',',
-        );
+      out.write(' on ');
+      visitAll<Reference>(spec.onTypes, out, (r) {
+        r.type.accept(this, out);
+      }, ',');
     } else if (spec.on != null) {
       out.write(' on ');
       spec.on!.type.accept(this, out);

--- a/pkgs/code_builder/lib/src/emitter.dart
+++ b/pkgs/code_builder/lib/src/emitter.dart
@@ -188,7 +188,14 @@ class DartEmitter extends Object
     }
     out.write('mixin ${spec.name}');
     visitTypeParameters(spec.types.map((r) => r.type), out);
-    if (spec.on != null) {
+    if (spec.onTypes.isNotEmpty) {
+      out
+        ..write(' on ')
+        ..writeAll(
+          spec.onTypes.map<StringSink>((m) => m.type.accept(this)),
+          ',',
+        );
+    } else if (spec.on != null) {
       out.write(' on ');
       spec.on!.type.accept(this, out);
     }

--- a/pkgs/code_builder/lib/src/specs/mixin.dart
+++ b/pkgs/code_builder/lib/src/specs/mixin.dart
@@ -35,7 +35,16 @@ abstract class Mixin extends Object
   @override
   BuiltList<String> get docs;
 
+  /// A single superclass constraint for this mixin.
+  ///
+  /// For a mixin with more than one superclass constraint, use [onTypes]
+  /// instead, which takes precedence over this field when non-empty.
   Reference? get on;
+
+  /// The superclass constraints for this mixin, e.g. `on A, B, C`.
+  ///
+  /// Takes precedence over [on] when non-empty.
+  BuiltList<Reference> get onTypes;
 
   BuiltList<Reference> get implements;
 
@@ -69,7 +78,16 @@ abstract class MixinBuilder extends Object
   @override
   ListBuilder<String> docs = ListBuilder<String>();
 
+  /// A single superclass constraint for this mixin.
+  ///
+  /// For a mixin with more than one superclass constraint, use [onTypes]
+  /// instead, which takes precedence over this field when non-empty.
   Reference? on;
+
+  /// The superclass constraints for this mixin, e.g. `on A, B, C`.
+  ///
+  /// Takes precedence over [on] when non-empty.
+  ListBuilder<Reference> onTypes = ListBuilder<Reference>();
 
   ListBuilder<Reference> implements = ListBuilder<Reference>();
 

--- a/pkgs/code_builder/lib/src/specs/mixin.g.dart
+++ b/pkgs/code_builder/lib/src/specs/mixin.g.dart
@@ -16,6 +16,8 @@ class _$Mixin extends Mixin {
   @override
   final Reference? on;
   @override
+  final BuiltList<Reference> onTypes;
+  @override
   final BuiltList<Reference> implements;
   @override
   final BuiltList<Reference> types;
@@ -34,6 +36,7 @@ class _$Mixin extends Mixin {
     required this.annotations,
     required this.docs,
     this.on,
+    required this.onTypes,
     required this.implements,
     required this.types,
     required this.methods,
@@ -55,6 +58,7 @@ class _$Mixin extends Mixin {
         annotations == other.annotations &&
         docs == other.docs &&
         on == other.on &&
+        onTypes == other.onTypes &&
         implements == other.implements &&
         types == other.types &&
         methods == other.methods &&
@@ -69,6 +73,7 @@ class _$Mixin extends Mixin {
     _$hash = $jc(_$hash, annotations.hashCode);
     _$hash = $jc(_$hash, docs.hashCode);
     _$hash = $jc(_$hash, on.hashCode);
+    _$hash = $jc(_$hash, onTypes.hashCode);
     _$hash = $jc(_$hash, implements.hashCode);
     _$hash = $jc(_$hash, types.hashCode);
     _$hash = $jc(_$hash, methods.hashCode);
@@ -85,6 +90,7 @@ class _$Mixin extends Mixin {
           ..add('annotations', annotations)
           ..add('docs', docs)
           ..add('on', on)
+          ..add('onTypes', onTypes)
           ..add('implements', implements)
           ..add('types', types)
           ..add('methods', methods)
@@ -143,6 +149,18 @@ class _$MixinBuilder extends MixinBuilder {
   set on(Reference? on) {
     _$this;
     super.on = on;
+  }
+
+  @override
+  ListBuilder<Reference> get onTypes {
+    _$this;
+    return super.onTypes;
+  }
+
+  @override
+  set onTypes(ListBuilder<Reference> onTypes) {
+    _$this;
+    super.onTypes = onTypes;
   }
 
   @override
@@ -214,6 +232,7 @@ class _$MixinBuilder extends MixinBuilder {
       super.annotations = $v.annotations.toBuilder();
       super.docs = $v.docs.toBuilder();
       super.on = $v.on;
+      super.onTypes = $v.onTypes.toBuilder();
       super.implements = $v.implements.toBuilder();
       super.types = $v.types.toBuilder();
       super.methods = $v.methods.toBuilder();
@@ -247,6 +266,7 @@ class _$MixinBuilder extends MixinBuilder {
             annotations: annotations.build(),
             docs: docs.build(),
             on: on,
+            onTypes: onTypes.build(),
             implements: implements.build(),
             types: types.build(),
             methods: methods.build(),
@@ -261,6 +281,8 @@ class _$MixinBuilder extends MixinBuilder {
         _$failedField = 'docs';
         docs.build();
 
+        _$failedField = 'onTypes';
+        onTypes.build();
         _$failedField = 'implements';
         implements.build();
         _$failedField = 'types';

--- a/pkgs/code_builder/test/specs/mixin_test.dart
+++ b/pkgs/code_builder/test/specs/mixin_test.dart
@@ -126,6 +126,36 @@ void main() {
     );
   });
 
+  test('should create a mixin on multiple superclass constraints', () {
+    expect(
+      Mixin(
+        (b) => b
+          ..name = 'Foo'
+          ..onTypes.addAll([
+            TypeReference((b) => b.symbol = 'Bar'),
+            TypeReference((b) => b.symbol = 'Baz'),
+          ]),
+      ),
+      equalsDart(r'''
+        mixin Foo on Bar, Baz {}
+      '''),
+    );
+  });
+
+  test('should prefer onTypes over on when both are set', () {
+    expect(
+      Mixin(
+        (b) => b
+          ..name = 'Foo'
+          ..on = TypeReference((b) => b.symbol = 'Ignored')
+          ..onTypes.add(TypeReference((b) => b.symbol = 'Bar')),
+      ),
+      equalsDart(r'''
+        mixin Foo on Bar {}
+      '''),
+    );
+  });
+
   test('should create a mixin implementing another mixin', () {
     expect(
       Mixin(


### PR DESCRIPTION
## Summary
- `MixinBuilder.on` only supports a single type for a mixin's `on` clause, but Dart mixins can declare multiple superclass constraints (`mixin Foo on A, B {}`).
- Adds `Mixin.onTypes` / `MixinBuilder.onTypes` as a `BuiltList<Reference>` for the multi-type case. When `onTypes` is non-empty it takes precedence over `on` during emission; `on` continues to work unchanged for the single-type case, so this is purely additive.

## Test plan
- [x] Added tests for a mixin with multiple superclass constraints and for `onTypes` taking precedence over `on`
- [x] `dart test` (403/403 passing)
- [x] `dart analyze` (no issues)
- [x] `dart format` applied

Closes #2270