### PR TITLE
[extension_discovery] Prevent config.yaml symlinks from escaping package boundary

### DIFF
--- a/pkgs/extension_discovery/CHANGELOG.md
+++ b/pkgs/extension_discovery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1-wip
+
+- Prevent symlinks from causing `config.yaml` to be read from outside the package folder.
+
 ## 2.1.0
 
 - Require Dart 3.4.

--- a/pkgs/extension_discovery/lib/extension_discovery.dart
+++ b/pkgs/extension_discovery/lib/extension_discovery.dart
@@ -6,8 +6,10 @@
 library;
 
 import 'dart:collection' show UnmodifiableListView;
-import 'dart:io' show File, IOException;
+import 'dart:io' show Directory, File, IOException;
 import 'dart:isolate' show Isolate;
+
+import 'package:path/path.dart' as path;
 
 import 'src/io.dart';
 import 'src/package_config.dart';
@@ -208,19 +210,23 @@ Future<List<Extension>> _findExtensions({
       final configStat = configFile.statSync();
       if (configStat.isFileOrLink) {
         if (configStat.isPossiblyModifiedAfter(registryStat.modified)) {
-          try {
-            registryUpdated = true;
-            registry[i] = (
-              package: p.package,
-              rootUri: p.rootUri,
-              packageUri: p.packageUri,
-              config: parseYamlFromConfigFile(await configFile.readAsString()),
-            );
-            continue;
-          } on FormatException {
-            // pass
-          } on IOException {
-            // pass
+          if (_isWithinPackageBoundary(rootUri, configFile)) {
+            try {
+              registryUpdated = true;
+              registry[i] = (
+                package: p.package,
+                rootUri: p.rootUri,
+                packageUri: p.packageUri,
+                config: parseYamlFromConfigFile(
+                  await configFile.readAsString(),
+                ),
+              );
+              continue;
+            } on FormatException {
+              // pass
+            } on IOException {
+              // pass
+            }
           }
           registryUpdated = true;
           registry[i] = (
@@ -254,12 +260,14 @@ Future<List<Extension>> _findExtensions({
         final configFile = File.fromUri(rootUri.resolve(configFileName));
         final configStat = configFile.statSync();
         if (configStat.isFileOrLink) {
-          return (
-            package: p.name,
-            rootUri: p.rootUri,
-            packageUri: p.packageUri,
-            config: parseYamlFromConfigFile(await configFile.readAsString()),
-          );
+          if (_isWithinPackageBoundary(rootUri, configFile)) {
+            return (
+              package: p.name,
+              rootUri: p.rootUri,
+              packageUri: p.packageUri,
+              config: parseYamlFromConfigFile(await configFile.readAsString()),
+            );
+          }
         }
       } on FormatException {
         // pass
@@ -296,4 +304,12 @@ Future<List<Extension>> _findExtensions({
             ))
         .toList(growable: false),
   );
+}
+
+/// Checks if [configFile] actually resides within [rootUri] after fully
+/// resolving symbolic links for both paths.
+bool _isWithinPackageBoundary(Uri rootUri, File configFile) {
+  final rootPath = Directory.fromUri(rootUri).resolveSymbolicLinksSync();
+  final realPath = configFile.resolveSymbolicLinksSync();
+  return path.isWithin(rootPath, realPath);
 }

--- a/pkgs/extension_discovery/lib/extension_discovery.dart
+++ b/pkgs/extension_discovery/lib/extension_discovery.dart
@@ -309,7 +309,11 @@ Future<List<Extension>> _findExtensions({
 /// Checks if [configFile] actually resides within [rootUri] after fully
 /// resolving symbolic links for both paths.
 bool _isWithinPackageBoundary(Uri rootUri, File configFile) {
-  final rootPath = Directory.fromUri(rootUri).resolveSymbolicLinksSync();
-  final realPath = configFile.resolveSymbolicLinksSync();
-  return path.isWithin(rootPath, realPath);
+  try {
+    final rootPath = Directory.fromUri(rootUri).resolveSymbolicLinksSync();
+    final realPath = configFile.resolveSymbolicLinksSync();
+    return path.isWithin(rootPath, realPath);
+  } on IOException {
+    return false;
+  }
 }

--- a/pkgs/extension_discovery/pubspec.yaml
+++ b/pkgs/extension_discovery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: extension_discovery
 description: >-
   A convention and utilities for package extension discovery.
-version: 2.1.0
+version: 2.1.1-wip
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/extension_discovery
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aextension_discovery
 
@@ -9,6 +9,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
+  path: ^1.9.1
   yaml: ^3.0.0
 
 dev_dependencies:

--- a/pkgs/extension_discovery/test/symlink_escape_test.dart
+++ b/pkgs/extension_discovery/test/symlink_escape_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 @TestOn('linux')
 library;
 

--- a/pkgs/extension_discovery/test/symlink_escape_test.dart
+++ b/pkgs/extension_discovery/test/symlink_escape_test.dart
@@ -1,0 +1,83 @@
+@TestOn('linux')
+library;
+
+import 'dart:io';
+import 'dart:isolate' show Isolate;
+
+import 'package:extension_discovery/extension_discovery.dart';
+import 'package:test/test.dart';
+
+import 'test_descriptor.dart' as d;
+
+void main() {
+  test('Prevents symlink cache poisoning', () async {
+    final pkgLibDir = await Isolate.resolvePackageUri(
+      Uri.parse('package:extension_discovery/'),
+    );
+    final pkgDir = pkgLibDir!.resolve('..');
+
+    // Create a target secret file outside the packages
+    await d.file('target_secret.txt', '{"secret":"initial secret"}').create();
+    final targetPath = d.path('target_secret.txt');
+
+    // Create a victim app and an evil package
+    await d.dir('evil_pkg', [
+      d.pubspec({
+        'name': 'evil_pkg',
+        'environment': {'sdk': '^3.0.0'},
+      }),
+      d.dir('extension', [
+        d.dir('devtools', [
+          d.json('config.yaml', {'secret': 'fake initial safe file'})
+        ])
+      ]),
+    ]).create();
+
+    await d.dir('myapp', [
+      d.pubspec({
+        'name': 'myapp',
+        'dependencies': {
+          'extension_discovery': {'path': pkgDir.toFilePath()},
+          'evil_pkg': {'path': '../evil_pkg'},
+        },
+        'environment': {'sdk': '^3.0.0'},
+      }),
+    ]).create();
+
+    // Get dependencies
+    await d.dartPubGet(d.path('myapp'));
+
+    // Round 1: Run findExtensions with a proper file
+    var extensions = await findExtensions(
+      'devtools',
+      packageConfig: d.fileUri('myapp/.dart_tool/package_config.json'),
+    );
+
+    // Verify it finds the extension
+    expect(extensions, isNotEmpty);
+    expect(extensions.first.config['secret'], 'fake initial safe file');
+
+    // Evict cache by deleting .dart_tool and re-running pub get
+    final dartToolDir = Directory(d.path('myapp/.dart_tool'));
+    if (dartToolDir.existsSync()) {
+      dartToolDir.deleteSync(recursive: true);
+    }
+    await d.dartPubGet(d.path('myapp'));
+
+    // Delete the safe file and create the symlink config.yaml utilizing test_descriptor
+    File(d.path('evil_pkg/extension/devtools/config.yaml')).deleteSync();
+
+    await d
+        .link('evil_pkg/extension/devtools/config.yaml', targetPath)
+        .create();
+
+    // Round 2: Run findExtensions with the malicious symlink
+    extensions = await findExtensions(
+      'devtools',
+      packageConfig: d.fileUri('myapp/.dart_tool/package_config.json'),
+    );
+
+    // Verify that evil_pkg did not poison the cache and leak the secret
+    expect(extensions, isEmpty);
+  });
+}

--- a/pkgs/extension_discovery/test/symlink_escape_test.dart
+++ b/pkgs/extension_discovery/test/symlink_escape_test.dart
@@ -64,7 +64,8 @@ void main() {
     }
     await d.dartPubGet(d.path('myapp'));
 
-    // Delete the safe file and create the symlink config.yaml utilizing test_descriptor
+    // Delete the safe file and create the symlink config.yaml utilizing
+    // test_descriptor
     File(d.path('evil_pkg/extension/devtools/config.yaml')).deleteSync();
 
     await d

--- a/pkgs/extension_discovery/test/test_descriptor.dart
+++ b/pkgs/extension_discovery/test/test_descriptor.dart
@@ -3,7 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert' show JsonEncoder;
-import 'dart:io' show Platform, Process;
+import 'dart:io'
+    show
+        Platform,
+        Process,
+        Link,
+        FileSystemEntity,
+        FileSystemEntityType,
+        File,
+        Directory;
 
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -17,6 +25,35 @@ d.FileDescriptor pubspec(Map<String, Object?> pubspec) =>
 
 Uri fileUri(String path) => Uri.file(d.path(path));
 Uri directoryUri(String path) => Uri.directory(d.path(path));
+
+class _LinkDescriptor extends d.Descriptor {
+  final String _target;
+
+  _LinkDescriptor(String name, this._target) : super(name);
+
+  String _path(String? parent) => Uri.directory(parent ?? d.sandbox)
+      .resolve(name)
+      .toFilePath(windows: Platform.isWindows);
+
+  @override
+  String describe() => 'link $name to $_target';
+
+  @override
+  Future<void> create([String? parent]) async {
+    final path = _path(parent);
+    final link = Link(path);
+    await link.create(_target);
+  }
+
+  @override
+  Future<void> validate([String? parent]) async {
+    final link = Link(_path(parent));
+    expect(await FileSystemEntity.isLink(link.path), isTrue);
+    expect(await link.target(), _target);
+  }
+}
+
+d.Descriptor link(String name, String target) => _LinkDescriptor(name, target);
 
 Future<String> dart([
   String? arg1,

--- a/pkgs/extension_discovery/test/test_descriptor.dart
+++ b/pkgs/extension_discovery/test/test_descriptor.dart
@@ -3,15 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert' show JsonEncoder;
-import 'dart:io'
-    show
-        Platform,
-        Process,
-        Link,
-        FileSystemEntity,
-        FileSystemEntityType,
-        File,
-        Directory;
+import 'dart:io' show FileSystemEntity, Link, Platform, Process;
 
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -29,7 +21,7 @@ Uri directoryUri(String path) => Uri.directory(d.path(path));
 class _LinkDescriptor extends d.Descriptor {
   final String _target;
 
-  _LinkDescriptor(String name, this._target) : super(name);
+  _LinkDescriptor(super.name, this._target);
 
   String _path(String? parent) => Uri.directory(parent ?? d.sandbox)
       .resolve(name)


### PR DESCRIPTION
Disallow `config.yaml` from being a symlink pointing outside the package root.

b/536195690