### PR TITLE
[unified_analytics] Add hostArch parameter to Event.flutterCommandResult

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 8.0.18-wip
 
+- Added optional `hostArch` parameter to `Event.flutterCommandResult`.
 - Added optional `pubspecHasFlutterSdk`, `pubspecEnvironmentSdk`, and
   `pubspecDependencies` parameters to the `Event.dartCliCommandExecuted`
   constructor.

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -651,11 +651,15 @@ final class Event {
   /// * [commandHasTerminal] - Boolean indicating if the flutter command ran
   ///   with a terminal.
   ///
+  /// * [hostArch] - the host CPU architecture executing the command (e.g.,
+  ///   "x64", "arm64", "arm", "ia32", "riscv64").
+  ///
   /// * [maxRss] - maximum resident size for a given flutter command.
   Event.flutterCommandResult({
     required String commandPath,
     required String result,
     required bool commandHasTerminal,
+    String? hostArch,
     int? maxRss,
   }) : this._(
          eventName: DashEvent.flutterCommandResult,
@@ -663,6 +667,7 @@ final class Event {
            'commandPath': commandPath,
            'result': result,
            'commandHasTerminal': commandHasTerminal,
+           'hostArch': ?hostArch,
            'maxRss': ?maxRss,
          },
        );

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -663,6 +663,7 @@ void main() {
       commandPath: 'commandPath',
       result: 'result',
       commandHasTerminal: true,
+      hostArch: 'arm64',
       maxRss: 123,
     );
 
@@ -673,9 +674,32 @@ void main() {
     expect(constructedEvent.eventData['commandPath'], 'commandPath');
     expect(constructedEvent.eventData['result'], 'result');
     expect(constructedEvent.eventData['commandHasTerminal'], true);
+    expect(constructedEvent.eventData['hostArch'], 'arm64');
     expect(constructedEvent.eventData['maxRss'], 123);
-    expect(constructedEvent.eventData.length, 4);
+    expect(constructedEvent.eventData.length, 5);
   });
+
+  test(
+    'Event.flutterCommandResult constructed with optional values omitted',
+    () {
+      Event generateEvent() => Event.flutterCommandResult(
+        commandPath: 'commandPath',
+        result: 'result',
+        commandHasTerminal: true,
+      );
+
+      final constructedEvent = generateEvent();
+
+      expect(generateEvent, returnsNormally);
+      expect(constructedEvent.eventName, DashEvent.flutterCommandResult);
+      expect(constructedEvent.eventData['commandPath'], 'commandPath');
+      expect(constructedEvent.eventData['result'], 'result');
+      expect(constructedEvent.eventData['commandHasTerminal'], true);
+      expect(constructedEvent.eventData['hostArch'], isNull);
+      expect(constructedEvent.eventData['maxRss'], isNull);
+      expect(constructedEvent.eventData.length, 3);
+    },
+  );
 
   test('Event.flutterWasmDryRunPackage constructed', () {
     Event generateEvent() => Event.flutterWasmDryRunPackage(


### PR DESCRIPTION
## Description

Adds an optional `hostArch` parameter to `Event.flutterCommandResult` in `package:unified_analytics`.

This allows the Flutter CLI (and other tools using `flutterCommandResult`) to explicitly report the host CPU architecture rather than relying on inconsistent OS version string parsing heuristics (e.g. Flutter issue flutter/flutter#191765).

## Changes
- Updated `Event.flutterCommandResult` in `lib/src/event.dart` with optional `String? hostArch`.
- Added test coverage in `test/event_test.dart`.
- Updated `CHANGELOG.md`.