### PR TITLE
fix: reconcile version mismatches in process and stack_trace

### DIFF
--- a/pkgs/process/lib/src/interface/common.dart
+++ b/pkgs/process/lib/src/interface/common.dart
@@ -48,8 +48,10 @@ String? getExecutablePath(
     // the cwd path. In this case, fall back on '.'.
     workingDirectory ??= '.';
   }
-  final Context context =
-      Context(style: fs.path.style, current: workingDirectory);
+  final Context context = Context(
+    style: fs.path.style,
+    current: workingDirectory,
+  );
 
   // TODO(goderbauer): refactor when github.com/google/platform.dart/issues/2
   //     is available.
@@ -74,8 +76,12 @@ String? getExecutablePath(
       ? <String>[workingDirectory]
       : platform.environment['PATH']!.split(pathSeparator);
 
-  final List<String> candidates =
-      _getCandidatePaths(executable, searchPath, extensions, context);
+  final List<String> candidates = _getCandidatePaths(
+    executable,
+    searchPath,
+    extensions,
+    context,
+  );
   final List<String> foundCandidates = <String>[];
   for (final String path in candidates) {
     final File candidate = fs.file(path);
@@ -146,8 +152,10 @@ List<String> _getCandidatePaths(
     return withExtensions;
   }
   return searchPaths
-      .map((String path) =>
-          withExtensions.map((String command) => context.join(path, command)))
+      .map(
+        (String path) =>
+            withExtensions.map((String command) => context.join(path, command)),
+      )
       .expand((Iterable<String> e) => e)
       .toList()
       .cast<String>();

--- a/pkgs/process/lib/src/interface/exceptions.dart
+++ b/pkgs/process/lib/src/interface/exceptions.dart
@@ -84,8 +84,9 @@ class ProcessPackageExecutableNotFoundException
 
   @override
   String toString() {
-    final StringBuffer buffer =
-        StringBuffer('ProcessPackageExecutableNotFoundException: $message\n');
+    final StringBuffer buffer = StringBuffer(
+      'ProcessPackageExecutableNotFoundException: $message\n',
+    );
     // Don't add an extra space if there are no arguments.
     final String args = arguments.isNotEmpty ? ' ${arguments.join(' ')}' : '';
     buffer.writeln('  Command: $executable$args');

--- a/pkgs/process/lib/src/interface/local_process_manager.dart
+++ b/pkgs/process/lib/src/interface/local_process_manager.dart
@@ -40,11 +40,7 @@ class LocalProcessManager implements ProcessManager {
   }) {
     try {
       return Process.start(
-        _getExecutable(
-          command,
-          workingDirectory,
-          runInShell,
-        ),
+        _getExecutable(command, workingDirectory, runInShell),
         _getArguments(command),
         workingDirectory: workingDirectory,
         environment: environment,
@@ -53,8 +49,10 @@ class LocalProcessManager implements ProcessManager {
         mode: mode,
       );
     } on ProcessException catch (exception) {
-      throw ProcessPackageException.fromProcessException(exception,
-          workingDirectory: workingDirectory);
+      throw ProcessPackageException.fromProcessException(
+        exception,
+        workingDirectory: workingDirectory,
+      );
     }
   }
 
@@ -70,11 +68,7 @@ class LocalProcessManager implements ProcessManager {
   }) {
     try {
       return Process.run(
-        _getExecutable(
-          command,
-          workingDirectory,
-          runInShell,
-        ),
+        _getExecutable(command, workingDirectory, runInShell),
         _getArguments(command),
         workingDirectory: workingDirectory,
         environment: environment,
@@ -84,8 +78,10 @@ class LocalProcessManager implements ProcessManager {
         stderrEncoding: stderrEncoding,
       );
     } on ProcessException catch (exception) {
-      throw ProcessPackageException.fromProcessException(exception,
-          workingDirectory: workingDirectory);
+      throw ProcessPackageException.fromProcessException(
+        exception,
+        workingDirectory: workingDirectory,
+      );
     }
   }
 
@@ -101,11 +97,7 @@ class LocalProcessManager implements ProcessManager {
   }) {
     try {
       return Process.runSync(
-        _getExecutable(
-          command,
-          workingDirectory,
-          runInShell,
-        ),
+        _getExecutable(command, workingDirectory, runInShell),
         _getArguments(command),
         workingDirectory: workingDirectory,
         environment: environment,
@@ -115,8 +107,10 @@ class LocalProcessManager implements ProcessManager {
         stderrEncoding: stderrEncoding,
       );
     } on ProcessException catch (exception) {
-      throw ProcessPackageException.fromProcessException(exception,
-          workingDirectory: workingDirectory);
+      throw ProcessPackageException.fromProcessException(
+        exception,
+        workingDirectory: workingDirectory,
+      );
     }
   }
 
@@ -131,7 +125,10 @@ class LocalProcessManager implements ProcessManager {
 }
 
 String _getExecutable(
-    List<dynamic> command, String? workingDirectory, bool runInShell) {
+  List<dynamic> command,
+  String? workingDirectory,
+  bool runInShell,
+) {
   final String commandName = command.first.toString();
   if (runInShell) {
     return commandName;

--- a/pkgs/process/pubspec.yaml
+++ b/pkgs/process/pubspec.yaml
@@ -1,6 +1,6 @@
 name: process
 description: A pluggable, mockable process invocation abstraction for Dart.
-version: 5.0.5
+version: 5.0.6-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/process
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aprocess
 

--- a/pkgs/process/test/src/interface/common_test.dart
+++ b/pkgs/process/test/src/interface/common_test.dart
@@ -32,7 +32,7 @@ void main() {
         workingDir,
         dir1,
         dir2,
-        dir3
+        dir3,
       ]) {
         directory.deleteSync(recursive: true);
       }
@@ -48,7 +48,7 @@ void main() {
           operatingSystem: 'windows',
           environment: <String, String>{
             'PATH': '${dir1.path};${dir2.path}',
-            'PATHEXT': '.exe;.bat'
+            'PATHEXT': '.exe;.bat',
           },
         );
       });
@@ -173,8 +173,10 @@ void main() {
         // Windows supports absolute paths with '/' separators.
         final String expectedPath = fs.path.join(dir3.path, 'bla.exe');
         fs.file(expectedPath).createSync();
-        final String commandWithForwardSlashes =
-            expectedPath.replaceAll('\\', '/');
+        final String commandWithForwardSlashes = expectedPath.replaceAll(
+          '\\',
+          '/',
+        );
 
         final String? executablePath = getExecutablePath(
           commandWithForwardSlashes,
@@ -240,41 +242,56 @@ void main() {
         expect(executablePath, isNull);
       });
 
-      test('not found with throwOnFailure throws exception with match state',
-          () {
-        const String command = 'foo.exe';
-        expect(
+      test(
+        'not found with throwOnFailure throws exception with match state',
+        () {
+          const String command = 'foo.exe';
+          expect(
             () => getExecutablePath(
-                  command,
-                  workingDir.path,
-                  platform: platform,
-                  fs: fs,
-                  throwOnFailure: true,
-                ),
-            throwsA(isA<ProcessPackageExecutableNotFoundException>()
-                .having(
-                    (ProcessPackageExecutableNotFoundException
-                            notFoundException) =>
+              command,
+              workingDir.path,
+              platform: platform,
+              fs: fs,
+              throwOnFailure: true,
+            ),
+            throwsA(
+              isA<ProcessPackageExecutableNotFoundException>()
+                  .having(
+                    (
+                      ProcessPackageExecutableNotFoundException
+                          notFoundException,
+                    ) =>
                         notFoundException.candidates,
                     'candidates',
-                    isEmpty)
-                .having(
-                    (ProcessPackageExecutableNotFoundException
-                            notFoundException) =>
+                    isEmpty,
+                  )
+                  .having(
+                    (
+                      ProcessPackageExecutableNotFoundException
+                          notFoundException,
+                    ) =>
                         notFoundException.workingDirectory,
                     'workingDirectory',
-                    equals(workingDir.path))
-                .having(
-                    (ProcessPackageExecutableNotFoundException
-                            notFoundException) =>
+                    equals(workingDir.path),
+                  )
+                  .having(
+                    (
+                      ProcessPackageExecutableNotFoundException
+                          notFoundException,
+                    ) =>
                         notFoundException.toString(),
                     'toString',
                     contains(
-                        '  Working Directory: C:\\.tmp_rand0\\work_dir_rand0\n'
-                        '  Search Path:\n'
-                        '    C:\\.tmp_rand0\\dir1_rand0\n'
-                        '    C:\\.tmp_rand0\\dir2_rand0\n'))));
-      });
+                      '  Working Directory: C:\\.tmp_rand0\\work_dir_rand0\n'
+                      '  Search Path:\n'
+                      '    C:\\.tmp_rand0\\dir1_rand0\n'
+                      '    C:\\.tmp_rand0\\dir2_rand0\n',
+                    ),
+                  ),
+            ),
+          );
+        },
+      );
 
       test('with absolute path when currentDirectory getter throws', () {
         final FileSystem fsNoCwd = MemoryFileSystemNoCwd(fs);
@@ -312,8 +329,9 @@ void main() {
 
       setUp(() {
         platform = FakePlatform(
-            operatingSystem: 'linux',
-            environment: <String, String>{'PATH': '${dir1.path}:${dir2.path}'});
+          operatingSystem: 'linux',
+          environment: <String, String>{'PATH': '${dir1.path}:${dir2.path}'},
+        );
       });
 
       test('absolute', () {
@@ -360,40 +378,56 @@ void main() {
         expect(executablePath, isNull);
       });
 
-      test('not found with throwOnFailure throws exception with match state',
-          () {
-        const String command = 'foo';
-        expect(
+      test(
+        'not found with throwOnFailure throws exception with match state',
+        () {
+          const String command = 'foo';
+          expect(
             () => getExecutablePath(
-                  command,
-                  workingDir.path,
-                  platform: platform,
-                  fs: fs,
-                  throwOnFailure: true,
-                ),
-            throwsA(isA<ProcessPackageExecutableNotFoundException>()
-                .having(
-                    (ProcessPackageExecutableNotFoundException
-                            notFoundException) =>
+              command,
+              workingDir.path,
+              platform: platform,
+              fs: fs,
+              throwOnFailure: true,
+            ),
+            throwsA(
+              isA<ProcessPackageExecutableNotFoundException>()
+                  .having(
+                    (
+                      ProcessPackageExecutableNotFoundException
+                          notFoundException,
+                    ) =>
                         notFoundException.candidates,
                     'candidates',
-                    isEmpty)
-                .having(
-                    (ProcessPackageExecutableNotFoundException
-                            notFoundException) =>
+                    isEmpty,
+                  )
+                  .having(
+                    (
+                      ProcessPackageExecutableNotFoundException
+                          notFoundException,
+                    ) =>
                         notFoundException.workingDirectory,
                     'workingDirectory',
-                    equals(workingDir.path))
-                .having(
-                    (ProcessPackageExecutableNotFoundException
-                            notFoundException) =>
+                    equals(workingDir.path),
+                  )
+                  .having(
+                    (
+                      ProcessPackageExecutableNotFoundException
+                          notFoundException,
+                    ) =>
                         notFoundException.toString(),
                     'toString',
-                    contains('  Working Directory: /.tmp_rand0/work_dir_rand0\n'
-                        '  Search Path:\n'
-                        '    /.tmp_rand0/dir1_rand0\n'
-                        '    /.tmp_rand0/dir2_rand0\n'))));
-      });
+                    contains(
+                      '  Working Directory: /.tmp_rand0/work_dir_rand0\n'
+                      '  Search Path:\n'
+                      '    /.tmp_rand0/dir1_rand0\n'
+                      '    /.tmp_rand0/dir2_rand0\n',
+                    ),
+                  ),
+            ),
+          );
+        },
+      );
     });
   });
   group('Real Filesystem', () {
@@ -479,36 +513,38 @@ void main() {
     });
 
     test(
-        'Test that finding non-executable paths throws with proper information',
-        () {
-      if (localPlatform.isWindows) {
-        // Windows doesn't check for executable-ness, and we can't run 'chmod'
-        // on Windows anyhow.
-        return;
-      }
+      'Test that finding non-executable paths throws with proper information',
+      () {
+        if (localPlatform.isWindows) {
+          // Windows doesn't check for executable-ness, and we can't run 'chmod'
+          // on Windows anyhow.
+          return;
+        }
 
-      // Make the second command in the path executable, but not the first.
-      // No executable permissions
-      io.Process.runSync('chmod', <String>['0644', '--', command1.path]);
-      // Only group executable permissions
-      io.Process.runSync('chmod', <String>['0645', '--', command2.path]);
-      // Only other executable permissions
-      io.Process.runSync('chmod', <String>['0654', '--', command3.path]);
-      // All executable permissions, but not readable
-      io.Process.runSync('chmod', <String>['0311', '--', command4.path]);
+        // Make the second command in the path executable, but not the first.
+        // No executable permissions
+        io.Process.runSync('chmod', <String>['0644', '--', command1.path]);
+        // Only group executable permissions
+        io.Process.runSync('chmod', <String>['0645', '--', command2.path]);
+        // Only other executable permissions
+        io.Process.runSync('chmod', <String>['0654', '--', command3.path]);
+        // All executable permissions, but not readable
+        io.Process.runSync('chmod', <String>['0311', '--', command4.path]);
 
-      expect(
+        expect(
           () => getExecutablePath(
-                'command',
-                tmpDir.path,
-                platform: platform,
-                fs: fs,
-                throwOnFailure: true,
-              ),
-          throwsA(isA<ProcessPackageExecutableNotFoundException>()
-              .having(
-                  (ProcessPackageExecutableNotFoundException
-                          notFoundException) =>
+            'command',
+            tmpDir.path,
+            platform: platform,
+            fs: fs,
+            throwOnFailure: true,
+          ),
+          throwsA(
+            isA<ProcessPackageExecutableNotFoundException>()
+                .having(
+                  (
+                    ProcessPackageExecutableNotFoundException notFoundException,
+                  ) =>
                       notFoundException.candidates,
                   'candidates',
                   equals(<String>[
@@ -517,69 +553,86 @@ void main() {
                     '${tmpDir.path}/path3/command',
                     '${tmpDir.path}/path4/command',
                     '${tmpDir.path}/path5/command',
-                  ]))
-              .having(
-                  (ProcessPackageExecutableNotFoundException
-                          notFoundException) =>
+                  ]),
+                )
+                .having(
+                  (
+                    ProcessPackageExecutableNotFoundException notFoundException,
+                  ) =>
                       notFoundException.toString(),
                   'toString',
                   contains(
-                      'ProcessPackageExecutableNotFoundException: Found candidates, but lacked sufficient permissions to execute "command".\n'
-                      '  Command: command\n'
-                      '  Working Directory: ${tmpDir.path}\n'
-                      '  Candidates:\n'
-                      '    ${tmpDir.path}/path1/command\n'
-                      '    ${tmpDir.path}/path2/command\n'
-                      '    ${tmpDir.path}/path3/command\n'
-                      '    ${tmpDir.path}/path4/command\n'
-                      '    ${tmpDir.path}/path5/command\n'
-                      '  Search Path:\n'
-                      '    ${tmpDir.path}/path1\n'
-                      '    ${tmpDir.path}/path2\n'
-                      '    ${tmpDir.path}/path3\n'
-                      '    ${tmpDir.path}/path4\n'
-                      '    ${tmpDir.path}/path5\n'))));
-    });
+                    'ProcessPackageExecutableNotFoundException: Found candidates, but lacked sufficient permissions to execute "command".\n'
+                    '  Command: command\n'
+                    '  Working Directory: ${tmpDir.path}\n'
+                    '  Candidates:\n'
+                    '    ${tmpDir.path}/path1/command\n'
+                    '    ${tmpDir.path}/path2/command\n'
+                    '    ${tmpDir.path}/path3/command\n'
+                    '    ${tmpDir.path}/path4/command\n'
+                    '    ${tmpDir.path}/path5/command\n'
+                    '  Search Path:\n'
+                    '    ${tmpDir.path}/path1\n'
+                    '    ${tmpDir.path}/path2\n'
+                    '    ${tmpDir.path}/path3\n'
+                    '    ${tmpDir.path}/path4\n'
+                    '    ${tmpDir.path}/path5\n',
+                  ),
+                ),
+          ),
+        );
+      },
+    );
 
-    test('Test that finding no executable paths throws with proper information',
-        () {
-      if (localPlatform.isWindows) {
-        // Windows doesn't check for executable-ness, and we can't run 'chmod'
-        // on Windows anyhow.
-        return;
-      }
+    test(
+      'Test that finding no executable paths throws with proper information',
+      () {
+        if (localPlatform.isWindows) {
+          // Windows doesn't check for executable-ness, and we can't run 'chmod'
+          // on Windows anyhow.
+          return;
+        }
 
-      expect(
+        expect(
           () => getExecutablePath(
-                'non-existent-command',
-                tmpDir.path,
-                platform: platform,
-                fs: fs,
-                throwOnFailure: true,
-              ),
-          throwsA(isA<ProcessPackageExecutableNotFoundException>()
-              .having(
-                  (ProcessPackageExecutableNotFoundException
-                          notFoundException) =>
+            'non-existent-command',
+            tmpDir.path,
+            platform: platform,
+            fs: fs,
+            throwOnFailure: true,
+          ),
+          throwsA(
+            isA<ProcessPackageExecutableNotFoundException>()
+                .having(
+                  (
+                    ProcessPackageExecutableNotFoundException notFoundException,
+                  ) =>
                       notFoundException.candidates,
                   'candidates',
-                  isEmpty)
-              .having(
-                  (ProcessPackageExecutableNotFoundException
-                          notFoundException) =>
+                  isEmpty,
+                )
+                .having(
+                  (
+                    ProcessPackageExecutableNotFoundException notFoundException,
+                  ) =>
                       notFoundException.toString(),
                   'toString',
                   contains(
-                      'ProcessPackageExecutableNotFoundException: Failed to find "non-existent-command" in the search path.\n'
-                      '  Command: non-existent-command\n'
-                      '  Working Directory: ${tmpDir.path}\n'
-                      '  Search Path:\n'
-                      '    ${tmpDir.path}/path1\n'
-                      '    ${tmpDir.path}/path2\n'
-                      '    ${tmpDir.path}/path3\n'
-                      '    ${tmpDir.path}/path4\n'
-                      '    ${tmpDir.path}/path5\n'))));
-    });
+                    'ProcessPackageExecutableNotFoundException: Failed to find "non-existent-command" in the search path.\n'
+                    '  Command: non-existent-command\n'
+                    '  Working Directory: ${tmpDir.path}\n'
+                    '  Search Path:\n'
+                    '    ${tmpDir.path}/path1\n'
+                    '    ${tmpDir.path}/path2\n'
+                    '    ${tmpDir.path}/path3\n'
+                    '    ${tmpDir.path}/path4\n'
+                    '    ${tmpDir.path}/path5\n',
+                  ),
+                ),
+          ),
+        );
+      },
+    );
 
     group('can actually execute files', () {
       void testCompileAndExecute(File mainFile) {
@@ -587,22 +640,27 @@ void main() {
         final exePath = '${mainFile.path}.exe';
         // Create an executable we can actually run.
         expect(
-            localProcessManager.runSync([
-              io.Platform.resolvedExecutable,
-              'compile',
-              'exe',
-              mainFile.path,
-              '-o',
-              exePath
-            ]).exitCode,
-            0);
+          localProcessManager.runSync([
+            io.Platform.resolvedExecutable,
+            'compile',
+            'exe',
+            mainFile.path,
+            '-o',
+            exePath,
+          ]).exitCode,
+          0,
+        );
 
         for (final runInShell in const [true, false]) {
-          final result =
-              localProcessManager.runSync([exePath], runInShell: runInShell);
-          expect(result.exitCode, 0,
-              reason: 'runInShell: $runInShell\nstdout: ${result.stdout}\n'
-                  'stderr: ${result.stderr}');
+          final result = localProcessManager.runSync([
+            exePath,
+          ], runInShell: runInShell);
+          expect(
+            result.exitCode,
+            0,
+            reason: 'runInShell: $runInShell\nstdout: ${result.stdout}\n'
+                'stderr: ${result.stderr}',
+          );
           expect(result.stdout, contains('hello'));
         }
       }
@@ -618,19 +676,22 @@ void main() {
         testCompileAndExecute(main);
       });
 
-      test('with parenthesis in the command name', () async {
-        final dir = tmpDir.childDirectory('theP()ath');
-        final main = dir.childFile('main.dart')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+      test(
+        'with parenthesis in the command name',
+        () async {
+          final dir = tmpDir.childDirectory('theP()ath');
+          final main = dir.childFile('main.dart')
+            ..createSync(recursive: true)
+            ..writeAsStringSync('''
 void main() {
   print('hello');
 }''');
-        testCompileAndExecute(main);
-      },
-          skip: io.Platform.isWindows
-              ? 'https://github.com/dart-lang/tools/issues/2139'
-              : null);
+          testCompileAndExecute(main);
+        },
+        skip: io.Platform.isWindows
+            ? 'https://github.com/dart-lang/tools/issues/2139'
+            : null,
+      );
 
       test('with spaces and parenthesis in the command name', () async {
         final dir = tmpDir.childDirectory('the P()ath');

--- a/pkgs/stack_trace/CHANGELOG.md
+++ b/pkgs/stack_trace/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.12.2-dev
+## 1.12.2-wip
 
 * Relax parsing of V8 traces to allow a missing initial description.
 


### PR DESCRIPTION
Reconciles version and changelog agreement errors identified during publish validation:

- **`package:process`**: Reconciled `pubspec.yaml` version to `5.0.6-wip` to match `CHANGELOG.md`.
- **`package:stack_trace`**: Reconciled `CHANGELOG.md` latest header to `1.12.2-wip` to match `pubspec.yaml`.
- **`package:process` formatting**: Caught up `package:process` with the current Dart SDK formatter output (`dart format .`). No semantic or behavioral code changes were made.