### PR TITLE
[pubspec_parse] Add false_secrets field to Pubspec

### DIFF
--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0-wip
+
+- Added `falseSecrets` field to `Pubspec`.
+
 ## 1.6.0
 
 - Added `toJson` method to `Pubspec` to serialize the object back to a `Map`.

--- a/pkgs/pubspec_parse/lib/src/pubspec.dart
+++ b/pkgs/pubspec_parse/lib/src/pubspec.dart
@@ -99,6 +99,12 @@ class Pubspec {
   /// Specifies how to resolve dependencies with the surrounding Pub Workspace.
   final String? resolution;
 
+  /// Gitignore style patterns for files that pub should not search for
+  /// leaked secrets when publishing.
+  ///
+  /// See https://dart.dev/tools/pub/pubspec#false_secrets.
+  final List<String>? falseSecrets;
+
   /// If [author] and [authors] are both provided, their values are combined
   /// with duplicates eliminated.
   Pubspec(
@@ -121,6 +127,7 @@ class Pubspec {
     this.description,
     this.workspace,
     this.resolution,
+    this.falseSecrets,
     Map<String, Dependency>? dependencies,
     Map<String, Dependency>? devDependencies,
     Map<String, Dependency>? dependencyOverrides,

--- a/pkgs/pubspec_parse/lib/src/pubspec.g.dart
+++ b/pkgs/pubspec_parse/lib/src/pubspec.g.dart
@@ -61,6 +61,10 @@ Pubspec _$PubspecFromJson(Map json) => $checkedCreate(
         (v) => (v as List<dynamic>?)?.map((e) => e as String).toList(),
       ),
       resolution: $checkedConvert('resolution', (v) => v as String?),
+      falseSecrets: $checkedConvert(
+        'false_secrets',
+        (v) => (v as List<dynamic>?)?.map((e) => e as String).toList(),
+      ),
       dependencies: $checkedConvert(
         'dependencies',
         (v) => parseDeps(v as Map?),
@@ -88,6 +92,7 @@ Pubspec _$PubspecFromJson(Map json) => $checkedCreate(
     'publishTo': 'publish_to',
     'issueTracker': 'issue_tracker',
     'ignoredAdvisories': 'ignored_advisories',
+    'falseSecrets': 'false_secrets',
     'devDependencies': 'dev_dependencies',
     'dependencyOverrides': 'dependency_overrides',
   },
@@ -116,4 +121,5 @@ Map<String, dynamic> _$PubspecToJson(Pubspec instance) => <String, dynamic>{
   'executables': _serializeExecutables(instance.executables),
   'workspace': instance.workspace,
   'resolution': instance.resolution,
+  'false_secrets': instance.falseSecrets,
 };

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.6.0
+version: 1.7.0-wip
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -267,7 +267,6 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
       }, lenient: true);
       expect(value.name, 'sample');
       expect(value.executables, isEmpty);
-      expect(value.falseSecrets, isNull);
     });
   });
 

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -34,6 +34,7 @@ void main() {
     expect(value.workspace, isNull);
     expect(value.resolution, isNull);
     expect(value.executables, isEmpty);
+    expect(value.falseSecrets, isNull);
   });
 
   test('all fields set', () async {
@@ -58,6 +59,7 @@ void main() {
       ],
       'workspace': ['pkg1', 'pkg2'],
       'resolution': 'workspace',
+      'false_secrets': ['/lib/src/hardcoded_api_key.dart', '/test/*.pem'],
       'executables': {
         'my_script': 'bin/my_script.dart',
         'my_script2': 'bin/my_script2.dart',
@@ -101,6 +103,10 @@ void main() {
     expect(value.workspace!.first, 'pkg1');
     expect(value.workspace!.last, 'pkg2');
     expect(value.resolution, 'workspace');
+    expect(value.falseSecrets, [
+      '/lib/src/hardcoded_api_key.dart',
+      '/test/*.pem',
+    ]);
   });
 
   test('environment values can be null', () async {
@@ -261,6 +267,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
       }, lenient: true);
       expect(value.name, 'sample');
       expect(value.executables, isEmpty);
+      expect(value.falseSecrets, isNull);
     });
   });
 
@@ -395,6 +402,54 @@ line 4, column 10: Unsupported value for "sdk". Could not parse version "silly".
         "Unsupported value for \"issue_tracker\". type 'YamlMap' is not a subtype of type 'String'",
         skipTryPub: true,
       );
+    });
+  });
+
+  group('false_secrets', () {
+    test('list of patterns', () async {
+      final value = await parse({
+        ...defaultPubspec,
+        'false_secrets': [
+          '/lib/src/hardcoded_api_key.dart',
+          '/test/localhost_certificates/*.pem',
+        ],
+      });
+      expect(value.falseSecrets, [
+        '/lib/src/hardcoded_api_key.dart',
+        '/test/localhost_certificates/*.pem',
+      ]);
+    });
+
+    test('not a list', () {
+      expectParseThrowsContaining(
+        {...defaultPubspec, 'false_secrets': 1},
+        "Unsupported value for \"false_secrets\". type 'int' is not a subtype of type 'List<dynamic>?'",
+        skipTryPub: true,
+      );
+    });
+
+    test('not a string', () {
+      expectParseThrowsContaining(
+        {
+          ...defaultPubspec,
+          'false_secrets': [1],
+        },
+        "Unsupported value for \"false_secrets\". type 'int' is not a subtype of type 'String'",
+        skipTryPub: true,
+      );
+    });
+
+    test('invalid data - lenient', () async {
+      final value = await parse(
+        {
+          ...defaultPubspec,
+          'false_secrets': [1],
+        },
+        skipTryPub: true,
+        lenient: true,
+      );
+      expect(value.name, 'sample');
+      expect(value.falseSecrets, isNull);
     });
   });
 

--- a/pkgs/pubspec_parse/test/tojson_test.dart
+++ b/pkgs/pubspec_parse/test/tojson_test.dart
@@ -39,6 +39,7 @@ void main() {
         'funding': null,
         'topics': null,
         'ignored_advisories': null,
+        'false_secrets': null,
       });
     });
 
@@ -65,6 +66,7 @@ void main() {
         ],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'false_secrets': ['/lib/src/hardcoded_api_key.dart', '/test/*.pem'],
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -106,6 +108,7 @@ void main() {
         'ignored_advisories': ['111', '222'],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'false_secrets': ['/lib/src/hardcoded_api_key.dart', '/test/*.pem'],
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -139,6 +142,7 @@ void main() {
       expect(newValue.workspace, value.workspace);
       expect(newValue.resolution, value.resolution);
       expect(newValue.executables, value.executables);
+      expect(newValue.falseSecrets, value.falseSecrets);
     });
 
     test('all fields set', () async {
@@ -163,6 +167,7 @@ void main() {
         ],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'false_secrets': ['/lib/src/hardcoded_api_key.dart', '/test/*.pem'],
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -200,6 +205,7 @@ void main() {
       expect(newValue.workspace, value.workspace);
       expect(newValue.resolution, value.resolution);
       expect(newValue.executables, value.executables);
+      expect(newValue.falseSecrets, value.falseSecrets);
     });
 
     test('dependencies', () async {


### PR DESCRIPTION
Adds the `false_secrets` field to `Pubspec` as `List<String>? falseSecrets`, see https://dart.dev/tools/pub/pubspec#false_secrets.

It is parsed the same way as `topics` and `ignored_advisories`, included in `Pubspec.toJson`, and covered by parsing, error, lenient, and round-trip tests.

Follow-up to #2565. Each new field is in its own PR to keep them easy to review.
