### PR TITLE
[json_rpc_2] Add strictProtocolChecks parameter to Client

### DIFF
--- a/pkgs/json_rpc_2/CHANGELOG.md
+++ b/pkgs/json_rpc_2/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.2.0-wip
+
+* Add `strictProtocolChecks` parameter to `Client` and `Client.withoutJson`,
+  matching the existing parameter on `Server`. When `false`, the client
+  accepts responses that omit the `jsonrpc` parameter.
+
 ## 4.1.0
 
 * Forward errors within `Peer` when it is acting as a client.

--- a/pkgs/json_rpc_2/lib/src/client.dart
+++ b/pkgs/json_rpc_2/lib/src/client.dart
@@ -248,11 +248,9 @@ class Client {
   /// Determines whether the server's response is valid per the spec.
   bool _isResponseValid(Object? response) {
     if (response is! Map) return false;
-    if (strictProtocolChecks && !response.containsKey('jsonrpc')) {
-      return false;
-    }
-    if ((strictProtocolChecks || response.containsKey('jsonrpc')) &&
-        response['jsonrpc'] != '2.0') {
+    if (response.containsKey('jsonrpc')) {
+      if (response['jsonrpc'] != '2.0') return false;
+    } else if (strictProtocolChecks) {
       return false;
     }
     var id = response['id'];

--- a/pkgs/json_rpc_2/lib/src/client.dart
+++ b/pkgs/json_rpc_2/lib/src/client.dart
@@ -47,6 +47,14 @@ class Client {
   /// endpoint closes the connection.
   bool get isClosed => _done.isCompleted;
 
+  /// Whether to strictly enforce the JSON-RPC 2.0 specification for received
+  /// responses.
+  ///
+  /// If `false`, this [Client] will accept some responses which are not
+  /// conformant with the JSON-RPC 2.0 specification. In particular, responses
+  /// missing the `jsonrpc` parameter will be accepted.
+  final bool strictProtocolChecks;
+
   /// Creates a [Client] that communicates over [channel].
   ///
   /// Note that the client won't begin listening to [channel] until
@@ -55,10 +63,17 @@ class Client {
   /// If [idGenerator] is passed, it will be called to generate an ID for each
   /// request. Defaults to an auto-incrementing `int`. The value returned must
   /// be either an `int` or `String`.
-  Client(StreamChannel<String> channel, {Object Function()? idGenerator})
+  ///
+  /// If [strictProtocolChecks] is false, this [Client] will accept some
+  /// responses which are not conformant with the JSON-RPC 2.0 specification.
+  /// In particular, responses missing the `jsonrpc` parameter will be
+  /// accepted.
+  Client(StreamChannel<String> channel,
+      {Object Function()? idGenerator, bool strictProtocolChecks = true})
       : this.withoutJson(
             jsonDocument.bind(channel).transformStream(ignoreFormatExceptions),
-            idGenerator: idGenerator);
+            idGenerator: idGenerator,
+            strictProtocolChecks: strictProtocolChecks);
 
   /// Creates a [Client] that communicates using decoded messages over
   /// [_channel].
@@ -72,7 +87,13 @@ class Client {
   /// If [_idGenerator] is passed, it will be called to generate an ID for each
   /// request. Defaults to an auto-incrementing `int`. The value returned must
   /// be either an `int` or `String`.
-  Client.withoutJson(this._channel, {Object Function()? idGenerator})
+  ///
+  /// If [strictProtocolChecks] is false, this [Client] will accept some
+  /// responses which are not conformant with the JSON-RPC 2.0 specification.
+  /// In particular, responses missing the `jsonrpc` parameter will be
+  /// accepted.
+  Client.withoutJson(this._channel,
+      {Object Function()? idGenerator, this.strictProtocolChecks = true})
       : _idGenerator = idGenerator ?? _createIncrementingIdGenerator() {
     done.whenComplete(() {
       for (var request in _pendingRequests.values) {
@@ -227,7 +248,13 @@ class Client {
   /// Determines whether the server's response is valid per the spec.
   bool _isResponseValid(Object? response) {
     if (response is! Map) return false;
-    if (response['jsonrpc'] != '2.0') return false;
+    if (strictProtocolChecks && !response.containsKey('jsonrpc')) {
+      return false;
+    }
+    if ((strictProtocolChecks || response.containsKey('jsonrpc')) &&
+        response['jsonrpc'] != '2.0') {
+      return false;
+    }
     var id = response['id'];
     if (!_pendingRequests.containsKey(id)) return false;
     if (response.containsKey('result')) return true;

--- a/pkgs/json_rpc_2/lib/src/peer.dart
+++ b/pkgs/json_rpc_2/lib/src/peer.dart
@@ -55,10 +55,10 @@ class Peer implements Client, Server {
   /// Unhandled exceptions in callbacks will be forwarded to [onUnhandledError].
   /// If this is not provided, unhandled exceptions will be swallowed.
   ///
-  /// If [strictProtocolChecks] is false, the underlying [Server] will accept
-  /// some requests which are not conformant with the JSON-RPC 2.0
-  /// specification. In particular, requests missing the `jsonrpc` parameter
-  /// will be accepted.
+  /// If [strictProtocolChecks] is false, the underlying [Server] and [Client]
+  /// will accept some requests and responses which are not conformant with
+  /// the JSON-RPC 2.0 specification. In particular, requests and responses
+  /// missing the `jsonrpc` parameter will be accepted.
   ///
   /// If [idGenerator] is passed, it will be called to generate an ID for each
   /// request. Defaults to an auto-incrementing `int`.  The value returned must
@@ -85,10 +85,10 @@ class Peer implements Client, Server {
   /// Unhandled exceptions in callbacks will be forwarded to [onUnhandledError].
   /// If this is not provided, unhandled exceptions will be swallowed.
   ///
-  /// If [strictProtocolChecks] is false, the underlying [Server] will accept
-  /// some requests which are not conformant with the JSON-RPC 2.0
-  /// specification. In particular, requests missing the `jsonrpc` parameter
-  /// will be accepted.
+  /// If [strictProtocolChecks] is false, the underlying [Server] and [Client]
+  /// will accept some requests and responses which are not conformant with
+  /// the JSON-RPC 2.0 specification. In particular, requests and responses
+  /// missing the `jsonrpc` parameter will be accepted.
   ///
   /// If [idGenerator] is passed, it will be called to generate an ID for each
   /// request. Defaults to an auto-incrementing `int`. The value returned must
@@ -106,7 +106,8 @@ class Peer implements Client, Server {
           _clientIncomingForwarder.stream,
           _channel.sink,
         ),
-        idGenerator: idGenerator);
+        idGenerator: idGenerator,
+        strictProtocolChecks: strictProtocolChecks);
   }
 
   // Client methods.

--- a/pkgs/json_rpc_2/pubspec.yaml
+++ b/pkgs/json_rpc_2/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 4.1.0
+version: 4.2.0-wip
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/json_rpc_2

--- a/pkgs/json_rpc_2/test/client/client_test.dart
+++ b/pkgs/json_rpc_2/test/client/client_test.dart
@@ -206,6 +206,33 @@ void main() {
     });
   });
 
+  group('strict protocol checks disabled', () {
+    setUp(() => controller = ClientController(strictProtocolChecks: false));
+
+    test('accepts a response with no jsonrpc key', () {
+      controller.expectRequest((request) {
+        return {'result': 'bar', 'id': request['id']};
+      });
+
+      expect(controller.client.sendRequest('foo'), completion(equals('bar')));
+    });
+
+    test('still rejects a response with the wrong jsonrpc version', () {
+      controller.expectRequest((request) {
+        controller.sendResponse({
+          'jsonrpc': 'wrong version',
+          'result': 'wrong',
+          'id': request['id']
+        });
+
+        return pumpEventQueue().then(
+            (_) => {'jsonrpc': '2.0', 'result': 'right', 'id': request['id']});
+      });
+
+      expect(controller.client.sendRequest('foo'), completion(equals('right')));
+    });
+  });
+
   test('with custom String ids', () {
     var id = 0;
     controller = ClientController(idGenerator: () => 'ID-${id++}');

--- a/pkgs/json_rpc_2/test/client/utils.dart
+++ b/pkgs/json_rpc_2/test/client/utils.dart
@@ -20,10 +20,12 @@ class ClientController {
   /// The client.
   late final json_rpc.Client client;
 
-  ClientController({Object Function()? idGenerator}) {
+  ClientController(
+      {Object Function()? idGenerator, bool strictProtocolChecks = true}) {
     client = json_rpc.Client(
         StreamChannel(_responseController.stream, _requestController.sink),
-        idGenerator: idGenerator);
+        idGenerator: idGenerator,
+        strictProtocolChecks: strictProtocolChecks);
     client.listen();
   }
 


### PR DESCRIPTION
Closes #2422

`Server` and `Peer` already accept a `strictProtocolChecks` flag that allows requests which don't include the `jsonrpc` field. `Client` had no equivalent, so there was no way to interoperate with a peer whose responses omit that field.

This mirrors the `Server` implementation exactly: when `strictProtocolChecks` is `false`, a response missing the `jsonrpc` key is tolerated, but a response with a `jsonrpc` key set to the wrong value is still rejected.

Also threads the flag through `Peer.withoutJson` to the internal `Client`, so `Peer(strictProtocolChecks: false)` relaxes response validation on the client side too, consistent with its existing effect on the server side.

## Changes
- Add `strictProtocolChecks` param to `Client` and `Client.withoutJson` (default `true`, matching `Server`).
- Update `Client._isResponseValid` to only require the `jsonrpc` key when strict.
- Pass `strictProtocolChecks` through to the internal `Client` in `Peer.withoutJson`.
- Bump to `4.2.0-wip` with a CHANGELOG entry.

## Test plan
- Added two tests: accepts a response with no `jsonrpc` key when `strictProtocolChecks: false`, and confirms a wrong `jsonrpc` version is still rejected even when non-strict.
- `dart test -p vm`: 127/127 passing.
- `dart analyze`: no issues.
- `dart format --set-exit-if-changed`: clean.

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.