### PR TITLE
[unified_analytics] Guard logFileStats against oversized or corrupted log files

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Dependencies are deterministically sorted and chunked using a hash-based
   algorithm salted with the canonical dependency set to fit within Google
   Analytics 4 parameter limitations without alphabetical or global package bias.
+- `LogHandler.logFileStats` no longer reads the log file into memory when it
+  exceeds `kMaxLogFileSize`, and discards any `FileSystemException` thrown
+  while reading it, to avoid crashing or exhausting memory on an abnormally
+  large or corrupted log file.
 
 ## 8.0.17
 - Added optional `agentPlugin` parameter to the `Event.dartMCPEvent` constructor to identify 

--- a/pkgs/unified_analytics/lib/src/log_handler.dart
+++ b/pkgs/unified_analytics/lib/src/log_handler.dart
@@ -173,11 +173,30 @@ class LogHandler {
   /// developers and will not have any data for flutter
   /// related metrics.
   LogFileStats? logFileStats() {
+    List<String> lines;
+    try {
+      // Avoid reading abnormally large (or corrupted) log files into
+      // memory, which can exhaust the heap; see
+      // https://github.com/dart-lang/tools/issues/275.
+      if (logFile.statSync().size > kMaxLogFileSize) return null;
+
+      lines = logFile.readAsLinesSync();
+    } on FileSystemException catch (err) {
+      errorSet.add(
+        Event.analyticsException(
+          workflow: 'LogHandler.logFileStats',
+          error: err.runtimeType.toString(),
+          description: 'message: ${err.message}\npath: ${err.path}',
+        ),
+      );
+
+      return null;
+    }
+
     // Parse each line of the log file through [LogItem],
     // some returned records may be null if malformed, they will be
     // removed later through `whereType<LogItem>`
-    final records = logFile
-        .readAsLinesSync()
+    final records = lines
         .map((String e) {
           try {
             return LogItem.fromRecord(jsonDecode(e) as Map<String, Object?>);

--- a/pkgs/unified_analytics/test/log_handler_test.dart
+++ b/pkgs/unified_analytics/test/log_handler_test.dart
@@ -350,6 +350,54 @@ void main() {
     );
   });
 
+  test('logFileStats returns null without reading the file when it exceeds '
+      'kMaxLogFileSize', () async {
+    var readAsLinesSyncCalled = false;
+    final logFile = _FakeFile('log.txt')
+      .._statSyncImpl = (() => _FakeFileStat(kMaxLogFileSize + 1))
+      .._readAsLinesSyncImpl = (() {
+        readAsLinesSyncCalled = true;
+        return <String>[];
+      });
+    final logHandler = LogHandler(logFile: logFile);
+
+    expect(logHandler.logFileStats(), isNull);
+    expect(
+      readAsLinesSyncCalled,
+      isFalse,
+      reason:
+          'The file should not be read into memory when it exceeds '
+          'kMaxLogFileSize, to avoid OOM on abnormally large log files',
+    );
+  });
+
+  test('logFileStats returns null and records an analyticsException when '
+      'reading the log file throws a FileSystemException', () async {
+    final logFile = _FakeFile('log.txt')
+      .._statSyncImpl = (() => _FakeFileStat(0))
+      .._readAsLinesSyncImpl = () {
+        throw const FileSystemException(
+          "Failed to decode data using encoding 'utf-8'",
+          'log.txt',
+        );
+      };
+    final logHandler = LogHandler(logFile: logFile);
+
+    expect(logHandler.logFileStats(), isNull);
+    expect(
+      logHandler.errorSet,
+      contains(
+        Event.analyticsException(
+          workflow: 'LogHandler.logFileStats',
+          error: 'FileSystemException',
+          description:
+              "message: Failed to decode data using encoding 'utf-8'\n"
+              'path: log.txt',
+        ),
+      ),
+    );
+  });
+
   test('truncateStringToLength returns same string when '
       'max length greater than string length', () {
     final testString = 'Version 14.1 (Build 23B74)';


### PR DESCRIPTION
## Summary

Fixes #275.

`LogHandler.logFileStats()` read the entire telemetry log file into memory via `readAsLinesSync()` with no size check and no exception handling. This is the same file `LogHandler.save()` already guards against via `kMaxLogFileSize`, but `logFileStats()` had no such protection.

An abnormally large or corrupted log file (see the crash report linked from the issue, flutter/flutter#150137) could cause an OOM ("Exhausted heap space") or an uncaught `FileSystemException` (e.g. invalid UTF-8 during decode) when read this way.

This PR:
1. Returns `null` from `logFileStats()` without reading the file when `logFile.statSync().size > kMaxLogFileSize`, mirroring the existing guard in `save()`.
2. Wraps the read in a `try`/`on FileSystemException` and records an `Event.analyticsException` in `errorSet`, following the existing pattern already used in this method for per-record `FormatException`/`TypeError` handling, so the failure remains observable via the package's existing error-reporting mechanism.

`logFileStats()` already returns `null` in other failure modes (empty file, all-malformed records), so this doesn't introduce a new contract surprise for callers — `AnalyticsImpl.fetchAvailableSurveys()` and the public `Analytics.logFileStats()` API already null-check the result.

## Test plan
- [x] Added a test asserting the size guard short-circuits before ever calling `readAsLinesSync()` (using the existing `_FakeFile` test double already used for the equivalent `save()` tests).
- [x] Added a test asserting a `FileSystemException` thrown during read is caught, `logFileStats()` returns `null`, and the expected `Event.analyticsException` is recorded in `errorSet`.
- [x] `dart test` — all 186 tests pass.
- [x] `dart analyze` — no issues.
- [x] `dart format` — no changes needed.