### PR TITLE
[unified_analytics] Prepare for 8.0.18 release

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.0.18-wip
+## 8.0.18
 
 - Added optional `hostArch` parameter to `Event.flutterCommandResult`.
 - Added optional `pubspecHasFlutterSdk`, `pubspecEnvironmentSdk`, and

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '8.0.18-wip';
+const String kPackageVersion = '8.0.18';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 8.0.18-wip
+version: 8.0.18
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aunified_analytics


### PR DESCRIPTION
## Description

Prepares `package:unified_analytics` for release version `8.0.18`.

## Changes
- Updated version to `8.0.18` in `pubspec.yaml`.
- Updated `kPackageVersion` in `lib/src/constants.dart`.
- Removed `-wip` suffix from `CHANGELOG.md`.