### PR TITLE
Prepare to publish packages

### DIFF
--- a/pkgs/browser_launcher/CHANGELOG.md
+++ b/pkgs/browser_launcher/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0-wip
+## 1.2.0
 
 - Add `--test-type` and `--disable-session-crashed-bubble` flags when launching
   chrome to prevent some warnings.

--- a/pkgs/browser_launcher/pubspec.yaml
+++ b/pkgs/browser_launcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: browser_launcher
-version: 1.2.0-wip
+version: 1.2.0
 description: Provides a standardized way to launch web browsers for testing and tools.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/browser_launcher
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Abrowser_launcher

--- a/pkgs/clock/CHANGELOG.md
+++ b/pkgs/clock/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.3-wip
+## 1.1.3
 
 * Keep microseconds when using `monthsAgo`, `monthsFromNow` and `yearsAgo`
 

--- a/pkgs/clock/pubspec.yaml
+++ b/pkgs/clock/pubspec.yaml
@@ -1,5 +1,5 @@
 name: clock
-version: 1.1.3-wip
+version: 1.1.3
 description: A fakeable wrapper for dart:core clock APIs.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/clock
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aclock

--- a/pkgs/code_builder/CHANGELOG.md
+++ b/pkgs/code_builder/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.12.0-wip
+## 4.12.0
 
 - Add `MixinBuilder.onTypes` to support a mixin `on` clause with multiple
   superclass constraints (e.g. `mixin Foo on A, B {}`). Takes precedence over

--- a/pkgs/code_builder/pubspec.yaml
+++ b/pkgs/code_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.12.0-wip
+version: 4.12.0
 description: A fluent, builder-based library for generating valid Dart code.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/code_builder
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Acode_builder

--- a/pkgs/file_testing/CHANGELOG.md
+++ b/pkgs/file_testing/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.0-wip
+## 3.1.0
 
 * Changed the type of several matchers to `TypeMatcher` which allows cascading
   their usage with `.having` and similar. 

--- a/pkgs/file_testing/pubspec.yaml
+++ b/pkgs/file_testing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file_testing
-version: 3.1.0-wip
+version: 3.1.0
 description: Testing utilities for package:file.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/file_testing
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Afile_testing

--- a/pkgs/glob/CHANGELOG.md
+++ b/pkgs/glob/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0-wip
+## 2.2.0
 
 - Limit option expansion during glob listing (`list()` and `listSync()`) to a
   maximum of 10,000 branches. Globs with combinatorial option expansions

--- a/pkgs/glob/pubspec.yaml
+++ b/pkgs/glob/pubspec.yaml
@@ -1,5 +1,5 @@
 name: glob
-version: 2.2.0-wip
+version: 2.2.0
 description: A library to perform Bash-style file and directory globbing.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/glob
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aglob

--- a/pkgs/html/CHANGELOG.md
+++ b/pkgs/html/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.7-wip
+## 0.15.7
 
 - `writeTextNodeAsHtml`: Escape text inside `<script>` and `<style>`-like tags in foreign namespaces.
 - Fix the tokenizer failing to close CDATA blocks when encountering extra brackets

--- a/pkgs/html/pubspec.yaml
+++ b/pkgs/html/pubspec.yaml
@@ -1,5 +1,5 @@
 name: html
-version: 0.15.7-wip
+version: 0.15.7
 description: APIs for parsing and manipulating HTML content outside the browser.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/html
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ahtml

--- a/pkgs/io/CHANGELOG.md
+++ b/pkgs/io/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0-wip
+## 1.1.0
 
 * Add a `deepCopyLinks` argument to `copyPath` and `copyPathSync`.
 * Remove the `@visibleForTesting` annotation from `SharedStdIn`.

--- a/pkgs/io/pubspec.yaml
+++ b/pkgs/io/pubspec.yaml
@@ -1,5 +1,5 @@
 name: io
-version: 1.1.0-wip
+version: 1.1.0
 description: >-
   Utilities for the Dart VM Runtime including support for ANSI colors, file
   copying, and standard exit code values.

--- a/pkgs/mime/CHANGELOG.md
+++ b/pkgs/mime/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0-wip
+## 2.1.0
 
 * Switched to using the Apache httpd mime.conf table as the source of truth for
   mime types.

--- a/pkgs/mime/pubspec.yaml
+++ b/pkgs/mime/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mime
-version: 2.1.0-wip
+version: 2.1.0
 description: >-
   Utilities for handling media (MIME) types, including determining a type from
   a file extension and file contents.

--- a/pkgs/pool/CHANGELOG.md
+++ b/pkgs/pool/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.5.3-wip
+## 1.5.3
 
 * Fix `Pool.forEach` to ensure all workers complete before the stream is closed, even on error or cancellation.
 * Added an example.

--- a/pkgs/pool/pubspec.yaml
+++ b/pkgs/pool/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pool
-version: 1.5.3-wip
+version: 1.5.3
 description: >-
   Manage a finite pool of resources. Useful for controlling concurrent file
   system or network requests.

--- a/pkgs/process/CHANGELOG.md
+++ b/pkgs/process/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.6-wip
+## 5.0.6
 
 * Add an example app.
 * Fix `getExecutablePath()` to support forward slashes on Windows.

--- a/pkgs/process/pubspec.yaml
+++ b/pkgs/process/pubspec.yaml
@@ -1,6 +1,6 @@
 name: process
 description: A pluggable, mockable process invocation abstraction for Dart.
-version: 5.0.6-wip
+version: 5.0.6
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/process
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aprocess
 

--- a/pkgs/pub_semver/CHANGELOG.md
+++ b/pkgs/pub_semver/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.1-wip
+## 2.2.1
 
 - Fix parsing of pre-release and build identifiers to only treat pure-digit
   base-10 identifiers as integers, treating hexadecimal and signed identifiers

--- a/pkgs/pub_semver/pubspec.yaml
+++ b/pkgs/pub_semver/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pub_semver
-version: 2.2.1-wip
+version: 2.2.1
 description: >-
   Versions and version constraints implementing pub's versioning policy. This
   is very similar to vanilla semver, with a few corner cases.

--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.0-wip
+## 1.6.0
 
 - Added `toJson` method to `Pubspec` to serialize the object back to a `Map`.
 - Parse `HostedDetails.url` as a non-git URI.

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.6.0-wip
+version: 1.6.0
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.

--- a/pkgs/stack_trace/CHANGELOG.md
+++ b/pkgs/stack_trace/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.12.2-wip
+## 1.12.2
 
 * Relax parsing of V8 traces to allow a missing initial description.
 

--- a/pkgs/stack_trace/pubspec.yaml
+++ b/pkgs/stack_trace/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stack_trace
-version: 1.12.2-wip
+version: 1.12.2
 description: A package for manipulating stack traces and printing them readably.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/stack_trace
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Astack_trace

--- a/pkgs/stream_transform/CHANGELOG.md
+++ b/pkgs/stream_transform/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.2-wip
+## 2.1.2
 
 - Fix an exception when a subscription to a `combineLatest` stream is canceled
   while there is an ongoing asynchronous combine callback.

--- a/pkgs/stream_transform/pubspec.yaml
+++ b/pkgs/stream_transform/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_transform
-version: 2.1.2-wip
+version: 2.1.2
 description: A collection of utilities to transform and manipulate streams.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/stream_transform
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Astream_transform

--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 3.1.4-wip
+## 3.1.4
+
 * Improve recovery for list entries without `-` prefix. When recovering, provide
   a more helpful error message suggesting the missing prefix.
 * Fix a bug where block strings terminated by `EOF` were not given an implicit

--- a/pkgs/yaml/pubspec.yaml
+++ b/pkgs/yaml/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml
-version: 3.1.4-wip
+version: 3.1.4
 description: A parser for YAML, a human-friendly data serialization standard
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/yaml
 issue_tracker: https://github.com/dart-lang/tools/labels/package%3Ayaml


### PR DESCRIPTION
Drop `-wip` version suffix from packages which have user facing changes
other than SDK constraint bumps mentioned in their CHANGELOG and have no
changes in `lib/` since the last package roll.
