### PR TITLE
Fix mutation XSS via Namespace-blind raw-text serialization

### DIFF
--- a/pkgs/html/CHANGELOG.md
+++ b/pkgs/html/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.15.7-wip
 
+- `writeTextNodeAsHtml`: Escape text inside `<script>` and `<style>`-like tags in foreign namespaces.
 - Require Dart `3.6`
 - Added new `textContent` method to `Node` class that returns the text content of
   the node.

--- a/pkgs/html/lib/dom_parsing.dart
+++ b/pkgs/html/lib/dom_parsing.dart
@@ -8,7 +8,7 @@ library;
 
 import 'dom.dart';
 import 'html_escape.dart';
-import 'src/constants.dart' show rcdataElements;
+import 'src/constants.dart' show Namespaces, rcdataElements;
 
 // Export a function which was previously declared here.
 export 'html_escape.dart';
@@ -152,7 +152,9 @@ void writeTextNodeAsHtml(StringBuffer str, Text node) {
   final parent = node.parentNode;
   if (parent is Element) {
     final tag = parent.localName;
-    if (rcdataElements.contains(tag) || tag == 'plaintext') {
+    final ns = parent.namespaceUri;
+    if ((ns == null || ns == Namespaces.html) &&
+        (rcdataElements.contains(tag) || tag == 'plaintext')) {
       str.write(node.data);
       return;
     }

--- a/pkgs/html/test/mxss_test.dart
+++ b/pkgs/html/test/mxss_test.dart
@@ -1,0 +1,33 @@
+import 'package:html/parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Mutation XSS Prevention (Namespace-aware raw-text serialization)', () {
+    void verifySafeSerialization(String outerTag, String innerTag) {
+      test('Escapes < inside <$outerTag><$innerTag>', () {
+        final payload = '&lt;img src=x onerror=alert(1)&gt;';
+        final input = '<$outerTag><$innerTag>$payload</$innerTag></$outerTag>';
+        final doc = parse(input);
+
+        final output = doc.body!.innerHtml;
+
+        // Output must retain &lt; and &gt; escaped
+        expect(
+            output, '<$outerTag><$innerTag>$payload</$innerTag></$outerTag>');
+
+        // Ensure that a reparse doesn't mutate it into a live <img> tag
+        final reparsedDoc = parse(output);
+        expect(reparsedDoc.querySelector('img'), isNull,
+            reason: 'img should remain escaped text');
+      });
+    }
+
+    verifySafeSerialization('svg', 'style');
+    verifySafeSerialization('svg', 'iframe');
+    verifySafeSerialization('svg', 'xmp');
+
+    verifySafeSerialization('math', 'style');
+    verifySafeSerialization('math', 'iframe');
+    verifySafeSerialization('math', 'xmp');
+  });
+}


### PR DESCRIPTION
**Description**
Fixes a mutation XSS vulnerability where `package:html` allows <script> and <style>-like tags in foreign namespaces (like SVG or MathML) to be serialized raw without escaping, enabling malicious DOM mutations on re-parse.

**Fix**
Added a check in `writeTextNodeAsHtml` to ensure it only writes raw-text when the parent element is actually in the HTML namespace (or a null internal namespace).

b/536307676