### PR TITLE
[glob] Make `listFileSystemFiles` check the context of the file system.

### DIFF
--- a/pkgs/glob/CHANGELOG.md
+++ b/pkgs/glob/CHANGELOG.md
@@ -6,6 +6,8 @@
   exhaustion. `Glob.matches()` uses regular expressions and is unaffected.
 - Allow `**` to match zero directories at the start of a pattern or following
   a separator (e.g. `**/foo` matches `foo` and `a/**/b` matches `a/b`).
+- Check the glob's path context against the file system's path context
+  when listing files, rather than using the unrelated platform path context.
 
 ## 2.1.3
 

--- a/pkgs/glob/lib/glob.dart
+++ b/pkgs/glob/lib/glob.dart
@@ -120,9 +120,13 @@ class Glob implements Pattern {
   /// [followLinks] works the same as for [Directory.list].
   Stream<FileSystemEntity> listFileSystem(FileSystem fileSystem,
       {String? root, bool followLinks = true}) {
-    if (context.style != p.style) {
-      throw StateError("Can't list glob \"$this\"; it matches "
-          '${context.style} paths, but this platform uses ${p.style} paths.');
+    if (context.style != fileSystem.path.style) {
+      throw ArgumentError.value(
+          fileSystem,
+          'fileSystem',
+          '''Can't list using glob \"$this\"; it matches '''
+              '${context.style} paths, but the file system uses '
+              '${fileSystem.path.style} paths.');
     }
 
     return _listTreeForFileSystem(fileSystem)
@@ -142,9 +146,13 @@ class Glob implements Pattern {
   /// [followLinks] works the same as for [Directory.list].
   List<FileSystemEntity> listFileSystemSync(FileSystem fileSystem,
       {String? root, bool followLinks = true}) {
-    if (context.style != p.style) {
-      throw StateError("Can't list glob \"$this\"; it matches "
-          '${context.style} paths, but this platform uses ${p.style} paths.');
+    if (context.style != fileSystem.path.style) {
+      throw ArgumentError.value(
+          fileSystem,
+          'fileSystem',
+          '''Can't list using glob \"$this\"; it matches '''
+              '${context.style} paths, but the file system uses '
+              '${fileSystem.path.style} paths.');
     }
 
     return _listTreeForFileSystem(fileSystem)
@@ -189,6 +197,7 @@ class Glob implements Pattern {
 
   /// Handles getting a possibly cached [ListTree] for a [fileSystem].
   ListTree _listTreeForFileSystem(FileSystem fileSystem) {
+    assert(context.style == fileSystem.path.style);
     // Don't use cached trees for in memory file systems to avoid memory leaks.
     if (fileSystem is MemoryFileSystem) return ListTree(_ast, fileSystem);
 

--- a/pkgs/glob/lib/src/list_tree.dart
+++ b/pkgs/glob/lib/src/list_tree.dart
@@ -69,6 +69,8 @@ class ListTree {
       : _canOverlap = _computeCanOverlap(_trees);
 
   factory ListTree(AstNode glob, FileSystem fileSystem) {
+    // Glob is known to use same context style as `fileSystem.path`.
+
     // The first step in constructing a tree from the glob is to simplify the
     // problem by eliminating options. [glob.flattenOptions] bubbles all options
     // (and certain ranges) up to the top level of the glob so we can deal with
@@ -79,7 +81,7 @@ class ListTree {
     for (var option in options.options) {
       // Since each option doesn't include its own options, we can safely split
       // it into path components.
-      var components = option.split(p.context);
+      var components = option.split(fileSystem.path);
       var firstNode = components.first.nodes.first;
       var root = '.';
 
@@ -87,8 +89,8 @@ class ListTree {
       // root's just ".".
       if (firstNode is LiteralNode) {
         var text = firstNode.text;
-        // Platform agnostic way of checking for Windows without `dart:io`.
-        if (p.context == p.windows) text.replaceAll('/', '\\');
+        if (fileSystem.path.style == p.windows.style)
+          text.replaceAll('/', r'\');
         if (p.isAbsolute(text)) {
           // If the path is absolute, the root should be the only thing in the
           // first component.

--- a/pkgs/glob/test/list_test.dart
+++ b/pkgs/glob/test/list_test.dart
@@ -8,6 +8,7 @@ library;
 import 'dart:async';
 import 'dart:io';
 
+import 'package:file/memory.dart';
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
 import 'package:glob/src/utils.dart';
@@ -24,8 +25,16 @@ void main() {
   });
 
   group('list()', () {
-    test("fails if the context doesn't match the system context", () {
-      expect(Glob('*', context: p.url).list, throwsStateError);
+    test("fails if the fileSystem context doesn't match the glob context", () {
+      expect(Glob('*', context: p.url).list, throwsArgumentError);
+    });
+
+    test("does not fail if the fileSystem and glob contexts match", () {
+      // Shouldn't fail even if neither is the platform context.
+      Glob('*', context: p.posix)
+          .listFileSystem(MemoryFileSystem(style: FileSystemStyle.posix));
+      Glob('*', context: p.windows)
+          .listFileSystem(MemoryFileSystem(style: FileSystemStyle.windows));
     });
 
     test('returns empty list for non-existent case-sensitive directories',
@@ -43,8 +52,16 @@ void main() {
   });
 
   group('listSync()', () {
-    test("fails if the context doesn't match the system context", () {
-      expect(Glob('*', context: p.url).listSync, throwsStateError);
+    test("fails if the fileSystem context doesn't match the glob context", () {
+      expect(Glob('*', context: p.url).listSync, throwsArgumentError);
+    });
+
+    test("does not fail if the fileSystem and glob contexts match", () {
+      // Shouldn't fail even if neither is the platform context.
+      Glob('*', context: p.posix)
+          .listFileSystemSync(MemoryFileSystem(style: FileSystemStyle.posix));
+      Glob('*', context: p.windows)
+          .listFileSystemSync(MemoryFileSystem(style: FileSystemStyle.windows));
     });
 
     test('returns empty list for non-existent case-sensitive directories', () {


### PR DESCRIPTION
Fixes #1998

Makes the `ListTree` class use the `fileSystem.path` path context instead of the platform context, `p.context` of `package:path`.
Calls to `ListTree` checks that the glob's path context and the file system's path context are the same style.

