### PR TITLE
[mime] Fix EBML magic bytes resolving to non-standard audio/weba

### DIFF
--- a/pkgs/mime/CHANGELOG.md
+++ b/pkgs/mime/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Switched to using the Apache httpd mime.conf table as the source of truth for
   mime types.
+* Fixed the magic number for the EBML header (`1A 45 DF A3`) to resolve to
+  `video/x-matroska` instead of the non-standard `audio/weba`.
 
 Mime type additions:
 - `application/vnd.geogebra.slides`

--- a/pkgs/mime/lib/src/magic_number.dart
+++ b/pkgs/mime/lib/src/magic_number.dart
@@ -65,7 +65,7 @@ const List<MagicNumber> initialMagicNumbers = [
   MagicNumber('image/tiff', '\x4D\x4D\x00\x2A'),
   MagicNumber('audio/aac', '\xFF\xF1'),
   MagicNumber('audio/aac', '\xFF\xF9'),
-  MagicNumber('audio/weba', '\x1A\x45\xDF\xA3'),
+  MagicNumber('video/x-matroska', '\x1A\x45\xDF\xA3'),
   MagicNumber('audio/mpeg', '\x49\x44\x33'),
   MagicNumber('audio/mpeg', '\xFF\xFB'),
   MagicNumber('audio/ogg', '\x4F\x70\x75'),

--- a/pkgs/mime/test/mime_type_test.dart
+++ b/pkgs/mime/test/mime_type_test.dart
@@ -204,6 +204,8 @@ void main() {
           headerBytes: [0xFF, 0xF1, 0x0D, 0x0A, 0x1A, 0x0A]);
       _expectMimeType('file', 'audio/ogg',
           headerBytes: [0x4F, 0x70, 0x75, 0x0D, 0x0A, 0x1A, 0x0A]);
+      _expectMimeType('file', 'video/x-matroska',
+          headerBytes: [0x1A, 0x45, 0xDF, 0xA3, 0x0D, 0x0A, 0x1A, 0x0A]);
       _expectMimeType('file', 'audio/x-aiff', headerBytes: [
         0x46,
         0x4F,
@@ -321,12 +323,6 @@ void main() {
     final magicMimes = initialMagicNumbers.map((magic) => magic.mimeType);
 
     for (final mime in magicMimes) {
-      if (mime == 'audio/weba') {
-        // TODO(devoncarew): We need to remove or rename audio/weba; it's not a
-        // mime type.
-        continue;
-      }
-
       expect(
         extensionFromMime(mime),
         isNotNull,


### PR DESCRIPTION
## Summary
- The magic-number entry for bytes `1A 45 DF A3` (the EBML header shared by WebM and Matroska containers) mapped to `audio/weba`, which isn't a registered MIME type — `mime_type_test.dart` already had a `TODO(devoncarew)` flagging this for removal/rename.
- A 4-byte prefix match can't distinguish audio from video, or WebM from Matroska, without parsing the `DocType` field deeper in the file, so this maps to the existing, resolvable `video/x-matroska` type instead (already present in the generated extension table, resolving to `.mkv`).
- Removed the now-unnecessary `audio/weba` skip in the "magic numbers in mime table" test.

Fixes #2157.

## Test plan
- [x] Added a test case asserting the EBML header resolves to `video/x-matroska`
- [x] `dart test` — all 87 tests pass
- [x] `dart analyze` — no issues
- [x] `dart format --set-exit-if-changed .` — clean