### PR TITLE
[glob] Fix StateError on patterns with an empty option branch

### DIFF
--- a/pkgs/glob/CHANGELOG.md
+++ b/pkgs/glob/CHANGELOG.md
@@ -6,6 +6,9 @@
   exhaustion. `Glob.matches()` uses regular expressions and is unaffected.
 - Allow `**` to match zero directories at the start of a pattern or following
   a separator (e.g. `**/foo` matches `foo` and `a/**/b` matches `a/b`).
+- Fixed a `StateError` ("Bad state: No element") thrown by `matches()` and
+  `matchAsPrefix()` for patterns with an empty option branch, such as
+  `{**/,}foo.dart`.
 
 ## 2.1.3
 

--- a/pkgs/glob/lib/src/ast.dart
+++ b/pkgs/glob/lib/src/ast.dart
@@ -73,10 +73,10 @@ class SequenceNode extends AstNode {
   }
 
   @override
-  bool get canMatchAbsolute => nodes.first.canMatchAbsolute;
+  bool get canMatchAbsolute => nodes.isNotEmpty && nodes.first.canMatchAbsolute;
 
   @override
-  bool get canMatchRelative => nodes.first.canMatchRelative;
+  bool get canMatchRelative => nodes.isEmpty || nodes.first.canMatchRelative;
 
   SequenceNode(Iterable<AstNode> nodes, {bool caseSensitive = true})
       : nodes = nodes.toList(),

--- a/pkgs/glob/test/match_test.dart
+++ b/pkgs/glob/test/match_test.dart
@@ -217,6 +217,14 @@ void main() {
       expect('foo/baz', isNot(contains(glob)));
       expect('foo/bar/bang', isNot(contains(glob)));
     });
+
+    test('an empty option does not throw', () {
+      var glob = Glob('{**/,}foo.dart');
+      expect('foo.dart', contains(glob));
+      expect('a/foo.dart', contains(glob));
+      expect('a/b/foo.dart', contains(glob));
+      expect('a/foo.txt', isNot(contains(glob)));
+    });
   });
 
   group('normalization', () {


### PR DESCRIPTION
## Summary
- `SequenceNode.canMatchAbsolute`/`canMatchRelative` in `pkgs/glob/lib/src/ast.dart` called `nodes.first` without checking for an empty node list, which throws `Bad state: No element` for any pattern with an empty option branch (e.g. `{**/,}foo.dart`).
- Guard both getters against an empty `nodes` list, falling back to the base-class defaults (`canMatchAbsolute = false`, `canMatchRelative = true`), which correctly describe an empty sequence: it can only match an empty (relative) segment, never an absolute path.

## Test plan
- [x] Added a regression test in `pkgs/glob/test/match_test.dart` reproducing the reported pattern (`{**/,}foo.dart`) and confirming it matches instead of throwing.
- [x] `dart test` — all 145 tests pass
- [x] `dart analyze` — no issues
- [x] `dart format --output=none --set-exit-if-changed .` — clean

Fixes #2004