### PR TITLE
[pubspec_parse] Add README usage examples #1807

### DIFF
--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+- Added usage examples to the README.
+
 ## 1.6.0
 
 - Added `toJson` method to `Pubspec` to serialize the object back to a `Map`.

--- a/pkgs/pubspec_parse/CHANGELOG.md
+++ b/pkgs/pubspec_parse/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.6.1
 
-- Added usage examples to the README.
+- Added a usage example.
 
 ## 1.6.0
 

--- a/pkgs/pubspec_parse/README.md
+++ b/pkgs/pubspec_parse/README.md
@@ -7,6 +7,59 @@
 Supports parsing `pubspec.yaml` files with robust error reporting and support
 for most of the documented features.
 
+## Usage
+
+Parse a `pubspec.yaml` string with `Pubspec.parse`:
+
+```dart
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+void main() {
+  const yaml = '''
+name: my_package
+version: 1.2.3
+environment:
+  sdk: ^3.8.0
+dependencies:
+  collection: ^1.19.0
+  path:
+    path: ../path
+''';
+
+  final pubspec = Pubspec.parse(yaml);
+  print(pubspec.name); // my_package
+  print(pubspec.version); // 1.2.3
+
+  final collection = pubspec.dependencies['collection'];
+  if (collection is HostedDependency) {
+    print(collection.version); // ^1.19.0
+  }
+
+  final path = pubspec.dependencies['path'];
+  if (path is PathDependency) {
+    print(path.path); // ../path
+  }
+}
+```
+
+`Pubspec.parse` throws a `ParsedYamlException` from `package:checked_yaml` when
+a field is invalid. Pass `lenient: true` to ignore unknown or invalid top-level
+keys.
+
+To load a file:
+
+```dart
+import 'dart:io';
+
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+void main() {
+  final yaml = File('pubspec.yaml').readAsStringSync();
+  final pubspec = Pubspec.parse(yaml, sourceUrl: Uri.parse('pubspec.yaml'));
+  print('${pubspec.name} ${pubspec.version}');
+}
+```
+
 ## More information
 
 Read more about the [pubspec format](https://dart.dev/tools/pub/pubspec).

--- a/pkgs/pubspec_parse/README.md
+++ b/pkgs/pubspec_parse/README.md
@@ -9,56 +9,15 @@ for most of the documented features.
 
 ## Usage
 
-Parse a `pubspec.yaml` string with `Pubspec.parse`:
-
-```dart
-import 'package:pubspec_parse/pubspec_parse.dart';
-
-void main() {
-  const yaml = '''
-name: my_package
-version: 1.2.3
-environment:
-  sdk: ^3.8.0
-dependencies:
-  collection: ^1.19.0
-  path:
-    path: ../path
-''';
-
-  final pubspec = Pubspec.parse(yaml);
-  print(pubspec.name); // my_package
-  print(pubspec.version); // 1.2.3
-
-  final collection = pubspec.dependencies['collection'];
-  if (collection is HostedDependency) {
-    print(collection.version); // ^1.19.0
-  }
-
-  final path = pubspec.dependencies['path'];
-  if (path is PathDependency) {
-    print(path.path); // ../path
-  }
-}
-```
+Parse a `pubspec.yaml` string with `Pubspec.parse`. Hosted and path
+dependencies come back as `HostedDependency` and `PathDependency`.
 
 `Pubspec.parse` throws a `ParsedYamlException` from `package:checked_yaml` when
 a field is invalid. Pass `lenient: true` to ignore unknown or invalid top-level
 keys.
 
-To load a file:
-
-```dart
-import 'dart:io';
-
-import 'package:pubspec_parse/pubspec_parse.dart';
-
-void main() {
-  final yaml = File('pubspec.yaml').readAsStringSync();
-  final pubspec = Pubspec.parse(yaml, sourceUrl: Uri.parse('pubspec.yaml'));
-  print('${pubspec.name} ${pubspec.version}');
-}
-```
+A complete example, including loading from a file, is in
+[example/example.dart](example/example.dart).
 
 ## More information
 

--- a/pkgs/pubspec_parse/example/example.dart
+++ b/pkgs/pubspec_parse/example/example.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+void main() {
+  const yaml = '''
+name: my_package
+version: 1.2.3
+environment:
+  sdk: ^3.8.0
+dependencies:
+  collection: ^1.19.0
+  path:
+    path: ../path
+''';
+
+  final pubspec = Pubspec.parse(yaml);
+  print(pubspec.name); // my_package
+  print(pubspec.version); // 1.2.3
+
+  final collection = pubspec.dependencies['collection'];
+  if (collection is HostedDependency) {
+    print(collection.version); // ^1.19.0
+  }
+
+  final path = pubspec.dependencies['path'];
+  if (path is PathDependency) {
+    print(path.path); // ../path
+  }
+
+  final fromFile = File('pubspec.yaml').readAsStringSync();
+  final parsedFile = Pubspec.parse(
+    fromFile,
+    sourceUrl: Uri.file('pubspec.yaml'),
+  );
+  print('${parsedFile.name} ${parsedFile.version}');
+}

--- a/pkgs/pubspec_parse/pubspec.yaml
+++ b/pkgs/pubspec_parse/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.6.0
+version: 1.6.1
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.


### PR DESCRIPTION
Adds a Usage section to the pubspec_parse README so you can parse a pubspec without reading the library source. Covers hosted and path dependencies, loading from a file, and lenient mode.

Fixes #1807

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
