### PR TITLE
test(cli_util): guard sdkPath in unit tests for hermetic environments

### DIFF
--- a/pkgs/cli_util/CHANGELOG.md
+++ b/pkgs/cli_util/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.6.1-wip
+
 ## 0.6.0
 
 - **Breaking Change**: `sdkPath` now returns `String?` (returning `null` if no

--- a/pkgs/cli_util/pubspec.yaml
+++ b/pkgs/cli_util/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_util
-version: 0.6.0
+version: 0.6.1-wip
 description: A library to help in building Dart command-line apps.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/cli_util
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acli_util

--- a/pkgs/cli_util/test/cli_util_test.dart
+++ b/pkgs/cli_util/test/cli_util_test.dart
@@ -14,17 +14,20 @@ import 'package:test/test.dart';
 void main() {
   group('sdkPath & dartExecutable', () {
     test('resolves in active VM environment', () {
-      expect(sdkPath, isNotNull);
-      expect(Directory(sdkPath!).existsSync(), isTrue);
-      expect(isValidSdkPath(sdkPath!), isTrue);
+      if (sdkPath case final path?) {
+        expect(Directory(path).existsSync(), isTrue);
+        expect(isValidSdkPath(path), isTrue);
 
-      expect(dartExecutable, isNotNull);
-      expect(File(dartExecutable!).existsSync(), isTrue);
+        expect(dartExecutable, isNotNull);
+        expect(File(dartExecutable!).existsSync(), isTrue);
+      }
     });
 
     test('isValidSdkPath validation', () {
       expect(isValidSdkPath(''), isFalse);
-      expect(isValidSdkPath(sdkPath!), isTrue);
+      if (sdkPath case final path?) {
+        expect(isValidSdkPath(path), isTrue);
+      }
 
       final tempDir = Directory.systemTemp.createTempSync('invalid_sdk_test');
       try {

--- a/pkgs/cli_util/test/cli_util_test.dart
+++ b/pkgs/cli_util/test/cli_util_test.dart
@@ -14,13 +14,16 @@ import 'package:test/test.dart';
 void main() {
   group('sdkPath & dartExecutable', () {
     test('resolves in active VM environment', () {
-      if (sdkPath case final path?) {
-        expect(Directory(path).existsSync(), isTrue);
-        expect(isValidSdkPath(path), isTrue);
-
-        expect(dartExecutable, isNotNull);
-        expect(File(dartExecutable!).existsSync(), isTrue);
+      final path = sdkPath;
+      if (path == null) {
+        markTestSkipped('sdkPath is not available in this environment');
+        return;
       }
+      expect(Directory(path).existsSync(), isTrue);
+      expect(isValidSdkPath(path), isTrue);
+
+      expect(dartExecutable, isNotNull);
+      expect(File(dartExecutable!).existsSync(), isTrue);
     });
 
     test('isValidSdkPath validation', () {


### PR DESCRIPTION
In hermetic test runners (such as Blaze/Bazel or environments without
a standard Dart SDK layout on disk at Platform.resolvedExecutable),
sdkPath evaluates to null. Guard the live SDK assertions so tests pass
in hermetic sandboxes.
