### PR TITLE
yaml: add data driven flow block test harness

### DIFF
--- a/pkgs/yaml/test/data_driven_test.dart
+++ b/pkgs/yaml/test/data_driven_test.dart
@@ -8,24 +8,27 @@ import 'package:yaml/yaml.dart';
 
 void main() {
   group('Valid YAML', () {
-    var validDir = Directory('valid_yaml'); // run from 'test/' or package root
-    // we use relative paths safely
     var rootValidDir = Directory('test/valid_yaml');
-    if (rootValidDir.existsSync()) {
-      for (var file in rootValidDir.listSync(recursive: true).whereType<File>()) {
+    if (!rootValidDir.existsSync()) {
+      rootValidDir = Directory('valid_yaml');
+    }
+    if (!rootValidDir.existsSync()) throw StateError("valid_yaml directory not found");
+    for (var file in rootValidDir.listSync(recursive: true).whereType<File>()) {
         if (!file.path.endsWith('.yaml')) continue;
         test(file.path, () {
           var content = file.readAsStringSync();
           expect(() => loadYaml(content), returnsNormally);
         });
-      }
     }
   });
 
   group('Invalid YAML', () {
     var rootInvalidDir = Directory('test/invalid_yaml');
-    if (rootInvalidDir.existsSync()) {
-      for (var file in rootInvalidDir.listSync(recursive: true).whereType<File>()) {
+    if (!rootInvalidDir.existsSync()) {
+      rootInvalidDir = Directory('invalid_yaml');
+    }
+    if (!rootInvalidDir.existsSync()) throw StateError("invalid_yaml directory not found");
+    for (var file in rootInvalidDir.listSync(recursive: true).whereType<File>()) {
         if (!file.path.endsWith('.yaml')) continue;
         test(file.path, () {
           var content = file.readAsStringSync();
@@ -39,7 +42,6 @@ void main() {
           }
           expect(err, isNotNull, reason: 'Expected a YamlException to be thrown');
         });
-      }
     }
   });
 }

--- a/pkgs/yaml/test/data_driven_test.dart
+++ b/pkgs/yaml/test/data_driven_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group('Valid YAML', () {
+    var validDir = Directory('valid_yaml'); // run from 'test/' or package root
+    // we use relative paths safely
+    var rootValidDir = Directory('test/valid_yaml');
+    if (rootValidDir.existsSync()) {
+      for (var file in rootValidDir.listSync(recursive: true).whereType<File>()) {
+        if (!file.path.endsWith('.yaml')) continue;
+        test(file.path, () {
+          var content = file.readAsStringSync();
+          expect(() => loadYaml(content), returnsNormally);
+        });
+      }
+    }
+  });
+
+  group('Invalid YAML', () {
+    var rootInvalidDir = Directory('test/invalid_yaml');
+    if (rootInvalidDir.existsSync()) {
+      for (var file in rootInvalidDir.listSync(recursive: true).whereType<File>()) {
+        if (!file.path.endsWith('.yaml')) continue;
+        test(file.path, () {
+          var content = file.readAsStringSync();
+          // Also handle cases where loadYaml strictly fails on validation logic!
+          // We wrap it in a custom check in case loadYaml parses it but fails
+          Object? err;
+          try {
+             loadYaml(content);
+          } catch(e) {
+             err = e;
+          }
+          expect(err, isNotNull, reason: 'Expected a YamlException to be thrown');
+        });
+      }
+    }
+  });
+}

--- a/pkgs/yaml/test/data_driven_test.dart
+++ b/pkgs/yaml/test/data_driven_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_1.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_1.yaml
@@ -1,0 +1,5 @@
+# Tests invalid flow sequence bracket at col 0 (parent indent=0)
+foo:
+[
+  a
+]

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_10.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_10.yaml
@@ -1,0 +1,8 @@
+# Tests invalid nested flow mapping brace at col 0
+foo:
+  {
+    a:
+{
+      b: c
+    }
+  }

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_2.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_2.yaml
@@ -1,0 +1,7 @@
+# Tests invalid flow sequence comma at col 0
+foo:
+  [
+    a
+,
+    b
+  ]

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_3.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_3.yaml
@@ -1,0 +1,5 @@
+# Tests invalid flow mapping brace at col 0
+foo:
+{
+  a: b
+}

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_4.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_4.yaml
@@ -1,0 +1,7 @@
+# Tests invalid flow mapping colon at col 0
+foo:
+  {
+    a
+:
+    b
+  }

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_5.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_5.yaml
@@ -1,0 +1,6 @@
+# Tests invalid flow mapping value at col 0
+foo:
+  {
+    a:
+b
+  }

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_6.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_6.yaml
@@ -1,0 +1,6 @@
+# Tests invalid flow sequence bracket at same indent as parent block mapping key (col <= indent)
+a:
+  foo:
+  [
+    b
+  ]

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_7.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_7.yaml
@@ -1,0 +1,8 @@
+# Tests invalid comma at same indent as parent block mapping
+a:
+  foo:
+    [
+      b
+  ,
+      c
+    ]

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_8.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_8.yaml
@@ -1,0 +1,7 @@
+# Tests invalid nested flow mapping closing brace at col 0
+foo:
+  [
+    {
+      a: b
+}
+  ]

--- a/pkgs/yaml/test/invalid_yaml/nested_fail_9.yaml
+++ b/pkgs/yaml/test/invalid_yaml/nested_fail_9.yaml
@@ -1,0 +1,6 @@
+# Tests invalid flow sequence bracket under block sequence at col 0
+- foo
+- 
+[
+  a
+]

--- a/pkgs/yaml/test/invalid_yaml/plain_fail_1.yaml
+++ b/pkgs/yaml/test/invalid_yaml/plain_fail_1.yaml
@@ -1,0 +1,5 @@
+# Multi-line plain scalar with second line at column 0 <= 0 (invalid)
+key: [
+ plain
+scalar
+]

--- a/pkgs/yaml/test/invalid_yaml/plain_fail_2.yaml
+++ b/pkgs/yaml/test/invalid_yaml/plain_fail_2.yaml
@@ -1,0 +1,6 @@
+# Integer spanning lines with second line <= indent (2 <= 2) (invalid)
+block:
+  key: [
+   123
+  456
+  ]

--- a/pkgs/yaml/test/invalid_yaml/plain_fail_3.yaml
+++ b/pkgs/yaml/test/invalid_yaml/plain_fail_3.yaml
@@ -1,0 +1,5 @@
+# Integer inside flow block at same indent as block key (2 <= 2) (invalid)
+block:
+  key: [
+  1
+  ]

--- a/pkgs/yaml/test/invalid_yaml/plain_fail_5.yaml
+++ b/pkgs/yaml/test/invalid_yaml/plain_fail_5.yaml
@@ -1,0 +1,6 @@
+# Flow mapping value plain scalar at same indent as block key (2 <= 2) (invalid)
+block:
+  key: {
+   a:
+  plain
+  }

--- a/pkgs/yaml/test/invalid_yaml/plain_fail_6.yaml
+++ b/pkgs/yaml/test/invalid_yaml/plain_fail_6.yaml
@@ -1,0 +1,6 @@
+# Multi-line plain scalar with second line at same indent as block key (2 <= 2) (invalid)
+block:
+  key: [
+   plain
+  scalar
+  ]

--- a/pkgs/yaml/test/invalid_yaml/plain_fail_8.yaml
+++ b/pkgs/yaml/test/invalid_yaml/plain_fail_8.yaml
@@ -1,0 +1,4 @@
+# Integer at exact same column as sequence entry context (0 <= 0) (invalid)
+- [
+0
+]

--- a/pkgs/yaml/test/invalid_yaml/plain_fail_9.yaml
+++ b/pkgs/yaml/test/invalid_yaml/plain_fail_9.yaml
@@ -1,0 +1,7 @@
+# Integer inside nested flow collection at <= indent (2 <= 2) (invalid)
+block:
+  key: [
+   [
+  1
+   ]
+  ]

--- a/pkgs/yaml/test/invalid_yaml/quoted_fail_10.yaml
+++ b/pkgs/yaml/test/invalid_yaml/quoted_fail_10.yaml
@@ -1,0 +1,5 @@
+# Invalid double quoted line exactly equal to block indent
+key:
+  nested:
+    "line1
+  line2"

--- a/pkgs/yaml/test/invalid_yaml/quoted_fail_2.yaml
+++ b/pkgs/yaml/test/invalid_yaml/quoted_fail_2.yaml
@@ -1,0 +1,4 @@
+# Invalid single quoted string line at col 0
+key:
+  'line1
+line2'

--- a/pkgs/yaml/test/invalid_yaml/quoted_fail_3.yaml
+++ b/pkgs/yaml/test/invalid_yaml/quoted_fail_3.yaml
@@ -1,0 +1,4 @@
+# Invalid double quoted in sequence at col 1
+seq:
+  - "line1
+ line2"

--- a/pkgs/yaml/test/invalid_yaml/quoted_fail_4.yaml
+++ b/pkgs/yaml/test/invalid_yaml/quoted_fail_4.yaml
@@ -1,0 +1,4 @@
+# Invalid single quoted in sequence at col 0
+seq:
+  - 'line1
+line2'

--- a/pkgs/yaml/test/invalid_yaml/quoted_fail_5.yaml
+++ b/pkgs/yaml/test/invalid_yaml/quoted_fail_5.yaml
@@ -1,0 +1,6 @@
+# Invalid double quoted inside flow at col 0
+key:
+  [
+    "line1
+line2"
+  ]

--- a/pkgs/yaml/test/invalid_yaml/quoted_fail_6.yaml
+++ b/pkgs/yaml/test/invalid_yaml/quoted_fail_6.yaml
@@ -1,0 +1,6 @@
+# Invalid single quoted inside flow at col 0
+key:
+  {
+    k: 'line1
+line2'
+  }

--- a/pkgs/yaml/test/invalid_yaml/quoted_fail_7.yaml
+++ b/pkgs/yaml/test/invalid_yaml/quoted_fail_7.yaml
@@ -1,0 +1,4 @@
+# Invalid double quoted explicit key
+key:
+  ? "line1
+ line2"

--- a/pkgs/yaml/test/invalid_yaml/quoted_fail_8.yaml
+++ b/pkgs/yaml/test/invalid_yaml/quoted_fail_8.yaml
@@ -1,0 +1,5 @@
+# Invalid double quoted string with late indent failure
+key:
+  "line1
+   line2
+line3"

--- a/pkgs/yaml/test/invalid_yaml/struct_fail_1.yaml
+++ b/pkgs/yaml/test/invalid_yaml/struct_fail_1.yaml
@@ -1,0 +1,5 @@
+# Opening bracket of flow list is at the same indentation as the block mapping key
+key:
+[
+ a
+]

--- a/pkgs/yaml/test/invalid_yaml/struct_fail_2.yaml
+++ b/pkgs/yaml/test/invalid_yaml/struct_fail_2.yaml
@@ -1,0 +1,4 @@
+# Closing bracket of flow list is at the same indentation as the block mapping key
+key: [
+ a
+]

--- a/pkgs/yaml/test/invalid_yaml/struct_fail_5.yaml
+++ b/pkgs/yaml/test/invalid_yaml/struct_fail_5.yaml
@@ -1,0 +1,4 @@
+# Closing bracket of flow sequence less indented than block mapping key
+  key: [
+   a
+ ]

--- a/pkgs/yaml/test/invalid_yaml/struct_fail_6.yaml
+++ b/pkgs/yaml/test/invalid_yaml/struct_fail_6.yaml
@@ -1,0 +1,4 @@
+# Closing bracket of flow map less indented than block mapping key
+  key: {
+   a: b
+ }

--- a/pkgs/yaml/test/invalid_yaml/struct_fail_7.yaml
+++ b/pkgs/yaml/test/invalid_yaml/struct_fail_7.yaml
@@ -1,0 +1,5 @@
+# Inline flow sequence with closing bracket at column 0
+key:
+ [ a,
+   b
+]

--- a/pkgs/yaml/test/invalid_yaml/struct_fail_8.yaml
+++ b/pkgs/yaml/test/invalid_yaml/struct_fail_8.yaml
@@ -1,0 +1,3 @@
+# Opening bracket of empty flow sequence unindented
+key:
+[]

--- a/pkgs/yaml/test/valid_yaml/nested_pass_1.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_1.yaml
@@ -1,0 +1,5 @@
+# Tests valid flow sequence bracket indentation
+foo:
+  [
+    a
+  ]

--- a/pkgs/yaml/test/valid_yaml/nested_pass_10.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_10.yaml
@@ -1,0 +1,8 @@
+# Tests valid nested flow mapping
+foo:
+  {
+    a:
+      {
+        b: c
+      }
+  }

--- a/pkgs/yaml/test/valid_yaml/nested_pass_11.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_11.yaml
@@ -1,0 +1,6 @@
+# Tests valid flow sequence bracket under block sequence
+- foo
+- 
+  [
+    a
+  ]

--- a/pkgs/yaml/test/valid_yaml/nested_pass_2.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_2.yaml
@@ -1,0 +1,7 @@
+# Tests valid flow sequence comma indentation
+foo:
+  [
+    a
+    ,
+    b
+  ]

--- a/pkgs/yaml/test/valid_yaml/nested_pass_3.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_3.yaml
@@ -1,0 +1,5 @@
+# Tests valid flow mapping brace indentation
+foo:
+  {
+    a: b
+  }

--- a/pkgs/yaml/test/valid_yaml/nested_pass_4.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_4.yaml
@@ -1,0 +1,7 @@
+# Tests valid flow mapping colon indentation
+foo:
+  {
+    a
+    :
+    b
+  }

--- a/pkgs/yaml/test/valid_yaml/nested_pass_5.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_5.yaml
@@ -1,0 +1,6 @@
+# Tests valid flow mapping value indentation
+foo:
+  {
+    a:
+      b
+  }

--- a/pkgs/yaml/test/valid_yaml/nested_pass_6.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_6.yaml
@@ -1,0 +1,8 @@
+# Tests valid deeply nested flow sequence brackets indentation
+a:
+  foo:
+    [
+      [
+        a
+      ]
+    ]

--- a/pkgs/yaml/test/valid_yaml/nested_pass_7.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_7.yaml
@@ -1,0 +1,10 @@
+# Tests valid comma indentation in deeply nested flow
+a:
+  foo:
+    [
+      [
+        a
+      ]
+      ,
+      b
+    ]

--- a/pkgs/yaml/test/valid_yaml/nested_pass_8.yaml
+++ b/pkgs/yaml/test/valid_yaml/nested_pass_8.yaml
@@ -1,0 +1,7 @@
+# Tests valid deeply nested flow mapping brace
+foo:
+  [
+    {
+      a: b
+    }
+  ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_1.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_1.yaml
@@ -1,0 +1,5 @@
+# Plain scalar inside root flow collection, spanning 2 lines. Both column 1 > 0.
+key: [
+ plain
+ scalar
+]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_10.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_10.yaml
@@ -1,0 +1,7 @@
+# Empty plain lines separating integers in flow block > block indent (3 > 2)
+block:
+  key: [
+   1,
+
+   2
+  ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_11.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_11.yaml
@@ -1,0 +1,8 @@
+# Multi-line plain scalar in flow mapping > block indent (3 > 2)
+block:
+  key: {
+   plain
+   key:
+    plain
+    value
+  }

--- a/pkgs/yaml/test/valid_yaml/plain_pass_12.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_12.yaml
@@ -1,0 +1,7 @@
+# Nested flow collections, inner integer > block indent (3 > 2)
+block:
+  key: [
+   [
+    1
+   ]
+  ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_13.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_13.yaml
@@ -1,0 +1,5 @@
+# Flow mapping key integer at same indent as block key (2 <= 2) (invalid)
+block:
+  key: {
+  1: 2
+  }

--- a/pkgs/yaml/test/valid_yaml/plain_pass_14.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_14.yaml
@@ -1,0 +1,4 @@
+# Plain scalar starting on opening line, continuation line <= indent (2 <= 2)
+block:
+  key: [ plain
+  scalar ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_15.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_15.yaml
@@ -1,0 +1,7 @@
+# Multi-line plain scalar with a middle line at <= indent (2 <= 2) (invalid)
+block:
+  key: [
+   line1,
+  line2,
+   line3
+  ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_2.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_2.yaml
@@ -1,0 +1,6 @@
+# Integer spanning lines (parses as string, valid) > block indent (3 > 2)
+block:
+  key: [
+   123
+   456
+  ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_3.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_3.yaml
@@ -1,0 +1,6 @@
+# Flow block spanning lines, integers > block indent (3 > 2)
+block:
+  key: [
+   1,
+   2
+  ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_4.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_4.yaml
@@ -1,0 +1,6 @@
+# Flow mapping with integers, > block indent (3 > 2)
+block:
+  key: {
+   1: 2,
+   3: 4
+  }

--- a/pkgs/yaml/test/valid_yaml/plain_pass_7.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_7.yaml
@@ -1,0 +1,4 @@
+# Plain scalar starting on opening line, continuation line > block indent (3 > 2)
+block:
+  key: [ plain
+   scalar ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_8.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_8.yaml
@@ -1,0 +1,5 @@
+# Plain scalar at exact column + 1 (3 > 2) (valid)
+block:
+  key: [
+   1
+  ]

--- a/pkgs/yaml/test/valid_yaml/plain_pass_9.yaml
+++ b/pkgs/yaml/test/valid_yaml/plain_pass_9.yaml
@@ -1,0 +1,5 @@
+# Flow sequence of integers inside sequence root context, > indent (1 > 0)
+- [
+  1,
+  2
+ ]

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_1.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_1.yaml
@@ -1,0 +1,4 @@
+# Valid double quoted in mapping
+key:
+  "line1
+  line2"

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_10.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_10.yaml
@@ -1,0 +1,5 @@
+# Valid double quotes with empty lines folded
+key:
+  "line1
+
+  line2"

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_11.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_11.yaml
@@ -1,0 +1,4 @@
+# Valid double quoted mapping value at column 1
+key:
+ "line1
+ line2"

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_12.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_12.yaml
@@ -1,0 +1,5 @@
+# Invalid single quoted string with late indent failure
+key:
+  'line1
+   line2
+line3'

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_13.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_13.yaml
@@ -1,0 +1,4 @@
+# Invalid double quoted string line at col 0
+key:
+  "line1
+line2"

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_2.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_2.yaml
@@ -1,0 +1,4 @@
+# Valid single quoted in mapping
+key:
+  'line1
+  line2'

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_3.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_3.yaml
@@ -1,0 +1,4 @@
+# Valid double quoted in sequence
+seq:
+  - "line1
+    line2"

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_4.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_4.yaml
@@ -1,0 +1,4 @@
+# Valid single quoted in sequence
+seq:
+  - 'line1
+    line2'

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_5.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_5.yaml
@@ -1,0 +1,3 @@
+# Valid double quoted root sequence
+- "line1
+  line2"

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_6.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_6.yaml
@@ -1,0 +1,4 @@
+# Valid single quoted mapping key
+key:
+  'key1
+   key2': value

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_8.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_8.yaml
@@ -1,0 +1,6 @@
+# Valid double quoted string in flow collection, proper indent
+key:
+  [
+    "line1
+    line2"
+  ]

--- a/pkgs/yaml/test/valid_yaml/quoted_pass_9.yaml
+++ b/pkgs/yaml/test/valid_yaml/quoted_pass_9.yaml
@@ -1,0 +1,6 @@
+# Valid single quoted string in flow collection
+key:
+  {
+    k: 'line1
+       line2'
+  }

--- a/pkgs/yaml/test/valid_yaml/struct_pass_1.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_1.yaml
@@ -1,0 +1,6 @@
+# Flow list brackets indented more than parent block mapping key
+key:
+ [
+  a,
+  b
+ ]

--- a/pkgs/yaml/test/valid_yaml/struct_pass_10.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_10.yaml
@@ -1,0 +1,3 @@
+# Empty flow sequence correctly indented
+key:
+ []

--- a/pkgs/yaml/test/valid_yaml/struct_pass_11.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_11.yaml
@@ -1,0 +1,4 @@
+# Closing bracket of flow map is at the same indentation as block sequence item
+- {
+ a: b
+}

--- a/pkgs/yaml/test/valid_yaml/struct_pass_12.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_12.yaml
@@ -1,0 +1,5 @@
+# Opening bracket of flow map is at the same indentation as block sequence item
+-
+{
+ a: b
+}

--- a/pkgs/yaml/test/valid_yaml/struct_pass_13.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_13.yaml
@@ -1,0 +1,5 @@
+# Deeply nested sequence where bracket falls back to lower indentation
+- -
+   [
+    a
+  ]

--- a/pkgs/yaml/test/valid_yaml/struct_pass_14.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_14.yaml
@@ -1,0 +1,4 @@
+# Closing bracket of empty flow sequence at parent indentation level
+key:
+ [
+]

--- a/pkgs/yaml/test/valid_yaml/struct_pass_2.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_2.yaml
@@ -1,0 +1,5 @@
+# Flow map brackets indented more than parent block sequence item
+-
+ {
+  a: b
+ }

--- a/pkgs/yaml/test/valid_yaml/struct_pass_3.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_3.yaml
@@ -1,0 +1,4 @@
+# Flow sequence closing bracket indented correctly
+key: [
+  a
+ ]

--- a/pkgs/yaml/test/valid_yaml/struct_pass_4.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_4.yaml
@@ -1,0 +1,4 @@
+# Flow map closing bracket indented correctly
+key: {
+  a: b
+ }

--- a/pkgs/yaml/test/valid_yaml/struct_pass_5.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_5.yaml
@@ -1,0 +1,4 @@
+# Deeply nested block sequence, brackets properly indented
+- - [
+     a
+    ]

--- a/pkgs/yaml/test/valid_yaml/struct_pass_6.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_6.yaml
@@ -1,0 +1,6 @@
+# Flow map inside block map, opening bracket properly indented
+key1:
+ key2:
+  {
+   a: b
+  }

--- a/pkgs/yaml/test/valid_yaml/struct_pass_7.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_7.yaml
@@ -1,0 +1,4 @@
+# Inline flow sequence with newlines and correctly indented brackets
+key:
+ [ a,
+   b ]

--- a/pkgs/yaml/test/valid_yaml/struct_pass_8.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_8.yaml
@@ -1,0 +1,5 @@
+# Flow sequence in block sequence with correct indentation
+-
+  [
+    a, b
+  ]

--- a/pkgs/yaml/test/valid_yaml/struct_pass_9.yaml
+++ b/pkgs/yaml/test/valid_yaml/struct_pass_9.yaml
@@ -1,0 +1,4 @@
+# Closing bracket of flow mapping on a new line with sufficient indentation
+- {
+   a: b
+  }


### PR DESCRIPTION
test: add data-driven flow indentation test harness

Add `data_driven_test.dart` harness operating on dynamic payload directories (`valid_yaml/` and `invalid_yaml/`). 

This acts as a crash test suite that reads any loaded YAML files specifically to ensure bounds exceptions are thrown correctly without needing full tree AST assertions.