### PR TITLE
[pubspec_parse] Add hooks field to Pubspec

### DIFF
--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0-wip
+
+- Added `hooks` field to `Pubspec`.
+
 ## 1.6.0
 
 - Added `toJson` method to `Pubspec` to serialize the object back to a `Map`.

--- a/pkgs/pubspec_parse/lib/src/pubspec.dart
+++ b/pkgs/pubspec_parse/lib/src/pubspec.dart
@@ -99,6 +99,13 @@ class Pubspec {
   /// Specifies how to resolve dependencies with the surrounding Pub Workspace.
   final String? resolution;
 
+  /// Configuration for hooks, such as native build or link hooks.
+  ///
+  /// May include `user_defines` and other settings.
+  ///
+  /// See https://dart.dev/tools/pub/pubspec#hooks.
+  final Map<String, dynamic>? hooks;
+
   /// If [author] and [authors] are both provided, their values are combined
   /// with duplicates eliminated.
   Pubspec(
@@ -121,6 +128,7 @@ class Pubspec {
     this.description,
     this.workspace,
     this.resolution,
+    this.hooks,
     Map<String, Dependency>? dependencies,
     Map<String, Dependency>? devDependencies,
     Map<String, Dependency>? dependencyOverrides,

--- a/pkgs/pubspec_parse/lib/src/pubspec.g.dart
+++ b/pkgs/pubspec_parse/lib/src/pubspec.g.dart
@@ -61,6 +61,10 @@ Pubspec _$PubspecFromJson(Map json) => $checkedCreate(
         (v) => (v as List<dynamic>?)?.map((e) => e as String).toList(),
       ),
       resolution: $checkedConvert('resolution', (v) => v as String?),
+      hooks: $checkedConvert(
+        'hooks',
+        (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+      ),
       dependencies: $checkedConvert(
         'dependencies',
         (v) => parseDeps(v as Map?),
@@ -116,4 +120,5 @@ Map<String, dynamic> _$PubspecToJson(Pubspec instance) => <String, dynamic>{
   'executables': _serializeExecutables(instance.executables),
   'workspace': instance.workspace,
   'resolution': instance.resolution,
+  'hooks': instance.hooks,
 };

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.6.0
+version: 1.7.0-wip
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -34,6 +34,7 @@ void main() {
     expect(value.workspace, isNull);
     expect(value.resolution, isNull);
     expect(value.executables, isEmpty);
+    expect(value.hooks, isNull);
   });
 
   test('all fields set', () async {
@@ -58,6 +59,11 @@ void main() {
       ],
       'workspace': ['pkg1', 'pkg2'],
       'resolution': 'workspace',
+      'hooks': {
+        'user_defines': {
+          'my_package': {'enable_experimental': true},
+        },
+      },
       'executables': {
         'my_script': 'bin/my_script.dart',
         'my_script2': 'bin/my_script2.dart',
@@ -101,6 +107,11 @@ void main() {
     expect(value.workspace!.first, 'pkg1');
     expect(value.workspace!.last, 'pkg2');
     expect(value.resolution, 'workspace');
+    expect(value.hooks, {
+      'user_defines': {
+        'my_package': {'enable_experimental': true},
+      },
+    });
   });
 
   test('environment values can be null', () async {
@@ -261,6 +272,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
       }, lenient: true);
       expect(value.name, 'sample');
       expect(value.executables, isEmpty);
+      expect(value.hooks, isNull);
     });
   });
 
@@ -395,6 +407,42 @@ line 4, column 10: Unsupported value for "sdk". Could not parse version "silly".
         "Unsupported value for \"issue_tracker\". type 'YamlMap' is not a subtype of type 'String'",
         skipTryPub: true,
       );
+    });
+  });
+
+  group('hooks', () {
+    test('map', () async {
+      final value = await parse({
+        ...defaultPubspec,
+        'hooks': {
+          'user_defines': {
+            'my_package': {'enable_experimental': true},
+          },
+        },
+      });
+      expect(value.hooks, {
+        'user_defines': {
+          'my_package': {'enable_experimental': true},
+        },
+      });
+    });
+
+    test('not a map', () {
+      expectParseThrowsContaining(
+        {...defaultPubspec, 'hooks': 1},
+        "Unsupported value for \"hooks\". type 'int' is not a subtype of type 'Map<dynamic, dynamic>?'",
+        skipTryPub: true,
+      );
+    });
+
+    test('invalid data - lenient', () async {
+      final value = await parse(
+        {...defaultPubspec, 'hooks': 1},
+        skipTryPub: true,
+        lenient: true,
+      );
+      expect(value.name, 'sample');
+      expect(value.hooks, isNull);
     });
   });
 

--- a/pkgs/pubspec_parse/test/parse_test.dart
+++ b/pkgs/pubspec_parse/test/parse_test.dart
@@ -272,7 +272,6 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
       }, lenient: true);
       expect(value.name, 'sample');
       expect(value.executables, isEmpty);
-      expect(value.hooks, isNull);
     });
   });
 

--- a/pkgs/pubspec_parse/test/tojson_test.dart
+++ b/pkgs/pubspec_parse/test/tojson_test.dart
@@ -39,6 +39,7 @@ void main() {
         'funding': null,
         'topics': null,
         'ignored_advisories': null,
+        'hooks': null,
       });
     });
 
@@ -65,6 +66,11 @@ void main() {
         ],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'hooks': {
+          'user_defines': {
+            'my_package': {'enable_experimental': true},
+          },
+        },
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -106,6 +112,11 @@ void main() {
         'ignored_advisories': ['111', '222'],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'hooks': {
+          'user_defines': {
+            'my_package': {'enable_experimental': true},
+          },
+        },
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -139,6 +150,7 @@ void main() {
       expect(newValue.workspace, value.workspace);
       expect(newValue.resolution, value.resolution);
       expect(newValue.executables, value.executables);
+      expect(newValue.hooks, value.hooks);
     });
 
     test('all fields set', () async {
@@ -163,6 +175,11 @@ void main() {
         ],
         'workspace': ['pkg1', 'pkg2'],
         'resolution': 'workspace',
+        'hooks': {
+          'user_defines': {
+            'my_package': {'enable_experimental': true},
+          },
+        },
         'executables': {
           'my_script': 'bin/my_script.dart',
           'my_script2': 'bin/my_script2.dart',
@@ -200,6 +217,7 @@ void main() {
       expect(newValue.workspace, value.workspace);
       expect(newValue.resolution, value.resolution);
       expect(newValue.executables, value.executables);
+      expect(newValue.hooks, value.hooks);
     });
 
     test('dependencies', () async {


### PR DESCRIPTION
Adds the `hooks` field to `Pubspec` as `Map<String, dynamic>? hooks`, see https://dart.dev/tools/pub/pubspec#hooks.

The field holds hook configuration such as `user_defines` for native build and link hooks. It is exposed as a raw map, mirroring the `flutter` section, since its contents are defined by the hooks packages rather than by pub. It is included in `Pubspec.toJson` and covered by parsing, error, lenient, and round-trip tests.

Follow-up to #2565. Each new field is in its own PR to keep them easy to review.
