### PR TITLE
[pubspec_parse] Support tag_pattern for git dependencies

### DIFF
--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.0-wip
+
+- Added `tagPattern` and `version` fields to `GitDependency`, to support the
+  `tag_pattern` key for git dependencies introduced in Dart 3.9.
+
 ## 1.6.0
 
 - Added `toJson` method to `Pubspec` to serialize the object back to a `Map`.

--- a/pkgs/pubspec_parse/lib/src/dependency.dart
+++ b/pkgs/pubspec_parse/lib/src/dependency.dart
@@ -142,36 +142,14 @@ class GitDependency extends Dependency {
   /// See https://dart.dev/tools/pub/dependencies#git-packages.
   final String? tagPattern;
 
-  /// The version constraint specified next to the `git` source, if any.
+  /// The version constraint specified next to the `git` source.
   ///
+  /// `null` if no constraint is specified, which pub treats as any version.
   /// This is mostly useful together with [tagPattern].
   @JsonKey(includeFromJson: false)
   final VersionConstraint? version;
 
-  GitDependency(
-    this.url, {
-    this.ref,
-    this.path,
-    this.tagPattern,
-    this.version,
-  }) {
-    if (tagPattern case final tagPattern?) {
-      if (tagPattern.split(_tagPatternVersionMarker).length != 2) {
-        throw ArgumentError.value(
-          tagPattern,
-          'tagPattern',
-          'Must contain a single "$_tagPatternVersionMarker".',
-        );
-      }
-      if (ref != null) {
-        throw ArgumentError.value(
-          tagPattern,
-          'tagPattern',
-          'Cannot be used together with "ref".',
-        );
-      }
-    }
-  }
+  GitDependency(this.url, {this.ref, this.path, this.tagPattern, this.version});
 
   factory GitDependency.fromData(Object? data, {VersionConstraint? version}) {
     if (data is String) {
@@ -180,6 +158,7 @@ class GitDependency extends Dependency {
 
     if (data is Map) {
       final parsed = _$GitDependencyFromJson(data);
+      _validateTagPattern(data, parsed);
       return GitDependency(
         parsed.url,
         ref: parsed.ref,
@@ -190,6 +169,29 @@ class GitDependency extends Dependency {
     }
 
     throw ArgumentError.value(data, 'git', 'Must be a String or a Map.');
+  }
+
+  static void _validateTagPattern(Map data, GitDependency parsed) {
+    final tagPattern = parsed.tagPattern;
+    if (tagPattern == null) {
+      return;
+    }
+    if (tagPattern.split(_tagPatternVersionMarker).length != 2) {
+      throw CheckedFromJsonException(
+        data,
+        'tag_pattern',
+        'GitDependency',
+        'Must contain a single "$_tagPatternVersionMarker".',
+      );
+    }
+    if (parsed.ref != null) {
+      throw CheckedFromJsonException(
+        data,
+        'tag_pattern',
+        'GitDependency',
+        'Cannot be used together with "ref".',
+      );
+    }
   }
 
   @override

--- a/pkgs/pubspec_parse/lib/src/dependency.dart
+++ b/pkgs/pubspec_parse/lib/src/dependency.dart
@@ -81,7 +81,10 @@ Dependency? _fromJson(Object? data, String name) {
         final key = matchedKeys.single;
 
         return switch (key) {
-          'git' => GitDependency.fromData(data[key]),
+          'git' => GitDependency.fromData(
+            data[key],
+            version: _optionalConstraintFromData(data),
+          ),
           'path' => PathDependency.fromData(data[key]),
           'sdk' => _$SdkDependencyFromJson(data),
           'hosted' => _$HostedDependencyFromJson(
@@ -131,15 +134,59 @@ class GitDependency extends Dependency {
   final String? ref;
   final String? path;
 
-  GitDependency(this.url, {this.ref, this.path});
+  /// A pattern used to find version tagged commits in the repository.
+  ///
+  /// Must contain a single `{{version}}` marker, for example `v{{version}}`.
+  /// Cannot be combined with [ref].
+  ///
+  /// See https://dart.dev/tools/pub/dependencies#git-packages.
+  final String? tagPattern;
 
-  factory GitDependency.fromData(Object? data) {
+  /// The version constraint specified next to the `git` source, if any.
+  ///
+  /// This is mostly useful together with [tagPattern].
+  @JsonKey(includeFromJson: false)
+  final VersionConstraint? version;
+
+  GitDependency(
+    this.url, {
+    this.ref,
+    this.path,
+    this.tagPattern,
+    this.version,
+  }) {
+    if (tagPattern case final tagPattern?) {
+      if (tagPattern.split(_tagPatternVersionMarker).length != 2) {
+        throw ArgumentError.value(
+          tagPattern,
+          'tagPattern',
+          'Must contain a single "$_tagPatternVersionMarker".',
+        );
+      }
+      if (ref != null) {
+        throw ArgumentError.value(
+          tagPattern,
+          'tagPattern',
+          'Cannot be used together with "ref".',
+        );
+      }
+    }
+  }
+
+  factory GitDependency.fromData(Object? data, {VersionConstraint? version}) {
     if (data is String) {
       data = {'url': data};
     }
 
     if (data is Map) {
-      return _$GitDependencyFromJson(data);
+      final parsed = _$GitDependencyFromJson(data);
+      return GitDependency(
+        parsed.url,
+        ref: parsed.ref,
+        path: parsed.path,
+        tagPattern: parsed.tagPattern,
+        version: version,
+      );
     }
 
     throw ArgumentError.value(data, 'git', 'Must be a String or a Map.');
@@ -150,19 +197,29 @@ class GitDependency extends Dependency {
       other is GitDependency &&
       other.url == url &&
       other.ref == ref &&
-      other.path == path;
+      other.path == path &&
+      other.tagPattern == tagPattern &&
+      other.version == version;
 
   @override
-  int get hashCode => Object.hash(url, ref, path);
+  int get hashCode => Object.hash(url, ref, path, tagPattern, version);
 
   @override
   String toString() => 'GitDependency: url@$url';
 
   @override
   Map<String, dynamic> toJson() => {
-    'git': {'url': url.toString(), 'ref': ?ref, 'path': ?path},
+    'git': {
+      'url': url.toString(),
+      'ref': ?ref,
+      'path': ?path,
+      'tag_pattern': ?tagPattern,
+    },
+    'version': ?version?.toString(),
   };
 }
+
+const _tagPatternVersionMarker = '{{version}}';
 
 Uri? _parseUriOrNull(String? value) => value == null ? null : Uri.parse(value);
 
@@ -306,3 +363,23 @@ class HostedDetails {
 
 VersionConstraint _constraintFromString(String? input) =>
     input == null ? VersionConstraint.any : VersionConstraint.parse(input);
+
+VersionConstraint? _optionalConstraintFromData(Map data) {
+  final value = data['version'];
+  if (value == null) {
+    return null;
+  }
+  if (value is! String) {
+    throw CheckedFromJsonException(
+      data,
+      'version',
+      'GitDependency',
+      '`$value` is not a String.',
+    );
+  }
+  try {
+    return VersionConstraint.parse(value);
+  } on FormatException catch (e) {
+    throw CheckedFromJsonException(data, 'version', 'GitDependency', e.message);
+  }
+}

--- a/pkgs/pubspec_parse/lib/src/dependency.g.dart
+++ b/pkgs/pubspec_parse/lib/src/dependency.g.dart
@@ -26,9 +26,10 @@ GitDependency _$GitDependencyFromJson(Map json) =>
         $checkedConvert('url', (v) => parseGitUri(v as String)),
         ref: $checkedConvert('ref', (v) => v as String?),
         path: $checkedConvert('path', (v) => v as String?),
+        tagPattern: $checkedConvert('tag_pattern', (v) => v as String?),
       );
       return val;
-    });
+    }, fieldKeyMap: const {'tagPattern': 'tag_pattern'});
 
 HostedDependency _$HostedDependencyFromJson(Map json) =>
     $checkedCreate('HostedDependency', json, ($checkedConvert) {

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.6.0
+version: 1.7.0-wip
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.

--- a/pkgs/pubspec_parse/test/dependency_test.dart
+++ b/pkgs/pubspec_parse/test/dependency_test.dart
@@ -10,6 +10,11 @@ import 'package:test/test.dart';
 
 import 'test_utils.dart';
 
+/// The pub client only accepts `tag_pattern` from Dart 3.9, so the
+/// cross-check against it is skipped on older SDKs.
+final _sdkSupportsTagPattern =
+    Version.parse(Platform.version.split(' ').first) >= Version(3, 9, 0);
+
 void main() {
   group('hosted', _hostedDependency);
   group('git', _gitDependency);
@@ -331,10 +336,14 @@ line 6, column 4: Unrecognized keys: [bob]; supported keys: [sdk, git, path, hos
   });
 
   test('map with tag_pattern and version', () async {
-    final dep = await _dependency<GitDependency>({
-      'git': {'url': 'url', 'path': 'path', 'tag_pattern': 'v{{version}}'},
-      'version': '^1.2.3',
-    }, sdkConstraint: '^3.9.0');
+    final dep = await _dependency<GitDependency>(
+      {
+        'git': {'url': 'url', 'path': 'path', 'tag_pattern': 'v{{version}}'},
+        'version': '^1.2.3',
+      },
+      sdkConstraint: '^3.9.0',
+      skipTryPub: !_sdkSupportsTagPattern,
+    );
     expect(dep.url.toString(), 'url');
     expect(dep.path, 'path');
     expect(dep.ref, isNull);
@@ -344,9 +353,13 @@ line 6, column 4: Unrecognized keys: [bob]; supported keys: [sdk, git, path, hos
   });
 
   test('map with tag_pattern without version', () async {
-    final dep = await _dependency<GitDependency>({
-      'git': {'url': 'url', 'tag_pattern': 'v{{version}}'},
-    }, sdkConstraint: '^3.9.0');
+    final dep = await _dependency<GitDependency>(
+      {
+        'git': {'url': 'url', 'tag_pattern': 'v{{version}}'},
+      },
+      sdkConstraint: '^3.9.0',
+      skipTryPub: !_sdkSupportsTagPattern,
+    );
     expect(dep.tagPattern, 'v{{version}}');
     expect(dep.version, isNull);
   });

--- a/pkgs/pubspec_parse/test/dependency_test.dart
+++ b/pkgs/pubspec_parse/test/dependency_test.dart
@@ -247,7 +247,7 @@ void _gitDependency() {
     expect(dep.toString(), 'GitDependency: url@url');
   });
 
-  test('string with version key is ignored', () async {
+  test('string with version key', () async {
     // Regression test for https://github.com/dart-lang/pubspec_parse/issues/13
     final dep = await _dependency<GitDependency>({
       'git': 'url',
@@ -256,7 +256,40 @@ void _gitDependency() {
     expect(dep.url.toString(), 'url');
     expect(dep.path, isNull);
     expect(dep.ref, isNull);
+    expect(dep.tagPattern, isNull);
+    expect(dep.version, VersionConstraint.parse('^1.2.3'));
     expect(dep.toString(), 'GitDependency: url@url');
+  });
+
+  test('string without version key', () async {
+    final dep = await _dependency<GitDependency>({'git': 'url'});
+    expect(dep.version, isNull);
+  });
+
+  test('string with invalid version key fails', () {
+    _expectThrows(
+      {'git': 'url', 'version': 'not a version'},
+      r'''
+line 6, column 15: Unsupported value for "version". Could not parse version "not a version". Unknown text at "not a version".
+  ╷
+6 │    "version": "not a version"
+  │               ^^^^^^^^^^^^^^^
+  ╵''',
+    );
+  });
+
+  test('string with non-String version key fails', () {
+    _expectThrows(
+      {'git': 'url', 'version': 42},
+      r'''
+line 6, column 15: Unsupported value for "version". `42` is not a String.
+  ╷
+6 │      "version": 42
+  │ ┌───────────────^
+7 │ │   }
+  │ └──^
+  ╵''',
+    );
   });
 
   test('string with user@ URL', () async {
@@ -292,7 +325,86 @@ line 6, column 4: Unrecognized keys: [bob]; supported keys: [sdk, git, path, hos
     expect(dep.url.toString(), 'url');
     expect(dep.path, 'path');
     expect(dep.ref, 'ref');
+    expect(dep.tagPattern, isNull);
+    expect(dep.version, isNull);
     expect(dep.toString(), 'GitDependency: url@url');
+  });
+
+  test('map with tag_pattern and version', () async {
+    final dep = await _dependency<GitDependency>({
+      'git': {'url': 'url', 'path': 'path', 'tag_pattern': 'v{{version}}'},
+      'version': '^1.2.3',
+    }, sdkConstraint: '^3.9.0');
+    expect(dep.url.toString(), 'url');
+    expect(dep.path, 'path');
+    expect(dep.ref, isNull);
+    expect(dep.tagPattern, 'v{{version}}');
+    expect(dep.version, VersionConstraint.parse('^1.2.3'));
+    expect(dep.toString(), 'GitDependency: url@url');
+  });
+
+  test('map with tag_pattern without version', () async {
+    final dep = await _dependency<GitDependency>({
+      'git': {'url': 'url', 'tag_pattern': 'v{{version}}'},
+    }, sdkConstraint: '^3.9.0');
+    expect(dep.tagPattern, 'v{{version}}');
+    expect(dep.version, isNull);
+  });
+
+  test('map with tag_pattern and ref fails', () {
+    _expectThrows(
+      {
+        'git': {'url': 'url', 'ref': 'ref', 'tag_pattern': 'v{{version}}'},
+      },
+      r'''
+line 11, column 20: Unsupported value for "tag_pattern". Cannot be used together with "ref".
+   ╷
+11 │     "tag_pattern": "v{{version}}"
+   │                    ^^^^^^^^^^^^^^
+   ╵''',
+      sdkConstraint: '^3.9.0',
+    );
+  });
+
+  test('map with tag_pattern missing {{version}} fails', () {
+    _expectThrows(
+      {
+        'git': {'url': 'url', 'tag_pattern': 'v'},
+      },
+      r'''
+line 10, column 20: Unsupported value for "tag_pattern". Must contain a single "{{version}}".
+   ╷
+10 │     "tag_pattern": "v"
+   │                    ^^^
+   ╵''',
+      sdkConstraint: '^3.9.0',
+    );
+  });
+
+  test('map with tag_pattern containing {{version}} twice fails', () {
+    _expectThrows(
+      {
+        'git': {'url': 'url', 'tag_pattern': '{{version}}-{{version}}'},
+      },
+      r'''
+line 10, column 20: Unsupported value for "tag_pattern". Must contain a single "{{version}}".
+   ╷
+10 │     "tag_pattern": "{{version}}-{{version}}"
+   │                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   ╵''',
+      sdkConstraint: '^3.9.0',
+    );
+  });
+
+  test('map with non-String tag_pattern fails', () {
+    _expectThrowsContaining(
+      {
+        'git': {'url': 'url', 'tag_pattern': 42},
+      },
+      'Unsupported value for "tag_pattern". '
+      "type 'int' is not a subtype of type 'String?' in type cast",
+      sdkConstraint: '^3.9.0',
+    );
   });
 
   test('git - null content', () {
@@ -399,16 +511,26 @@ line 5, column 12: Unsupported value for "path". Must be a String.
   });
 }
 
-void _expectThrows(Object content, String expectedError) {
+void _expectThrows(
+  Object content,
+  String expectedError, {
+  String? sdkConstraint,
+}) {
   expectParseThrows({
     'name': 'sample',
+    if (sdkConstraint != null) 'environment': {'sdk': sdkConstraint},
     'dependencies': {'dep': content},
   }, expectedError);
 }
 
-void _expectThrowsContaining(Object content, String errorText) {
+void _expectThrowsContaining(
+  Object content,
+  String errorText, {
+  String? sdkConstraint,
+}) {
   expectParseThrowsContaining({
     'name': 'sample',
+    if (sdkConstraint != null) 'environment': {'sdk': sdkConstraint},
     'dependencies': {'dep': content},
   }, errorText);
 }
@@ -416,9 +538,11 @@ void _expectThrowsContaining(Object content, String errorText) {
 Future<T> _dependency<T extends Dependency>(
   Object? content, {
   bool skipTryPub = false,
+  String? sdkConstraint,
 }) async {
   final value = await parse({
     ...defaultPubspec,
+    if (sdkConstraint != null) 'environment': {'sdk': sdkConstraint},
     'dependencies': {'dep': content},
   }, skipTryPub: skipTryPub);
   expect(value.name, 'sample');

--- a/pkgs/pubspec_parse/test/tojson_test.dart
+++ b/pkgs/pubspec_parse/test/tojson_test.dart
@@ -222,6 +222,13 @@ void main() {
               'path': 'packages/shared_preferences/shared_preferences',
             },
           },
+          'kittens': {
+            'git': {
+              'url': 'https://github.com/munificent/kittens.git',
+              'tag_pattern': 'v{{version}}',
+            },
+            'version': '^2.0.1',
+          },
           'local_utils': {'path': '../local_utils'},
         },
       }, skipTryPub: true);
@@ -230,7 +237,7 @@ void main() {
 
       final newValue = await parse(jsonValue, skipTryPub: true);
 
-      expect(value.dependencies, hasLength(8));
+      expect(value.dependencies, hasLength(9));
       expect(value.dependencies, {
         'flutter': isA<SdkDependency>(),
         'http': isA<HostedDependency>(),
@@ -239,6 +246,7 @@ void main() {
         'google_fonts': isA<SdkDependency>(),
         'flutter_bloc': isA<GitDependency>(),
         'shared_preferences': isA<GitDependency>(),
+        'kittens': isA<GitDependency>(),
         'local_utils': isA<PathDependency>(),
       });
 
@@ -269,6 +277,17 @@ void main() {
       expect(
         value.dependencies['shared_preferences']?.toJson(),
         newValue.dependencies['shared_preferences']?.toJson(),
+      );
+      expect(value.dependencies['kittens']?.toJson(), {
+        'git': {
+          'url': 'https://github.com/munificent/kittens.git',
+          'tag_pattern': 'v{{version}}',
+        },
+        'version': '^2.0.1',
+      });
+      expect(
+        value.dependencies['kittens']?.toJson(),
+        newValue.dependencies['kittens']?.toJson(),
       );
       expect(
         value.dependencies['local_utils']?.toJson(),


### PR DESCRIPTION
Fixes #2155

Adds support for the `tag_pattern` key on git dependencies, introduced in Dart 3.9 (https://dart.dev/tools/pub/dependencies#git-packages).

This takes a deliberately minimal, non-breaking approach compared to the earlier attempt in #2159:

- `GitDependency` gets two new nullable fields, `tagPattern` and `version`. The existing constructor and the public `GitDependency.fromData` factory are kept, `fromData` only gains an optional named `version` parameter.
- The `version` key next to a `git` source is now parsed into `GitDependency.version` instead of being silently dropped. This mirrors the pub client, which reads the `version` constraint for every dependency source.
- `tag_pattern` is validated the same way the pub client validates it: it must contain a single `{{version}}` marker and cannot be combined with `ref`. Validation errors are reported with the span of the `tag_pattern` key. Like the rest of this package, nothing is gated on the language version, so a `tag_pattern` under an SDK constraint older than 3.9 parses here even though pub rejects it.
- `GitDependency.toJson` includes `tag_pattern` and `version` when present, so `Pubspec.toJson` round-trips.
- Tests cover parsing, validation errors, and `toJson` round-tripping. The parsing tests are cross-checked against the pub client like the rest of the suite.

Separate PRs will follow for the other pubspec fields that `pubspec_parse` does not handle yet (`platforms`, `false_secrets`, `hooks`).
