### PR TITLE
Fix O(N^2) DoS vulnerability in HTML parser formatting elements

### DIFF
--- a/pkgs/html/CHANGELOG.md
+++ b/pkgs/html/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.15.7-wip
 
 - Require Dart `3.6`
+- Limit ["Noah's Ark" clause](https://html.spec.whatwg.org/multipage/parsing.html#list-of-active-formatting-elements) to avoid degenerate O(N^2) when parsing deeply nested formatting elements with unique attributes.
 - Added new `textContent` method to `Node` class that returns the text content of
   the node.
 

--- a/pkgs/html/lib/parser.dart
+++ b/pkgs/html/lib/parser.dart
@@ -1487,8 +1487,10 @@ class InBodyPhase extends Phase {
     final element = tree.openElements.last;
 
     final matchingElements = <Node?>[];
+    var scanned = 0;
     for (Node? node in tree.activeFormattingElements.reversed) {
-      if (node == null) {
+      if (node == null ||
+          scanned++ >= ActiveFormattingElements.noahArkScanLimit) {
         break;
       } else if (isMatchingFormattingElement(node as Element, element)) {
         matchingElements.add(node);

--- a/pkgs/html/lib/src/treebuilder.dart
+++ b/pkgs/html/lib/src/treebuilder.dart
@@ -22,6 +22,12 @@ import 'token.dart';
 ///
 /// https://html.spec.whatwg.org/multipage/parsing.html#list-of-active-formatting-elements
 class ActiveFormattingElements extends ListProxy<Element?> {
+  /// Upper bound on how many trailing entries the Noah's-Ark clause scans.
+  ///
+  /// Prevents O(N^2) parse time on maliciously crafted nested formatting
+  /// elements with unique attributes.
+  static const int noahArkScanLimit = 256;
+
   /// Push an element into the active formatting elements.
   ///
   /// Prevents equivalent elements from appearing more than 3 times following
@@ -33,8 +39,9 @@ class ActiveFormattingElements extends ListProxy<Element?> {
   void add(Element? node) {
     var equalCount = 0;
     if (node != null) {
+      var scanned = 0;
       for (var element in reversed) {
-        if (element == null) {
+        if (element == null || scanned++ == noahArkScanLimit) {
           break;
         }
         if (_nodesEqual(element, node)) {
@@ -174,7 +181,11 @@ class TreeBuilder {
     // Step 2 and step 3: we start with the last element. So i is -1.
     var i = activeFormattingElements.length - 1;
     var entry = activeFormattingElements[i];
-    if (entry == null || openElements.contains(entry)) {
+    // Fast path: checking identity of the most recent formatting element
+    // avoids an O(n) `contains` scan on every formatting start tag.
+    if (entry == null ||
+        (openElements.isNotEmpty && identical(entry, openElements.last)) ||
+        openElements.contains(entry)) {
       return;
     }
 

--- a/pkgs/html/test/noah_ark_clause_limit_test.dart
+++ b/pkgs/html/test/noah_ark_clause_limit_test.dart
@@ -1,0 +1,25 @@
+@TestOn('vm')
+library;
+
+import 'dart:isolate';
+
+import 'package:html/parser.dart' show parse;
+import 'package:test/test.dart';
+
+void main() {
+  test('parse() limits active formatting element backwards scan', () async {
+    final n = 50000;
+    final payload = StringBuffer();
+    for (var i = 0; i < n; i++) {
+      payload.write('<b x=$i>');
+    }
+
+    final payloadStr = payload.toString();
+
+    // This will reliably timeout on unpatched versions because Isolate.run
+    // frees the main event loop to trigger the test framework's timer.
+    await Isolate.run(() {
+      parse(payloadStr);
+    });
+  }, timeout: const Timeout(Duration(seconds: 10)));
+}


### PR DESCRIPTION
Add a bound to the backward scan (capped at 256 elements) during the parsing of active formatting elements (the ["Noah's Ark" clause](https://html.spec.whatwg.org/multipage/parsing.html#list-of-active-formatting-elements)). 

Without this a maliciously crafted HTML containing highly nested formatting elements with unique attributes (e.g., `<b x=1><b x=2>...`) would bypass the element deduplication, causing an unchecked $O(N^2)$ scan across the active formatting elements list. 

By bounding the traversal explicitly and adding a fast-path identity comparison to `TreeBuilder.reconstructActiveFormattingElements`, the parse time degrades linearly ($O(N)$) for pathological payloads while avoiding any behavioral changes for legitimate spec-conforming HTML documents. 

b/528621660