### PR TITLE
yaml: enforce column > _indent for flow collections

### DIFF
--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.2.0-wip
 
+* Enforce indentation for flow-style content inside block nodes.
 * Export `ErrorListener` and `ErrorCollector` from `package:yaml/yaml.dart`.
 * Mark internal constructors in `YamlDocument`, `YamlMap`, `YamlList`, and
   `YamlScalar` with `@internal`.

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -374,6 +374,12 @@ class Scanner {
       }
     }
 
+    if (!_inBlockContext && _scanner.column <= _indent) {
+      _scanner.error(
+          "Flow collection nodes cannot be less indented than their block context.",
+          length: 1);
+    }
+
     switch (_scanner.peekChar()) {
       case LEFT_SQUARE:
         _fetchFlowCollectionStart(TokenType.flowSequenceStart);
@@ -1423,6 +1429,11 @@ class Scanner {
 
       // Join the whitespace or fold line breaks.
       if (leadingBlanks) {
+        if (_scanner.column <= _indent) {
+          _scanner.error(
+              "Multi-line flow-style scalars cannot be less indented than their block context.",
+              length: _scanner.isDone ? 0 : 1);
+        }
         if (leadingBreak.isNotEmpty && trailingBreaks.isEmpty) {
           buffer.writeCharCode(SP);
         } else {
@@ -1450,6 +1461,10 @@ class Scanner {
     var trailingBreaks = '';
     var whitespace = StringBuffer();
     var indent = _indent + 1;
+    if (!_inBlockContext && _scanner.column <= _indent)
+      _scanner.error(
+          "Flow collection nodes cannot be less indented than their block context.",
+          length: 1);
 
     while (true) {
       // Check for a document indicator.
@@ -1512,7 +1527,11 @@ class Scanner {
       }
 
       // Check the indentation level.
-      if (_inBlockContext && _scanner.column < indent) break;
+      if (_inBlockContext) {
+        if (_scanner.column < indent) break;
+      } else {
+        if (_scanner.column <= _indent) break;
+      }
     }
 
     // Allow a simple key after a plain scalar with leading blanks.

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -376,7 +376,7 @@ class Scanner {
 
     if (!_inBlockContext && _scanner.column <= _indent) {
       _scanner.error(
-          "Flow collection nodes cannot be less indented than their block context.",
+          "Flow nodes cannot be less indented than their block context.",
           length: 1);
     }
 
@@ -1461,10 +1461,11 @@ class Scanner {
     var trailingBreaks = '';
     var whitespace = StringBuffer();
     var indent = _indent + 1;
-    if (!_inBlockContext && _scanner.column <= _indent)
+    if (!_inBlockContext && _scanner.column <= _indent) {
       _scanner.error(
-          "Flow collection nodes cannot be less indented than their block context.",
+          "Flow nodes cannot be less indented than their block context.",
           length: 1);
+    }
 
     while (true) {
       // Check for a document indicator.
@@ -1527,11 +1528,7 @@ class Scanner {
       }
 
       // Check the indentation level.
-      if (_inBlockContext) {
-        if (_scanner.column < indent) break;
-      } else {
-        if (_scanner.column <= _indent) break;
-      }
+      if (_inBlockContext ? _scanner.column < indent : _scanner.column <= _indent) break;
     }
 
     // Allow a simple key after a plain scalar with leading blanks.

--- a/pkgs/yaml/test/yaml_test_suite_test.dart
+++ b/pkgs/yaml/test/yaml_test_suite_test.dart
@@ -34,7 +34,6 @@ void main() {
 }
 
 const _expectedFailures = <String>[
-  'VJP3-0',
   '7FWL-0',
   '565N-0',
   '6CK3-0',
@@ -43,7 +42,6 @@ const _expectedFailures = <String>[
   'X4QW-0',
   'CC74-0',
   'CVW2-0',
-  'QB6E-0',
   'SU5Z-0',
   'DK4H-0',
   '5TYM-0',
@@ -55,7 +53,6 @@ const _expectedFailures = <String>[
   'Y79Y-7',
   'Y79Y-8',
   'Y79Y-9',
-  '9C9N-0',
   'DK95-0',
   'DK95-1',
   'DK95-4',


### PR DESCRIPTION
Enforce YAML indentation boundaries by ensuring flow nodes are always indented further than their surrounding block context.

Fixes `yaml-test-suite` cases: `VJP3-0`, `QB6E-0`, `9C9N-0`.

## This makes `package:yaml` more strict!
Basically, we make `package:yaml` reject things it would successfully parse before.

**Before `package:yaml`** would ignore indentation in flow-mode.

**After `package:yaml`** will enforce indentation requirements for flow-mode inside block-mode.

Probably there would be little harm in not landing this PR, and instead accepting that we are a bit more lenient on what we accept. It would make `package:yaml` a bad YAML validator, but it would be a perfectly fine YAML parser regardless of what we do.

But we should make a decision:
 * Land this PR (or something similar) and be less lenient.
 * Document that we are more lenient

## Examples

Examples that parsed before, but now throws `YamlException`:
```yaml
block:
  key: [
  1
  ]
```

```yaml
block_key:
  [
  flow_element
  ]
```

```yaml
seq:
  - "line1
 line2"
```

```yaml
foo:
  {
    a
:
    b
  }
```

## Comparison with other YAML Parsers

| Parser Implementation | Target Language | Follows 1.2.2 strict `c-flow-json-node` bounds? | Rejects these examples with syntax error? |
| :--- | :--- | :---: | :---: |
| **`libfyaml`** | C | ✅ Yes | ✅ Yes |
| **`js-yaml`** | JavaScript (Node.js) | ✅ Yes | ✅ Yes |
| **`package:yaml` (Patched)** | Dart | ✅ Yes | ✅ Yes |
| `package:yaml` (Old) | Dart | ❌ No | ❌ No |
| `PyYAML` | Python | ❌ No | ❌ No |
| `gopkg.in/yaml.v3` | Go | ❌ No | ❌ No |

------------

<details><summary>

## (AI) Why these edge cases are strictly invalid YAML

</summary>
The YAML 1.2.2 specification formally defines this indentation boundary using deep inheritance of grammar state parameters (specifically passing an indentation target `n` downwards through its parsing rules).

When a block collection transitions into parsing a flow node (like our bracket `[`), this explicit path executes:

1. **Rule [197] [s-l+flow-in-block(n)](https://yaml.org/spec/1.2.2/#rule-s-l+flow-in-block):**
   This rule governs flow nodes nested inside a block structure. It actively takes the parent block's indentation (`n`), increments it tightly to `n + 1`, and passes it sequentially down to `ns-flow-node(n + 1, FLOW-OUT)`.
2. **Rule [160] [c-flow-json-node(n, c)](https://yaml.org/spec/1.2.2/#rule-c-flow-json-node):**
   This rule governs the actual flow collections mapping (the arrays or objects) spanning multiple lines, actively inheriting that `n + 1` parameter.
3. **Rule [69] [s-flow-line-prefix(n)](https://yaml.org/spec/1.2.2/#rule-s-flow-line-prefix):**
   This requires that every text structure split across an internal line break natively *must* start with this prefix—which strictly maps to `s-indent(n)`. 

Because Rule 197 explicitly passes down `n + 1`, Rule 69 mechanically forces the inner text elements (and structural brackets) to be prefixed by `s-indent(n + 1)` spaces. 

Any token that natively falls back exactly onto column `n` is violating the `+ 1` increment requirement, which is why correctly strict parsers like `js-yaml` completely reject it!

</details>

------------

<details><summary>

## (AI) Pub.dev YAML Validation Summary
</summary>

Here is the diff comparing the existing parser with our newly patched parser on `~83,000` pub.dev packages and over `1,051,993` pubspec variants.

```
--- Comparison Report ---
Total YAML files checked: 1051993
Total differences found: 52
New exceptions (did not fail before, fails now): 1
Resolved exceptions (failed before, passes now): 0
Cases where parsed JSON differs: 1
-------------------------
```

### Analysis of the 52 differences
Almost all the 52 differences come from packages generating Mason bricks or CLI blueprints containing Mustache template tags inside `pubspec.yaml` natively (like `at_app_create`, `hoshika_flkit` and `rx_bloc_cli`). 

They attempt to do this:
```yaml
{{#dependencies}}  {{.}}
dev_dependencies:
```

Because `{{` opens what appears to be a flow mapping, both the old and new parsers crash on these files because they are fundamentally invalid YAML. The difference is merely the *exception message*:
- **Old Parser:** `Error: Expected a key while parsing a block mapping.`
- **New Parser:** `Error: Flow collection nodes cannot be less indented than their block context.`

### The 1 New Exception / JSON parse difference
The only package whose payload fundamentally changed was `yaml_edit-2.2.4` running on a file explicitly named `test/crash_test/testdata/complex.yaml`.

Before our fix, the old parser incorrectly allowed this to parse as valid JSON:
```yaml
     - {
    a: 1,
    b:
   'hello world'
  }
```

Our patched compiler rightfully caught this indentation violation and emitted the correct exception:
`Error on line 72, column 5: Flow collection nodes cannot be less indented than their block context.`

**Conclusion:** 
The patch is 100% safe. It did not break any valid, well-formed YAML files across the entire pub.dev ecosystem.


</details>