### PR TITLE
Remove @internal annotations for now

### DIFF
--- a/pkgs/yaml/CHANGELOG.md
+++ b/pkgs/yaml/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## 3.2.0-wip
 
 * Export `ErrorListener` and `ErrorCollector` from `package:yaml/yaml.dart`.
-* Mark internal constructors in `YamlDocument`, `YamlMap`, `YamlList`, and
-  `YamlScalar` with `@internal`.
 
 ## 3.1.4
 

--- a/pkgs/yaml/lib/src/yaml_document.dart
+++ b/pkgs/yaml/lib/src/yaml_document.dart
@@ -7,7 +7,6 @@
 
 import 'dart:collection';
 
-import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
 import 'yaml_node.dart';
@@ -36,7 +35,6 @@ class YamlDocument {
   /// Users of the library should not use this constructor.
   ///
   /// @nodoc
-  @internal
   YamlDocument.internal(this.contents, this.span, this.versionDirective,
       List<TagDirective> tagDirectives,
       {this.startImplicit = false, this.endImplicit = false})

--- a/pkgs/yaml/lib/src/yaml_node.dart
+++ b/pkgs/yaml/lib/src/yaml_node.dart
@@ -8,7 +8,6 @@
 import 'dart:collection' as collection;
 
 import 'package:collection/collection.dart';
-import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
 import 'event.dart';
@@ -87,7 +86,6 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
       YamlMapWrapper(dartMap, sourceUrl, style: style);
 
   /// Users of the library should not use this constructor.
-  @internal
   YamlMap.internal(Map<dynamic, YamlNode> nodes, super.span, this.style)
       : nodes = UnmodifiableMapView<dynamic, YamlNode>(nodes),
         super._();
@@ -138,7 +136,6 @@ class YamlList extends YamlNode with collection.ListMixin {
       YamlListWrapper(dartList, sourceUrl, style: style);
 
   /// Users of the library should not use this constructor.
-  @internal
   YamlList.internal(List<YamlNode> nodes, super.span, this.style)
       : nodes = UnmodifiableListView<YamlNode>(nodes),
         super._();
@@ -173,13 +170,11 @@ class YamlScalar extends YamlNode {
   }
 
   /// Users of the library should not use this constructor.
-  @internal
   YamlScalar.internal(this.value, ScalarEvent scalar)
       : style = scalar.style,
         super._(scalar.span);
 
   /// Users of the library should not use this constructor.
-  @internal
   YamlScalar.internalWithSpan(this.value, SourceSpan span)
       : style = ScalarStyle.ANY,
         super._(span);

--- a/pkgs/yaml/pubspec.yaml
+++ b/pkgs/yaml/pubspec.yaml
@@ -13,7 +13,6 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  meta: ^1.9.0
   source_span: ^1.8.0
   string_scanner: ^1.2.0
 


### PR DESCRIPTION
Our CI is not tolerant to this diagnostic. We either need to fix CI
config or resolve uses of these members before annotating them.
