### PR TITLE
[pubspec_parse] Expose version constraint on GitDependency and PathDependency

### DIFF
--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.0-wip
+
+- Added `version` to `GitDependency` and `PathDependency`, exposing the
+  constraint from an accompanying `version` key instead of silently
+  discarding it.
+
 ## 1.6.0
 
 - Added `toJson` method to `Pubspec` to serialize the object back to a `Map`.

--- a/pkgs/pubspec_parse/lib/src/dependency.dart
+++ b/pkgs/pubspec_parse/lib/src/dependency.dart
@@ -81,8 +81,11 @@ Dependency? _fromJson(Object? data, String name) {
         final key = matchedKeys.single;
 
         return switch (key) {
-          'git' => GitDependency.fromData(data[key]),
-          'path' => PathDependency.fromData(data[key]),
+          'git' => GitDependency.fromData(data[key], version: data['version']),
+          'path' => PathDependency.fromData(
+            data[key],
+            version: data['version'],
+          ),
           'sdk' => _$SdkDependencyFromJson(data),
           'hosted' => _$HostedDependencyFromJson(
             data,
@@ -131,15 +134,26 @@ class GitDependency extends Dependency {
   final String? ref;
   final String? path;
 
-  GitDependency(this.url, {this.ref, this.path});
+  /// The constraint from the `version` key that may accompany a `git`
+  /// dependency.
+  ///
+  /// This isn't used to select a revision, but pub's solver still validates
+  /// it against the resolved package's version.
+  @JsonKey(fromJson: _constraintFromString)
+  final VersionConstraint version;
 
-  factory GitDependency.fromData(Object? data) {
+  GitDependency(this.url, {this.ref, this.path, VersionConstraint? version})
+    : version = version ?? VersionConstraint.any;
+
+  factory GitDependency.fromData(Object? data, {Object? version}) {
     if (data is String) {
       data = {'url': data};
     }
 
     if (data is Map) {
-      return _$GitDependencyFromJson(data);
+      return _$GitDependencyFromJson(
+        version == null ? data : {...data, 'version': version},
+      );
     }
 
     throw ArgumentError.value(data, 'git', 'Must be a String or a Map.');
@@ -150,10 +164,11 @@ class GitDependency extends Dependency {
       other is GitDependency &&
       other.url == url &&
       other.ref == ref &&
-      other.path == path;
+      other.path == path &&
+      other.version == version;
 
   @override
-  int get hashCode => Object.hash(url, ref, path);
+  int get hashCode => Object.hash(url, ref, path, version);
 
   @override
   String toString() => 'GitDependency: url@$url';
@@ -161,6 +176,7 @@ class GitDependency extends Dependency {
   @override
   Map<String, dynamic> toJson() => {
     'git': {'url': url.toString(), 'ref': ?ref, 'path': ?path},
+    if (version != VersionConstraint.any) 'version': version.toString(),
   };
 }
 
@@ -202,27 +218,41 @@ Uri? _tryParseScpUri(String value) {
 class PathDependency extends Dependency {
   final String path;
 
-  PathDependency(this.path);
+  /// The constraint from the `version` key that may accompany a `path`
+  /// dependency.
+  ///
+  /// This isn't used to select the dependency, but pub's solver still
+  /// validates it against the resolved package's version.
+  final VersionConstraint version;
 
-  factory PathDependency.fromData(Object? data) {
+  PathDependency(this.path, {VersionConstraint? version})
+    : version = version ?? VersionConstraint.any;
+
+  factory PathDependency.fromData(Object? data, {Object? version}) {
     if (data is String) {
-      return PathDependency(data);
+      return PathDependency(
+        data,
+        version: _constraintFromString(version as String?),
+      );
     }
     throw ArgumentError.value(data, 'path', 'Must be a String.');
   }
 
   @override
   bool operator ==(Object other) =>
-      other is PathDependency && other.path == path;
+      other is PathDependency && other.path == path && other.version == version;
 
   @override
-  int get hashCode => path.hashCode;
+  int get hashCode => Object.hash(path, version);
 
   @override
   String toString() => 'PathDependency: path@$path';
 
   @override
-  Map<String, dynamic> toJson() => {'path': path};
+  Map<String, dynamic> toJson() => {
+    'path': path,
+    if (version != VersionConstraint.any) 'version': version.toString(),
+  };
 }
 
 @JsonSerializable(disallowUnrecognizedKeys: true)

--- a/pkgs/pubspec_parse/lib/src/dependency.g.dart
+++ b/pkgs/pubspec_parse/lib/src/dependency.g.dart
@@ -26,6 +26,10 @@ GitDependency _$GitDependencyFromJson(Map json) =>
         $checkedConvert('url', (v) => parseGitUri(v as String)),
         ref: $checkedConvert('ref', (v) => v as String?),
         path: $checkedConvert('path', (v) => v as String?),
+        version: $checkedConvert(
+          'version',
+          (v) => _constraintFromString(v as String?),
+        ),
       );
       return val;
     });

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.6.0
+version: 1.7.0-wip
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.

--- a/pkgs/pubspec_parse/test/dependency_test.dart
+++ b/pkgs/pubspec_parse/test/dependency_test.dart
@@ -247,8 +247,7 @@ void _gitDependency() {
     expect(dep.toString(), 'GitDependency: url@url');
   });
 
-  test('string with version key is ignored', () async {
-    // Regression test for https://github.com/dart-lang/pubspec_parse/issues/13
+  test('string with version key exposes the constraint', () async {
     final dep = await _dependency<GitDependency>({
       'git': 'url',
       'version': '^1.2.3',
@@ -256,7 +255,21 @@ void _gitDependency() {
     expect(dep.url.toString(), 'url');
     expect(dep.path, isNull);
     expect(dep.ref, isNull);
+    expect(dep.version, VersionConstraint.parse('^1.2.3'));
     expect(dep.toString(), 'GitDependency: url@url');
+  });
+
+  test('without a version key defaults to any', () async {
+    final dep = await _dependency<GitDependency>({'git': 'url'});
+    expect(dep.version, VersionConstraint.any);
+  });
+
+  test('map with version key exposes the constraint', () async {
+    final dep = await _dependency<GitDependency>({
+      'git': {'url': 'url', 'path': 'path', 'ref': 'ref'},
+      'version': '^1.2.3',
+    });
+    expect(dep.version, VersionConstraint.parse('^1.2.3'));
   });
 
   test('string with user@ URL', () async {
@@ -349,13 +362,19 @@ void _pathDependency() {
     expect(dep.toString(), 'PathDependency: path@../path');
   });
 
-  test('valid with version key is ignored', () async {
+  test('valid with version key exposes the constraint', () async {
     final dep = await _dependency<PathDependency>({
       'path': '../path',
       'version': '^1.2.3',
     });
     expect(dep.path, '../path');
+    expect(dep.version, VersionConstraint.parse('^1.2.3'));
     expect(dep.toString(), 'PathDependency: path@../path');
+  });
+
+  test('without a version key defaults to any', () async {
+    final dep = await _dependency<PathDependency>({'path': '../path'});
+    expect(dep.version, VersionConstraint.any);
   });
 
   test('valid with random extra key fails', () {


### PR DESCRIPTION
## Summary
- `git`/`path` dependencies may be written with a sibling `version:` key (pub's solver still validates it against the resolved package's version), but `pubspec_parse` silently discarded it — `GitDependency`/`PathDependency` had no way to expose it.
- Adds a `version` field (`VersionConstraint`, defaulting to `VersionConstraint.any`) to both classes, parsed from the sibling `version` key, mirroring the existing pattern on `HostedDependency`/`SdkDependency`.
- Purely additive: `toJson()` only emits `version` when it's set to something other than `VersionConstraint.any`, so existing serialization output is unchanged.

Fixes #1809

## Test plan
- [x] `dart test` — all 113 tests pass
- [x] `dart analyze` — no issues
- [x] `dart format --output=none --set-exit-if-changed .` — clean
- [x] Added regression tests covering: string-form and map-form `git` deps with a `version` key, `path` deps with a `version` key, and the default (`VersionConstraint.any`) when no `version` key is present