### PR TITLE
yaml: add comment explaining why 2JQS-0 is expected to fail

### DIFF
--- a/pkgs/yaml/test/yaml_test_suite_test.dart
+++ b/pkgs/yaml/test/yaml_test_suite_test.dart
@@ -64,7 +64,7 @@ const _expectedFailures = <String>[
   'P76L-0',
   '9JBA-0',
   'S98Z-0',
-  '2JQS-0',
+  '2JQS-0', // Intentionally failing (strict parsing duplicate keys in maps)
   'MUS6-0',
   'MUS6-1',
   'BS4K-0',


### PR DESCRIPTION
Add a comment to yaml-test-suite `2JQS-0` explaining it intentionally fails due to rejection of duplicate keys in maps. 

Example of input that causes strict failure:
```yaml
: a
: b
```