### PR TITLE
[unified_analytics]Add an 'is_external' const to indicate external builds

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Dependencies are deterministically sorted and chunked using a hash-based
   algorithm salted with the canonical dependency set to fit within Google
   Analytics 4 parameter limitations without alphabetical or global package bias.
+- Add optional `minSdkConstraints` and `languageVersionOverrides` parameters
+  to the `Event.contextStructure` constructor.
+- Add `isExternal` to indicate if analytics are collected from an extenal build
+  system. The analytics consent mechanism is bypassed for non external builds.
 
 ## 8.0.17
 - Added optional `agentPlugin` parameter to the `Event.dartMCPEvent` constructor to identify 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -17,6 +17,7 @@ import 'enums.dart';
 import 'event.dart';
 import 'ga_client.dart';
 import 'initializer.dart';
+import 'is_external.dart';
 import 'log_handler.dart';
 import 'survey_handler.dart';
 import 'user_property.dart';
@@ -441,32 +442,34 @@ class AnalyticsImpl implements Analytics {
              .childDirectory(kDartToolDirectoryName)
              .childFile(kLogFileName),
        ) {
-    // This initializer class will let the instance know
-    // if it was the first run; if it is, nothing will be sent
-    // on the first run
-    if (firstRun) {
-      _showMessage = true;
-      _firstRun = true;
-    } else {
-      _showMessage = false;
-      _firstRun = false;
-    }
+    if (isExternal) {
+      // This initializer class will let the instance know
+      // if it was the first run; if it is, nothing will be sent
+      // on the first run
+      if (firstRun) {
+        _showMessage = true;
+        _firstRun = true;
+      } else {
+        _showMessage = false;
+        _firstRun = false;
+      }
 
-    // Check if the tool has already been onboarded, and if it
-    // has, check if the latest message version is greater to
-    // prompt the client to show a message
-    //
-    // If the tool has not been added to the config file, then
-    // we will show the message as well
-    final currentVersion =
-        _configHandler.parsedTools[tool.label]?.versionNumber ?? -1;
-    if (currentVersion < toolsMessageVersion) {
-      _showMessage = true;
+      // Check if the tool has already been onboarded, and if it
+      // has, check if the latest message version is greater to
+      // prompt the client to show a message
+      //
+      // If the tool has not been added to the config file, then
+      // we will show the message as well
+      final currentVersion =
+          _configHandler.parsedTools[tool.label]?.versionNumber ?? -1;
+      if (currentVersion < toolsMessageVersion) {
+        _showMessage = true;
 
-      // If the message version has been updated, it will be considered
-      // as if it was a first run and any events attempting to get sent
-      // will be blocked
-      _firstRun = true;
+        // If the message version has been updated, it will be considered
+        // as if it was a first run and any events attempting to get sent
+        // will be blocked
+        _firstRun = true;
+      }
     }
   }
 
@@ -517,7 +520,8 @@ class AnalyticsImpl implements Analytics {
   bool get shouldShowMessage => _showMessage;
 
   @override
-  bool get telemetryEnabled => _configHandler.telemetryEnabled;
+  bool get telemetryEnabled =>
+      isExternal ? _configHandler.telemetryEnabled : true;
 
   @override
   Map<String, Map<String, Object?>> get userPropertyMap =>
@@ -525,6 +529,8 @@ class AnalyticsImpl implements Analytics {
 
   @override
   void clientShowedMessage() {
+    if (!isExternal) return;
+
     // Check the tool needs to be added to the config file
     if (!_configHandler.parsedTools.containsKey(tool.label)) {
       _configHandler.addTool(

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -442,34 +442,33 @@ class AnalyticsImpl implements Analytics {
              .childDirectory(kDartToolDirectoryName)
              .childFile(kLogFileName),
        ) {
-    if (isExternal) {
-      // This initializer class will let the instance know
-      // if it was the first run; if it is, nothing will be sent
-      // on the first run
-      if (firstRun) {
-        _showMessage = true;
-        _firstRun = true;
-      } else {
-        _showMessage = false;
-        _firstRun = false;
-      }
+    if (!isExternal) return;
+    // This initializer class will let the instance know
+    // if it was the first run; if it is, nothing will be sent
+    // on the first run
+    if (firstRun) {
+      _showMessage = true;
+      _firstRun = true;
+    } else {
+      _showMessage = false;
+      _firstRun = false;
+    }
 
-      // Check if the tool has already been onboarded, and if it
-      // has, check if the latest message version is greater to
-      // prompt the client to show a message
-      //
-      // If the tool has not been added to the config file, then
-      // we will show the message as well
-      final currentVersion =
-          _configHandler.parsedTools[tool.label]?.versionNumber ?? -1;
-      if (currentVersion < toolsMessageVersion) {
-        _showMessage = true;
+    // Check if the tool has already been onboarded, and if it
+    // has, check if the latest message version is greater to
+    // prompt the client to show a message
+    //
+    // If the tool has not been added to the config file, then
+    // we will show the message as well
+    final currentVersion =
+        _configHandler.parsedTools[tool.label]?.versionNumber ?? -1;
+    if (currentVersion < toolsMessageVersion) {
+      _showMessage = true;
 
-        // If the message version has been updated, it will be considered
-        // as if it was a first run and any events attempting to get sent
-        // will be blocked
-        _firstRun = true;
-      }
+      // If the message version has been updated, it will be considered
+      // as if it was a first run and any events attempting to get sent
+      // will be blocked
+      _firstRun = true;
     }
   }
 

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -520,8 +520,7 @@ class AnalyticsImpl implements Analytics {
   bool get shouldShowMessage => _showMessage;
 
   @override
-  bool get telemetryEnabled =>
-      isExternal ? _configHandler.telemetryEnabled : true;
+  bool get telemetryEnabled => !isExternal || _configHandler.telemetryEnabled;
 
   @override
   Map<String, Map<String, Object?>> get userPropertyMap =>
@@ -655,6 +654,7 @@ class AnalyticsImpl implements Analytics {
 
   @override
   Future<void> setTelemetry(bool reportingBool) {
+    if (!isExternal) return Future.value();
     _configHandler.setTelemetry(reportingBool);
 
     // Creation of the [Event] for opting out

--- a/pkgs/unified_analytics/lib/src/config_handler.dart
+++ b/pkgs/unified_analytics/lib/src/config_handler.dart
@@ -45,10 +45,9 @@ class ConfigHandler {
   bool _telemetryEnabled = true;
 
   ConfigHandler({required this.homeDirectory, required this.configFile})
-    : configFileLastModified =
-          isExternal && configFile.existsSync()
-              ? configFile.lastModifiedSync()
-              : DateTime.fromMillisecondsSinceEpoch(0) {
+    : configFileLastModified = isExternal && configFile.existsSync()
+          ? configFile.lastModifiedSync()
+          : DateTime.fromMillisecondsSinceEpoch(0) {
     // Call the method to parse the contents of the config file when
     // this class is initialized
     if (isExternal) {

--- a/pkgs/unified_analytics/lib/src/config_handler.dart
+++ b/pkgs/unified_analytics/lib/src/config_handler.dart
@@ -9,6 +9,7 @@ import 'package:convert/convert.dart';
 import 'package:file/file.dart';
 
 import 'initializer.dart';
+import 'is_external.dart';
 import 'utils.dart';
 
 /// The regex pattern used to parse the disable analytics line.
@@ -44,10 +45,15 @@ class ConfigHandler {
   bool _telemetryEnabled = true;
 
   ConfigHandler({required this.homeDirectory, required this.configFile})
-    : configFileLastModified = configFile.lastModifiedSync() {
+    : configFileLastModified =
+          isExternal && configFile.existsSync()
+              ? configFile.lastModifiedSync()
+              : DateTime.fromMillisecondsSinceEpoch(0) {
     // Call the method to parse the contents of the config file when
     // this class is initialized
-    parseConfig();
+    if (isExternal) {
+      parseConfig();
+    }
   }
 
   /// Returns the telemetry state from the config file.
@@ -56,6 +62,9 @@ class ConfigHandler {
   /// last modified datetime is different from what was parsed when
   /// the class was initialized.
   bool get telemetryEnabled {
+    if (!isExternal) {
+      return true;
+    }
     if (configFileLastModified.isBefore(configFile.lastModifiedSync())) {
       parseConfig();
       configFileLastModified = configFile.lastModifiedSync();
@@ -68,6 +77,8 @@ class ConfigHandler {
   /// for the tool being passed in by the user and adding a
   /// [ToolInfo] object.
   void addTool({required String tool, required int versionNumber}) {
+    if (!isExternal) return;
+
     // Create the new instance of [ToolInfo] to be added
     // to the [parsedTools] map
     parsedTools[tool] = ToolInfo(
@@ -92,6 +103,8 @@ class ConfigHandler {
     required String tool,
     required int newVersionNumber,
   }) {
+    if (!isExternal) return;
+
     if (!parsedTools.containsKey(tool)) {
       return;
     }
@@ -132,6 +145,8 @@ class ConfigHandler {
   /// have been logged in the file, the dates they were last run, and
   /// determining if telemetry is enabled by parsing the file.
   void parseConfig() {
+    if (!isExternal) return;
+
     // Begin with the assumption that telemetry is always enabled
     _telemetryEnabled = true;
 
@@ -168,6 +183,8 @@ class ConfigHandler {
   /// This will reset the configuration file and clear the
   /// [parsedTools] map and trigger parsing the config again.
   void resetConfig() {
+    if (!isExternal) return;
+
     createConfigFile(configFile: configFile, homeDirectory: homeDirectory);
     parsedTools.clear();
     parseConfig();
@@ -175,6 +192,8 @@ class ConfigHandler {
 
   /// Disables the reporting capabilities if [reportingBool] is set to `false`.
   Future<void> setTelemetry(bool reportingBool) async {
+    if (!isExternal) return;
+
     final flag = reportingBool ? '1' : '0';
     final configString = await configFile.readAsString();
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -425,10 +425,15 @@ final class Event {
   ///
   /// * [minSdkConstraints] - JSON-encoded map of the minimum SDK constraints
   ///   specified in the pubspec.yaml files for all of the packages in the
-  ///   context.
+  ///   context. The format of the map is "&lt;String,int&gt;" where the key
+  ///   is the SDK version (e.g., "2.12", "2.17", etc) and the value is the
+  ///   count of packages with that constraint.
   ///
   /// * [languageVersionOverrides] - JSON-encoded map of the language version
-  ///   overrides specified for all of the libraries in the context.
+  ///   overrides specified for all of the libraries in the context. The format
+  ///   of the map is "&lt;String,String&gt;" where the key is the language
+  ///   version override and the value is the count of libraries with that
+  ///   override.
   Event.contextStructure({
     required int immediateFileCount,
     required int immediateFileLineCount,

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -422,6 +422,14 @@ final class Event {
   ///
   /// * [numberOfPackagesInWorkspace] - JSON-encoded percentile values for the
   ///   number of packages in the Pub workspaces.
+  ///
+  /// * [minSdkConstraints] - JSON-encoded map of the minimum SDK constraints
+  ///   specified in the pubspec.yaml files for all of the packages in the
+  ///   context.
+  ///
+  /// * [languageVersionOverrides] - JSON-encoded map of the language version
+  ///   overrides specified for all of the libraries in the context.  Format:
+  ///   { "2.12":5,"3.10":2}
   Event.contextStructure({
     required int immediateFileCount,
     required int immediateFileLineCount,
@@ -434,6 +442,8 @@ final class Event {
     String libraryCycleLineCounts = '',
     String contextWorkspaceType = '',
     String numberOfPackagesInWorkspace = '',
+    Map<String, int> minSdkConstraints = const {},
+    Map<String, int> languageVersionOverrides = const {},
   }) : this._(
          eventName: DashEvent.contextStructure,
          eventData: {
@@ -448,6 +458,8 @@ final class Event {
            'libraryCycleLineCounts': libraryCycleLineCounts,
            'contextWorkspaceType': contextWorkspaceType,
            'numberOfPackagesInWorkspace': numberOfPackagesInWorkspace,
+           'minSdkConstraints': minSdkConstraints,
+           'languageVersionOverrides': languageVersionOverrides,
          },
        );
 

--- a/pkgs/unified_analytics/lib/src/event.dart
+++ b/pkgs/unified_analytics/lib/src/event.dart
@@ -428,8 +428,7 @@ final class Event {
   ///   context.
   ///
   /// * [languageVersionOverrides] - JSON-encoded map of the language version
-  ///   overrides specified for all of the libraries in the context.  Format:
-  ///   { "2.12":5,"3.10":2}
+  ///   overrides specified for all of the libraries in the context.
   Event.contextStructure({
     required int immediateFileCount,
     required int immediateFileLineCount,
@@ -442,8 +441,8 @@ final class Event {
     String libraryCycleLineCounts = '',
     String contextWorkspaceType = '',
     String numberOfPackagesInWorkspace = '',
-    Map<String, int> minSdkConstraints = const {},
-    Map<String, int> languageVersionOverrides = const {},
+    String minSdkConstraints = '',
+    String languageVersionOverrides = '',
   }) : this._(
          eventName: DashEvent.contextStructure,
          eventData: {

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -6,6 +6,7 @@ import 'package:clock/clock.dart';
 import 'package:file/file.dart';
 
 import 'constants.dart';
+import 'is_external.dart';
 import 'utils.dart';
 
 /// Creates the text file that will contain the client ID
@@ -80,10 +81,12 @@ bool runInitialization({required Directory homeDirectory}) {
 
   // When the config file doesn't exist, initialize it with the default tools
   // and the current date.
-  final configFile = dartToolDirectory.childFile(kConfigFileName);
-  if (!configFile.existsSync()) {
-    firstRun = true;
-    createConfigFile(configFile: configFile, homeDirectory: homeDirectory);
+  if (isExternal) {
+    final configFile = dartToolDirectory.childFile(kConfigFileName);
+    if (!configFile.existsSync()) {
+      firstRun = true;
+      createConfigFile(configFile: configFile, homeDirectory: homeDirectory);
+    }
   }
 
   // Begin initialization checks for the client id.

--- a/pkgs/unified_analytics/lib/src/is_external.dart
+++ b/pkgs/unified_analytics/lib/src/is_external.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Indicates whether the analytics package is running in an external build.
+///
+/// When `true` (default), consent messages are displayed on first run and
+/// telemetry status is read from the configuration file.
+///
+/// When `false`, the first run check is bypassed, no consent message is shown,
+/// telemetry is always enabled, and the configuration file is not read.
+const bool isExternal = true;

--- a/pkgs/unified_analytics/lib/src/user_property.dart
+++ b/pkgs/unified_analytics/lib/src/user_property.dart
@@ -10,6 +10,7 @@ import 'package:file/file.dart';
 import 'constants.dart';
 import 'event.dart';
 import 'initializer.dart';
+import 'is_external.dart' as ie;
 import 'utils.dart';
 
 class UserProperty {
@@ -22,6 +23,7 @@ class UserProperty {
   final String locale;
   final String? clientIde;
   final String? aiAgent;
+  final bool isExternal = ie.isExternal;
 
   final File sessionFile;
 
@@ -162,5 +164,6 @@ class UserProperty {
     'locale': locale,
     'client_ide': clientIde,
     'ai_agent': aiAgent,
+    'is_external': isExternal,
   };
 }

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -174,7 +174,55 @@ void main() {
     expect(constructedEvent.eventData['libraryCycleLineCounts'], 'b');
     expect(constructedEvent.eventData['contextWorkspaceType'], '[0,1,2]');
     expect(constructedEvent.eventData['numberOfPackagesInWorkspace'], '32');
-    expect(constructedEvent.eventData.length, 11);
+    expect(constructedEvent.eventData['minSdkConstraints'], <String, int>{});
+    expect(
+      constructedEvent.eventData['languageVersionOverrides'],
+      <String, int>{},
+    );
+    expect(constructedEvent.eventData.length, 13);
+  });
+
+  test('Event.contextStructure constructed with optional parameters', () {
+    Event generateEvent() => Event.contextStructure(
+      immediateFileCount: 1,
+      immediateFileLineCount: 2,
+      numberOfContexts: 3,
+      transitiveFileCount: 4,
+      transitiveFileLineCount: 5,
+      transitiveFileUniqueCount: 6,
+      transitiveFileUniqueLineCount: 7,
+      libraryCycleLibraryCounts: 'a',
+      libraryCycleLineCounts: 'b',
+      contextWorkspaceType: '[0,1,2]',
+      numberOfPackagesInWorkspace: '32',
+      minSdkConstraints: {'2.12.0': 5, '3.0.0': 2},
+      languageVersionOverrides: {'2.12': 5, '3.10': 2},
+    );
+
+    final constructedEvent = generateEvent();
+
+    expect(generateEvent, returnsNormally);
+    expect(constructedEvent.eventName, DashEvent.contextStructure);
+    expect(constructedEvent.eventData['immediateFileCount'], 1);
+    expect(constructedEvent.eventData['immediateFileLineCount'], 2);
+    expect(constructedEvent.eventData['numberOfContexts'], 3);
+    expect(constructedEvent.eventData['transitiveFileCount'], 4);
+    expect(constructedEvent.eventData['transitiveFileLineCount'], 5);
+    expect(constructedEvent.eventData['transitiveFileUniqueCount'], 6);
+    expect(constructedEvent.eventData['transitiveFileUniqueLineCount'], 7);
+    expect(constructedEvent.eventData['libraryCycleLibraryCounts'], 'a');
+    expect(constructedEvent.eventData['libraryCycleLineCounts'], 'b');
+    expect(constructedEvent.eventData['contextWorkspaceType'], '[0,1,2]');
+    expect(constructedEvent.eventData['numberOfPackagesInWorkspace'], '32');
+    expect(
+      constructedEvent.eventData['minSdkConstraints'],
+      {'2.12.0': 5, '3.0.0': 2},
+    );
+    expect(
+      constructedEvent.eventData['languageVersionOverrides'],
+      {'2.12': 5, '3.10': 2},
+    );
+    expect(constructedEvent.eventData.length, 13);
   });
 
   test('Event.dartCliCommandExecuted constructed', () {

--- a/pkgs/unified_analytics/test/event_test.dart
+++ b/pkgs/unified_analytics/test/event_test.dart
@@ -174,11 +174,8 @@ void main() {
     expect(constructedEvent.eventData['libraryCycleLineCounts'], 'b');
     expect(constructedEvent.eventData['contextWorkspaceType'], '[0,1,2]');
     expect(constructedEvent.eventData['numberOfPackagesInWorkspace'], '32');
-    expect(constructedEvent.eventData['minSdkConstraints'], <String, int>{});
-    expect(
-      constructedEvent.eventData['languageVersionOverrides'],
-      <String, int>{},
-    );
+    expect(constructedEvent.eventData['minSdkConstraints'], '');
+    expect(constructedEvent.eventData['languageVersionOverrides'], '');
     expect(constructedEvent.eventData.length, 13);
   });
 
@@ -195,8 +192,8 @@ void main() {
       libraryCycleLineCounts: 'b',
       contextWorkspaceType: '[0,1,2]',
       numberOfPackagesInWorkspace: '32',
-      minSdkConstraints: {'2.12.0': 5, '3.0.0': 2},
-      languageVersionOverrides: {'2.12': 5, '3.10': 2},
+      minSdkConstraints: '{"2.12.0":5,"3.0.0":2}',
+      languageVersionOverrides: '{"2.12":5,"3.10":2}',
     );
 
     final constructedEvent = generateEvent();
@@ -216,11 +213,11 @@ void main() {
     expect(constructedEvent.eventData['numberOfPackagesInWorkspace'], '32');
     expect(
       constructedEvent.eventData['minSdkConstraints'],
-      {'2.12.0': 5, '3.0.0': 2},
+      '{"2.12.0":5,"3.0.0":2}',
     );
     expect(
       constructedEvent.eventData['languageVersionOverrides'],
-      {'2.12': 5, '3.10': 2},
+      '{"2.12":5,"3.10":2}',
     );
     expect(constructedEvent.eventData.length, 13);
   });

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -14,6 +14,8 @@ import 'package:file/memory.dart';
 import 'package:test/test.dart';
 import 'package:unified_analytics/src/constants.dart';
 import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/src/is_external.dart';
+import 'package:unified_analytics/src/user_property.dart';
 import 'package:unified_analytics/src/utils.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 import 'package:yaml/yaml.dart';
@@ -808,6 +810,7 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       'locale',
       'client_ide',
       'ai_agent',
+      'is_external',
     ];
     expect(
       analytics.userPropertyMap.keys.length,
@@ -822,6 +825,39 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
       );
     }
   });
+
+  test('The isExternal constant is true by default', () {
+    expect(isExternal, true);
+  });
+
+  test(
+    'The UserProperty class correctly sets and exposes the is_external value',
+    () {
+      expect(
+        analytics.userPropertyMap['is_external']?['value'],
+        isExternal,
+        reason: 'The is_external user property should mirror isExternal',
+      );
+
+      final userProperty = UserProperty(
+        flutterChannel: flutterChannel,
+        host: 'macos',
+        flutterVersion: flutterVersion,
+        dartVersion: dartVersion,
+        tool: initialTool.label,
+        hostOsVersion: '14.0',
+        locale: 'en',
+        clientIde: null,
+        aiAgent: null,
+        sessionFile: sessionFile,
+      );
+      expect(userProperty.isExternal, isExternal);
+      expect(
+        userProperty.preparePayload()['is_external']?['value'],
+        isExternal,
+      );
+    },
+  );
 
   test(
     'The UserProperty class correctly sets and exposes the ai_agent value',


### PR DESCRIPTION
Adds an `is_external` const to indicate external builds, default value is `true`.

-  telemetry is enabled when `is_external` is false.
- This const is defined in `is_external.dart`, to make it easier to maintain.
- The `firstRun` and config file is not used when `is_external` is false.
- The consent dialog is only shown for external builds.
- This value is logged as part of `UserProperty`. 

For analysis server stats, added fields to `Event.contextStructure` to capture 
- minimum SDK version constraints specified in `pubspec.yaml` files  in a workspace, 
- language version overrides in libraries in the workspace