### PR TITLE
[pubspec_parse] Add platforms field to Pubspec

### DIFF
--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0-wip
+
+- Added `platforms` field to `Pubspec`.
+
 ## 1.6.0
 
 - Added `toJson` method to `Pubspec` to serialize the object back to a `Map`.

--- a/pkgs/pubspec_parse/lib/src/pubspec.dart
+++ b/pkgs/pubspec_parse/lib/src/pubspec.dart
@@ -99,6 +99,14 @@ class Pubspec {
   /// Specifies how to resolve dependencies with the surrounding Pub Workspace.
   final String? resolution;
 
+  /// The platforms this package explicitly declares support for.
+  ///
+  /// Keys are platform names, such as `android`, `ios`, `linux`, `macos`,
+  /// `web` and `windows`. Values are currently always `null`.
+  ///
+  /// See https://dart.dev/tools/pub/pubspec#platforms.
+  final Map<String, dynamic>? platforms;
+
   /// If [author] and [authors] are both provided, their values are combined
   /// with duplicates eliminated.
   Pubspec(
@@ -121,6 +129,7 @@ class Pubspec {
     this.description,
     this.workspace,
     this.resolution,
+    this.platforms,
     Map<String, Dependency>? dependencies,
     Map<String, Dependency>? devDependencies,
     Map<String, Dependency>? dependencyOverrides,

--- a/pkgs/pubspec_parse/lib/src/pubspec.g.dart
+++ b/pkgs/pubspec_parse/lib/src/pubspec.g.dart
@@ -61,6 +61,10 @@ Pubspec _$PubspecFromJson(Map json) => $checkedCreate(
         (v) => (v as List<dynamic>?)?.map((e) => e as String).toList(),
       ),
       resolution: $checkedConvert('resolution', (v) => v as String?),
+      platforms: $checkedConvert(
+        'platforms',
+        (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+      ),
       dependencies: $checkedConvert(
         'dependencies',
         (v) => parseDeps(v as Map?),
@@ -116,4 +120,5 @@ Map<String, dynamic> _$PubspecToJson(Pubspec instance) => <String, dynamic>{
   'executables': _serializeExecutables(instance.executables),
   'workspace': instance.workspace,
   'resolution': instance.resolution,
+  'platforms': instance.platforms,
 };

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.6.0
+version: 1.7.0-wip
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -264,7 +264,6 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
       }, lenient: true);
       expect(value.name, 'sample');
       expect(value.executables, isEmpty);
-      expect(value.platforms, isNull);
     });
   });
 

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -34,6 +34,7 @@ void main() {
     expect(value.workspace, isNull);
     expect(value.resolution, isNull);
     expect(value.executables, isEmpty);
+    expect(value.platforms, isNull);
   });
 
   test('all fields set', () async {
@@ -58,6 +59,7 @@ void main() {
       ],
       'workspace': ['pkg1', 'pkg2'],
       'resolution': 'workspace',
+      'platforms': {'android': null, 'web': null},
       'executables': {
         'my_script': 'bin/my_script.dart',
         'my_script2': 'bin/my_script2.dart',
@@ -101,6 +103,7 @@ void main() {
     expect(value.workspace!.first, 'pkg1');
     expect(value.workspace!.last, 'pkg2');
     expect(value.resolution, 'workspace');
+    expect(value.platforms, {'android': null, 'web': null});
   });
 
   test('environment values can be null', () async {
@@ -261,6 +264,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
       }, lenient: true);
       expect(value.name, 'sample');
       expect(value.executables, isEmpty);
+      expect(value.platforms, isNull);
     });
   });
 
@@ -395,6 +399,34 @@ line 4, column 10: Unsupported value for "sdk". Could not parse version "silly".
         "Unsupported value for \"issue_tracker\". type 'YamlMap' is not a subtype of type 'String'",
         skipTryPub: true,
       );
+    });
+  });
+
+  group('platforms', () {
+    test('map with null values', () async {
+      final value = await parse({
+        ...defaultPubspec,
+        'platforms': {'android': null, 'ios': null, 'web': null},
+      });
+      expect(value.platforms, {'android': null, 'ios': null, 'web': null});
+    });
+
+    test('not a map', () {
+      expectParseThrowsContaining(
+        {...defaultPubspec, 'platforms': 1},
+        "Unsupported value for \"platforms\". type 'int' is not a subtype of type 'Map<dynamic, dynamic>?'",
+        skipTryPub: true,
+      );
+    });
+
+    test('invalid data - lenient', () async {
+      final value = await parse(
+        {...defaultPubspec, 'platforms': 1},
+        skipTryPub: true,
+        lenient: true,
+      );
+      expect(value.name, 'sample');
+      expect(value.platforms, isNull);
     });
   });
 

--- a/pkgs/pubspec_parse/test/tojson_test.dart
+++ b/pkgs/pubspec_parse/test/tojson_test.dart
@@ -39,6 +39,7 @@ void main() {
         'funding': null,
         'topics': null,
         'ignored_advisories': null,
+        'platforms': null,
       });
     });
 
@@ -65,6 +66,7 @@ void main() {
         ],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'platforms': {'android': null, 'web': null},
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -106,6 +108,7 @@ void main() {
         'ignored_advisories': ['111', '222'],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'platforms': {'android': null, 'web': null},
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -139,6 +142,7 @@ void main() {
       expect(newValue.workspace, value.workspace);
       expect(newValue.resolution, value.resolution);
       expect(newValue.executables, value.executables);
+      expect(newValue.platforms, value.platforms);
     });
 
     test('all fields set', () async {
@@ -163,6 +167,7 @@ void main() {
         ],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'platforms': {'android': null, 'web': null},
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -200,6 +205,7 @@ void main() {
       expect(newValue.workspace, value.workspace);
       expect(newValue.resolution, value.resolution);
       expect(newValue.executables, value.executables);
+      expect(newValue.platforms, value.platforms);
     });
 
     test('dependencies', () async {


### PR DESCRIPTION
Adds the `platforms` field to `Pubspec`, see https://dart.dev/tools/pub/pubspec#platforms.

The field is parsed as a `Map<String, dynamic>?`, mirroring how the `flutter` section is exposed, since the pubspec format declares platforms as a map with `null` values (`android:`, `ios:`, and so on). It is included in `Pubspec.toJson` and covered by parsing, error, lenient, and round-trip tests.

Follow-up to #2565. Each new field is in its own PR to keep them easy to review.
