### PR TITLE
Fix XSS vulnerability in `htmlToCodeMarkup()`

### DIFF
--- a/pkgs/html/CHANGELOG.md
+++ b/pkgs/html/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Require Dart `3.6`
 - Added new `textContent` method to `Node` class that returns the text content of
   the node.
+- Fix XSS vulnerability in `htmlToCodeMarkup()` by escaping DOCTYPE, element, and attribute names.
 
 ## 0.15.6
 

--- a/pkgs/html/lib/dom_parsing.dart
+++ b/pkgs/html/lib/dom_parsing.dart
@@ -81,23 +81,27 @@ class CodeMarkupVisitor extends TreeVisitor {
 
   @override
   void visitDocumentType(DocumentType node) {
-    _str.write('<code class="markup doctype">&lt;!DOCTYPE ${node.name}>'
+    var name = node.name ?? '';
+    if (name.isNotEmpty) name = ' ${htmlSerializeEscape(name)}';
+    _str.write('<code class="markup doctype">&lt;!DOCTYPE$name>'
         '</code>');
   }
 
   @override
   void visitText(Text node) {
-    writeTextNodeAsHtml(_str, node);
+    _str.write(htmlSerializeEscape(node.data));
   }
 
   @override
   void visitElement(Element node) {
     final tag = node.localName;
-    _str.write('&lt;<code class="markup element-name">$tag</code>');
+    final escapedTag = tag != null ? htmlSerializeEscape(tag) : null;
+    _str.write('&lt;<code class="markup element-name">$escapedTag</code>');
     if (node.attributes.isNotEmpty) {
       node.attributes.forEach((key, v) {
-        v = htmlSerializeEscape(v, attributeMode: true);
-        _str.write(' <code class="markup attribute-name">$key</code>'
+        final escapedKey = htmlSerializeEscape(key.toString());
+        v = htmlSerializeEscape(v);
+        _str.write(' <code class="markup attribute-name">$escapedKey</code>'
             '=<code class="markup attribute-value">"$v"</code>');
       });
     }
@@ -107,8 +111,10 @@ class CodeMarkupVisitor extends TreeVisitor {
     } else if (isVoidElement(tag)) {
       _str.write('>');
       return;
+    } else {
+      _str.write('>');
     }
-    _str.write('&lt;/<code class="markup element-name">$tag</code>>');
+    _str.write('&lt;/<code class="markup element-name">$escapedTag</code>>');
   }
 
   @override

--- a/pkgs/html/test/dom_parsing_test.dart
+++ b/pkgs/html/test/dom_parsing_test.dart
@@ -1,0 +1,38 @@
+import 'package:html/dom_parsing.dart' show htmlToCodeMarkup;
+import 'package:html/parser.dart' show parse;
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'htmlToCodeMarkup unescaped structural-name XSS DOCTYPE name reaches output unescaped',
+      () {
+    // Proves that you don't even need to call constructors; just parsing
+    // a malicious string creates these nodes via WHATWG error recovery.
+    var doc = parse('<!DOCTYPE x<img/src/onerror=alert(1)>');
+    var code = htmlToCodeMarkup(doc);
+    expect(code, isNot(contains('<img/src/onerror=alert(1)>')));
+  });
+
+  test(
+      'htmlToCodeMarkup unescaped structural-name XSS attribute name reaches output unescaped',
+      () {
+    var doc = parse('<div <injected="v">text</div>');
+    var code = htmlToCodeMarkup(doc);
+    expect(
+        code,
+        isNot(
+            contains('<code class="markup attribute-name"><injected</code>')));
+  });
+
+  test('htmlToCodeMarkup escapes script text contents for XSS protection', () {
+    var doc = parse('<script><img src=x onerror=alert("XSS")></script>');
+    var code = htmlToCodeMarkup(doc);
+    expect(code, isNot(contains('<img')));
+  });
+
+  test('htmlToCodeMarkup escapes attribute values for XSS protection', () {
+    var doc = parse('<div x="><script>alert(1)</script>">text</div>');
+    var code = htmlToCodeMarkup(doc);
+    expect(code, isNot(contains('<script>')));
+  });
+}


### PR DESCRIPTION
This properly escapes DOCTYPE names, element/attribute names, and inner text node content (which was previously leaking `<script>` and `<style>` payloads unescaped).

b/536196684