### PR TITLE
Fix HTML tokenizer failing to close CDATA blocks on extra brackets

### DIFF
--- a/pkgs/html/CHANGELOG.md
+++ b/pkgs/html/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.15.7-wip
 
+- Fix the tokenizer failing to close CDATA blocks when encountering extra brackets
 - Require Dart `3.6`
 - Added new `textContent` method to `Node` class that returns the text content of
   the node.

--- a/pkgs/html/lib/src/tokenizer.dart
+++ b/pkgs/html/lib/src/tokenizer.dart
@@ -1888,8 +1888,10 @@ class HtmlTokenizer implements Iterator<Token> {
       data.add(ch);
       // TODO(jmesserly): it'd be nice if we had an easier way to match the end,
       // perhaps with a "peek" API.
-      if (ch == ']' && matchedEnd < 2) {
-        matchedEnd++;
+      if (ch == ']') {
+        if (matchedEnd < 2) {
+          matchedEnd++;
+        }
       } else if (ch == '>' && matchedEnd == 2) {
         // Remove "]]>" from the end.
         data.removeLast();

--- a/pkgs/html/test/parser_feature_test.dart
+++ b/pkgs/html/test/parser_feature_test.dart
@@ -15,6 +15,18 @@ import 'package:test/test.dart';
 
 void main() {
   _testElementSpans();
+
+  test('CDATA parser differential avoids XSS payload hiding (b/536201494)', () {
+    final payload = '<svg><![CDATA[x]]]><img src=1 onerror=alert(1)>]]></svg>';
+    final document = parseFragment(payload);
+
+    final images = document.querySelectorAll('img');
+
+    // Check that <img> wasn't incorrectly swallowed as part of the CDATA block.
+    expect(images, isNotEmpty);
+    expect(images.first.attributes.containsKey('onerror'), isTrue);
+  });
+
   test('doctype is cloneable', () {
     final doc = parse('<!doctype HTML>');
     final doctype = doc.nodes[0] as DocumentType;


### PR DESCRIPTION
When reading characters that end a CDATA block, encountering 3 or more right-square brackets before the final closing brace caused the state machine to improperly reset its tracking counter back to 0. The counter is now properly capped at 2 to correctly preserve the "CDATA section end state" transition limits as defined in the WHATWG parser specification.

b/536201494
