### PR TITLE
[markdown] Generate header anchor ids from inline-parsed text

### DIFF
--- a/pkgs/markdown/CHANGELOG.md
+++ b/pkgs/markdown/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 7.4.1-wip
 
+* Fixes header id generation (from `HeaderWithIdSyntax` and
+  `SetextHeaderWithIdSyntax`) to use each header's fully inline-parsed text,
+  so that a header containing a link uses the link's text instead of its
+  target, and a header containing an image omits it entirely.
+
 ## 7.4.0
 
 * Adds `linkBuilder`/`imageLinkBuilder` alternatives to `linkResolver`/  

--- a/pkgs/markdown/lib/src/ast.dart
+++ b/pkgs/markdown/lib/src/ast.dart
@@ -62,6 +62,14 @@ class Element implements Node {
   String? generatedId;
   String? footnoteLabel;
 
+  /// Whether this element still needs [generatedId] computed from its
+  /// fully inline-parsed [textContent].
+  ///
+  /// Set by header syntaxes that support generated ids; consumed by the
+  /// document once inline parsing of this element's children completes,
+  /// so that link targets and images don't leak into the generated id.
+  bool needsGeneratedId = false;
+
   /// Instantiates a [tag] Element with [children].
   Element(this.tag, this.children, [Map<String, String>? attributes])
     : attributes = {...?attributes};

--- a/pkgs/markdown/lib/src/block_syntaxes/block_syntax.dart
+++ b/pkgs/markdown/lib/src/block_syntaxes/block_syntax.dart
@@ -56,10 +56,11 @@ abstract class BlockSyntax {
   }
 
   /// Generates a valid HTML anchor from the inner text of [element].
-  static String generateAnchorHash(Element element) => element
-      .children!
-      .first
-      .textContent
+  ///
+  /// Must be called after inline parsing of [element]'s children, so that
+  /// links contribute only their text (not their target) and images are
+  /// excluded entirely.
+  static String generateAnchorHash(Element element) => element.textContent
       .toLowerCase()
       .trim()
       .replaceAll(RegExp('[^a-z0-9 _-]'), '')

--- a/pkgs/markdown/lib/src/block_syntaxes/header_with_id_syntax.dart
+++ b/pkgs/markdown/lib/src/block_syntaxes/header_with_id_syntax.dart
@@ -4,7 +4,6 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
-import 'block_syntax.dart';
 import 'header_syntax.dart';
 
 /// Parses atx-style headers, and adds generated IDs to the generated elements.
@@ -16,7 +15,7 @@ class HeaderWithIdSyntax extends HeaderSyntax {
     final element = super.parse(parser) as Element;
 
     if (element.children?.isNotEmpty ?? false) {
-      element.generatedId = BlockSyntax.generateAnchorHash(element);
+      element.needsGeneratedId = true;
     }
 
     return element;

--- a/pkgs/markdown/lib/src/block_syntaxes/setext_header_with_id_syntax.dart
+++ b/pkgs/markdown/lib/src/block_syntaxes/setext_header_with_id_syntax.dart
@@ -4,7 +4,6 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
-import 'block_syntax.dart';
 import 'setext_header_syntax.dart';
 
 /// Parses setext-style headers, and adds generated IDs to the generated
@@ -15,7 +14,7 @@ class SetextHeaderWithIdSyntax extends SetextHeaderSyntax {
   @override
   Node parse(BlockParser parser) {
     final element = super.parse(parser) as Element;
-    element.generatedId = BlockSyntax.generateAnchorHash(element);
+    element.needsGeneratedId = true;
     return element;
   }
 }

--- a/pkgs/markdown/lib/src/document.dart
+++ b/pkgs/markdown/lib/src/document.dart
@@ -113,6 +113,9 @@ class Document {
         i += inlineNodes.length - 1;
       } else if (node is Element && node.children != null) {
         _parseInlineContent(node.children!);
+        if (node.needsGeneratedId) {
+          node.generatedId = BlockSyntax.generateAnchorHash(node);
+        }
       }
     }
   }

--- a/pkgs/markdown/test/extensions/headers_with_ids.unit
+++ b/pkgs/markdown/test/extensions/headers_with_ids.unit
@@ -39,3 +39,11 @@
 # #
 <<<
 <h1></h1>
+>>> header containing a link uses the link text, not the target
+### [Task](/packages/fpdart/lib/src/task.dart)
+<<<
+<h3 id="task"><a href="/packages/fpdart/lib/src/task.dart">Task</a></h3>
+>>> header containing an image omits it entirely
+### A [Link text](http://example.com) ![with image](http://example.com/favicon.gif) header
+<<<
+<h3 id="a-link-text--header">A <a href="http://example.com">Link text</a> <img src="http://example.com/favicon.gif" alt="with image" /> header</h3>

--- a/pkgs/markdown/test/extensions/setext_headers_with_ids.unit
+++ b/pkgs/markdown/test/extensions/setext_headers_with_ids.unit
@@ -16,3 +16,9 @@ header *emphasised*
 
 <<<
 <h1 id="header-emphasised">header <em>emphasised</em></h1>
+>>> header containing a link uses the link text, not the target
+[Task](/packages/fpdart/lib/src/task.dart)
+===
+
+<<<
+<h1 id="task"><a href="/packages/fpdart/lib/src/task.dart">Task</a></h1>


### PR DESCRIPTION
## Summary
- `HeaderWithIdSyntax`/`SetextHeaderWithIdSyntax` generated a header's anchor id from the raw, un-inline-parsed markdown source. For a header containing a link (e.g. `### [Task](/packages/fpdart/lib/src/task.dart)`), that folded the link *target* into the id (`taskpackagesfpdartlibsrctaskdart`) instead of using just the link text (`task`), breaking in-page anchor navigation wherever this pattern appears (e.g. on pub.dev-rendered READMEs).
- Id generation is now deferred until after inline parsing, so it runs against the resolved element tree: link targets are excluded (only the link text is used), images contribute nothing (matching GitHub's behavior), and other inline formatting (`**bold**`, `` `code` ``, etc.) is flattened to plain text before the id is derived.
- Added a `needsGeneratedId` flag on `Element` so header syntaxes can mark "this element wants a generated id," and `Document` computes the actual id right after resolving that element's inline children.

Fixes #1339

## Test plan
- [x] Added unit-format test cases in `test/extensions/headers_with_ids.unit` and `test/extensions/setext_headers_with_ids.unit` reproducing the exact repro from the issue (a header containing a link, and a header containing a link + image) — confirmed these fail against the old code and pass with the fix.
- [x] `dart test` (full suite, 2766 tests) passes.
- [x] `dart analyze` — no issues.
- [x] `dart format --output=none --set-exit-if-changed` — no changes needed.