### PR TITLE
[package_config] Forbid UNC paths in rootUri to mitigate UNC path injection

### DIFF
--- a/pkgs/package_config/CHANGELOG.md
+++ b/pkgs/package_config/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.1-wip
 
-- Forbid non-local file paths in `rootUri` and `packageUri` to mitigate UNC path injection ([SMB NTLM leak](https://attack.mitre.org/techniques/T1187/)).
+- Forbid Windows UNC paths in `rootUri` and `packageUri` to mitigate UNC path injection ([SMB NTLM leak](https://attack.mitre.org/techniques/T1187/)).
 
 ## 3.0.0
 

--- a/pkgs/package_config/CHANGELOG.md
+++ b/pkgs/package_config/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.1-wip
 
-- Forbid non-local file paths in `rootUri` to mitigate UNC path injection ([SMB NTLM leak](https://attack.mitre.org/techniques/T1187/)).
+- Forbid non-local file paths in `rootUri` and `packageUri` to mitigate UNC path injection ([SMB NTLM leak](https://attack.mitre.org/techniques/T1187/)).
 
 ## 3.0.0
 

--- a/pkgs/package_config/CHANGELOG.md
+++ b/pkgs/package_config/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.0.1-wip
 
+- Forbid non-local file paths in `rootUri` to mitigate UNC path injection ([SMB NTLM leak](https://attack.mitre.org/techniques/T1187/)).
+
 ## 3.0.0
 
 - Adds discovery API to find both a configuration and its location:

--- a/pkgs/package_config/lib/src/package_config.dart
+++ b/pkgs/package_config/lib/src/package_config.dart
@@ -821,6 +821,22 @@ class SimplePackage implements Package {
         root = root.replace(path: '${root.path}/');
       }
     }
+
+    if (!fatalError && root.isScheme('file')) {
+      var windowsPath = root.toFilePath(windows: true);
+      if (windowsPath.startsWith(r'\\')) {
+        onError(
+          PackageConfigArgumentError(
+            root,
+            'root',
+            'Package root URIs must not evaluate to a Windows UNC path. '
+                'The rootUri must be a local file path. '
+                'Found: "$windowsPath".',
+          ),
+        );
+        fatalError = true;
+      }
+    }
     if (packageUriRoot == null) {
       packageUriRoot = root;
     } else if (!fatalError) {
@@ -844,6 +860,22 @@ class SimplePackage implements Package {
           ),
         );
         packageUriRoot = root;
+      } else {
+        if (packageUriRoot.isScheme('file')) {
+          var windowsPath = packageUriRoot.toFilePath(windows: true);
+          if (windowsPath.startsWith(r'\\')) {
+            onError(
+              PackageConfigArgumentError(
+                packageUriRoot,
+                'packageUriRoot',
+                'Package URIs must not evaluate to a Windows UNC path. '
+                    'The packageUri must be a local file path. '
+                    'Found: "$windowsPath".',
+              ),
+            );
+            packageUriRoot = root;
+          }
+        }
       }
     }
     if (fatalError) return null;

--- a/pkgs/package_config/lib/src/package_config_json.dart
+++ b/pkgs/package_config/lib/src/package_config_json.dart
@@ -154,20 +154,6 @@ PackageConfig parsePackageConfigJson(
     var parsedRootUri = Uri.parse(rootUri!);
     var relativeRoot = !hasAbsolutePath(parsedRootUri);
     var root = baseLocation.resolveUri(parsedRootUri);
-    if (root.isScheme('file')) {
-      var windowsPath = root.toFilePath(windows: true);
-      if (windowsPath.startsWith(r'\\')) {
-        onError(
-          PackageConfigFormatException(
-            'Package root URIs must not evaluate to a Windows UNC path. '
-            'The rootUri must be a local file path. '
-            'Found: "$windowsPath".',
-            entry,
-          ),
-        );
-        return null;
-      }
-    }
     if (!root.path.endsWith('/')) root = root.replace(path: '${root.path}/');
     var packageRoot = root;
     if (packageUri != null) packageRoot = root.resolve(packageUri!);

--- a/pkgs/package_config/lib/src/package_config_json.dart
+++ b/pkgs/package_config/lib/src/package_config_json.dart
@@ -154,16 +154,19 @@ PackageConfig parsePackageConfigJson(
     var parsedRootUri = Uri.parse(rootUri!);
     var relativeRoot = !hasAbsolutePath(parsedRootUri);
     var root = baseLocation.resolveUri(parsedRootUri);
-    if (root.host.isNotEmpty) {
-      onError(
-        PackageConfigFormatException(
-          'Package root URIs must not have a host (authority) component. '
-          'The rootUri must be a local file path. '
-          'Found: "${root.host}".',
-          entry,
-        ),
-      );
-      return null;
+    if (root.isScheme('file')) {
+      var windowsPath = root.toFilePath(windows: true);
+      if (windowsPath.startsWith(r'\\')) {
+        onError(
+          PackageConfigFormatException(
+            'Package root URIs must not evaluate to a Windows UNC path. '
+            'The rootUri must be a local file path. '
+            'Found: "$windowsPath".',
+            entry,
+          ),
+        );
+        return null;
+      }
     }
     if (!root.path.endsWith('/')) root = root.replace(path: '${root.path}/');
     var packageRoot = root;

--- a/pkgs/package_config/lib/src/package_config_json.dart
+++ b/pkgs/package_config/lib/src/package_config_json.dart
@@ -154,6 +154,17 @@ PackageConfig parsePackageConfigJson(
     var parsedRootUri = Uri.parse(rootUri!);
     var relativeRoot = !hasAbsolutePath(parsedRootUri);
     var root = baseLocation.resolveUri(parsedRootUri);
+    if (root.host.isNotEmpty) {
+      onError(
+        PackageConfigFormatException(
+          'Package root URIs must not have a host (authority) component. '
+          'The rootUri must be a local file path. '
+          'Found: "${root.host}".',
+          entry,
+        ),
+      );
+      return null;
+    }
     if (!root.path.endsWith('/')) root = root.replace(path: '${root.path}/');
     var packageRoot = root;
     if (packageUri != null) packageRoot = root.resolve(packageUri!);

--- a/pkgs/package_config/test/parse_test.dart
+++ b/pkgs/package_config/test/parse_test.dart
@@ -401,8 +401,16 @@ void main() {
             '{$cfg,"packages":[{$name,"rootUri":"package:x/x/"}]}',
           );
           testThrows(
-            'has-host',
-            '{$cfg,"packages":[{$name,"rootUri":"file://attacker.com/share/"}]}',
+            'has-unc-host',
+            '{$cfg,"packages":[{$name,"rootUri":"file://example.com/share/"}]}',
+          );
+          testThrows(
+            'has-unc-path-injection',
+            '{$cfg,"packages":[{$name,"rootUri":"file://///example.com/share/"}]}',
+          );
+          testThrows(
+            'has-unc-bypass',
+            '{$cfg,"packages":[{$name,"rootUri":"file://localhost/\\\\example.com/share/"}]}',
           );
         });
         group('package-URI root:', () {

--- a/pkgs/package_config/test/parse_test.dart
+++ b/pkgs/package_config/test/parse_test.dart
@@ -436,6 +436,18 @@ void main() {
             '{$cfg,"packages":[{$name,$root,"packageUri":"package:x/x/"}]}',
           );
           testThrows(
+            'has-unc-host',
+            '{$cfg,"packages":[{$name,$root,"packageUri":"file://example.com/share/"}]}',
+          );
+          testThrows(
+            'has-unc-path-injection',
+            '{$cfg,"packages":[{$name,$root,"packageUri":"file://///example.com/share/"}]}',
+          );
+          testThrows(
+            'has-unc-bypass',
+            '{$cfg,"packages":[{$name,$root,"packageUri":"file://localhost/\\\\example.com/share/"}]}',
+          );
+          testThrows(
             'not inside root',
             '{$cfg,"packages":[{$name,$root,"packageUri":"../other/"}]}',
           );

--- a/pkgs/package_config/test/parse_test.dart
+++ b/pkgs/package_config/test/parse_test.dart
@@ -400,6 +400,10 @@ void main() {
             'package-URI',
             '{$cfg,"packages":[{$name,"rootUri":"package:x/x/"}]}',
           );
+          testThrows(
+            'has-host',
+            '{$cfg,"packages":[{$name,"rootUri":"file://attacker.com/share/"}]}',
+          );
         });
         group('package-URI root:', () {
           testThrows(


### PR DESCRIPTION
On Windows a `package_config.json`, crafted by a malicious actor, can point to an external UNC network share (e.g. `"rootUri": "//attacker.example.com/share/"`). 

Downstream tools (`analyzer`, `pub`, etc) that attempt to read from such a path (or just `File.statSync`) may trigger Windows to initiate an SMB request which the attacker can use to [record the user's account hashes](https://attack.mitre.org/techniques/T1187/).

To mitigate this issue, we require that `rootUri`s inside `package_config.json` must be a local file path.

For users who legitimately have `package_config.json` on a network share, the solution is to mount these network shares as local drive letters (like `Z:\`).


BUG=536309083
