### PR TITLE
allow methods to read their request id and notification flag

### DIFF
--- a/pkgs/json_rpc_2/CHANGELOG.md
+++ b/pkgs/json_rpc_2/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * `Parameters` now carries `id`. A method can read it.
 * Add `Parameters.isNotification`, to tell a notification apart from a request
-  with a `null` id.
+  with a `null` ID.
 * A class that implements `Parameters` now needs `id` and `isNotification`.
 
 ## 4.1.0

--- a/pkgs/json_rpc_2/CHANGELOG.md
+++ b/pkgs/json_rpc_2/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.2.0-wip
+
+* `Parameters` now carries `id`. A method can read it.
+* Add `Parameters.isNotification`, to tell a notification apart from a request
+  with a `null` id.
+* A class that implements `Parameters` now needs `id` and `isNotification`.
+
 ## 4.1.0
 
 * Forward errors within `Peer` when it is acting as a client.

--- a/pkgs/json_rpc_2/lib/src/parameters.dart
+++ b/pkgs/json_rpc_2/lib/src/parameters.dart
@@ -28,10 +28,10 @@ class Parameters {
   /// will be automatically rejected. To avoid this, use [Parameter.valueOr].
   final dynamic value;
 
-  /// The id of the request that called [method].
+  /// The ID of the request that called [method].
   ///
   /// JSON-RPC allows a string, a number, or `null` here. A notification has no
-  /// id, and reaches a method as `null` too. Read [isNotification] to tell
+  /// ID, and reaches a method as `null` too. Read [isNotification] to tell
   /// those apart.
   final Object? id;
 

--- a/pkgs/json_rpc_2/lib/src/parameters.dart
+++ b/pkgs/json_rpc_2/lib/src/parameters.dart
@@ -28,7 +28,20 @@ class Parameters {
   /// will be automatically rejected. To avoid this, use [Parameter.valueOr].
   final dynamic value;
 
-  Parameters(this.method, this.value);
+  /// The id of the request that called [method].
+  ///
+  /// JSON-RPC allows a string, a number, or `null` here. A notification has no
+  /// id, and reaches a method as `null` too. Read [isNotification] to tell
+  /// those apart.
+  final Object? id;
+
+  /// Whether the request that called [method] was a notification.
+  ///
+  /// A notification gets no response. Whatever the method returns for one is
+  /// dropped.
+  final bool isNotification;
+
+  Parameters(this.method, this.value, {this.id, this.isNotification = false});
 
   /// Returns a single parameter.
   ///
@@ -106,7 +119,8 @@ class Parameters {
 ///     // "params.value" is "{'scores': {'home': [5, 10, 17]}}"
 ///     params['scores']['home'][2].asInt // => 17
 class Parameter extends Parameters {
-  // The parent parameters, used to construct [_path].
+  // The parent parameters, used to construct [_path] and to reach the request
+  // this parameter came from.
   final Parameters _parent;
 
   /// The key used to access `this`, used to construct [_path].
@@ -153,6 +167,12 @@ class Parameter extends Parameters {
 
   /// Whether this parameter exists.
   bool get exists => true;
+
+  @override
+  Object? get id => _parent.id;
+
+  @override
+  bool get isNotification => _parent.isNotification;
 
   Parameter._(super.method, super.value, this._parent, this._key);
 

--- a/pkgs/json_rpc_2/lib/src/parameters.dart
+++ b/pkgs/json_rpc_2/lib/src/parameters.dart
@@ -168,13 +168,8 @@ class Parameter extends Parameters {
   /// Whether this parameter exists.
   bool get exists => true;
 
-  @override
-  Object? get id => _parent.id;
-
-  @override
-  bool get isNotification => _parent.isNotification;
-
-  Parameter._(super.method, super.value, this._parent, this._key);
+  Parameter._(super.method, super.value, this._parent, this._key)
+      : super(id: _parent.id, isNotification: _parent.isNotification);
 
   /// Returns [value], or [defaultValue] if this parameter wasn't passed.
   dynamic valueOr(Object? defaultValue) => value;

--- a/pkgs/json_rpc_2/lib/src/server.dart
+++ b/pkgs/json_rpc_2/lib/src/server.dart
@@ -209,7 +209,8 @@ class Server {
         }
         result = await method();
       } else {
-        result = await method(Parameters(name, request['params']));
+        result = await method(Parameters(name, request['params'],
+            id: request['id'], isNotification: !request.containsKey('id')));
       }
 
       // A request without an id is a notification, which should not be sent a

--- a/pkgs/json_rpc_2/pubspec.yaml
+++ b/pkgs/json_rpc_2/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 4.1.0
+version: 4.2.0-wip
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/json_rpc_2

--- a/pkgs/json_rpc_2/test/server/server_test.dart
+++ b/pkgs/json_rpc_2/test/server/server_test.dart
@@ -74,9 +74,11 @@ void main() {
   });
 
   test('a request with no id is a notification', () async {
-    final completer = Completer<json_rpc.Parameters>();
+    json_rpc.Parameters? received;
+    final handled = Completer<void>();
     controller.server.registerMethod('foo', (json_rpc.Parameters params) {
-      completer.complete(params);
+      received = params;
+      handled.complete();
     });
 
     unawaited(controller.handleRequest({
@@ -85,10 +87,10 @@ void main() {
       'params': {'param': 'value'}
     }));
 
-    var params = await completer.future;
-    expect(params.id, isNull);
-    expect(params.isNotification, isTrue);
-    expect(params['param'].isNotification, isTrue);
+    await handled.future;
+    expect(received!.id, isNull);
+    expect(received!.isNotification, isTrue);
+    expect(received!['param'].isNotification, isTrue);
   });
 
   test('calls a method that takes no parameters', () {

--- a/pkgs/json_rpc_2/test/server/server_test.dart
+++ b/pkgs/json_rpc_2/test/server/server_test.dart
@@ -37,7 +37,7 @@ void main() {
         })));
   });
 
-  test('passes the id of the request being answered', () {
+  test('passes the ID of the request being answered', () {
     controller.server.registerMethod(
         'foo',
         (json_rpc.Parameters params) =>
@@ -57,7 +57,7 @@ void main() {
         })));
   });
 
-  test('a null id is not a notification', () {
+  test('a null ID is not a notification', () {
     controller.server.registerMethod(
         'foo',
         (json_rpc.Parameters params) =>
@@ -73,7 +73,7 @@ void main() {
         })));
   });
 
-  test('a request with no id is a notification', () async {
+  test('a request with no ID is a notification', () async {
     json_rpc.Parameters? received;
     final handled = Completer<void>();
     controller.server.registerMethod('foo', (json_rpc.Parameters params) {

--- a/pkgs/json_rpc_2/test/server/server_test.dart
+++ b/pkgs/json_rpc_2/test/server/server_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:json_rpc_2/error_code.dart' as error_code;
@@ -34,6 +35,60 @@ void main() {
           },
           'id': 1234
         })));
+  });
+
+  test('passes the id of the request being answered', () {
+    controller.server.registerMethod(
+        'foo',
+        (json_rpc.Parameters params) =>
+            {'id': params.id, 'nested': params['param'].id});
+
+    expect(
+        controller.handleRequest({
+          'jsonrpc': '2.0',
+          'method': 'foo',
+          'params': {'param': 'value'},
+          'id': 1234
+        }),
+        completion(equals({
+          'jsonrpc': '2.0',
+          'result': {'id': 1234, 'nested': 1234},
+          'id': 1234
+        })));
+  });
+
+  test('a null id is not a notification', () {
+    controller.server.registerMethod(
+        'foo',
+        (json_rpc.Parameters params) =>
+            {'id': params.id, 'notification': params.isNotification});
+
+    expect(
+        controller
+            .handleRequest({'jsonrpc': '2.0', 'method': 'foo', 'id': null}),
+        completion(equals({
+          'jsonrpc': '2.0',
+          'result': {'id': null, 'notification': false},
+          'id': null
+        })));
+  });
+
+  test('a request with no id is a notification', () async {
+    final completer = Completer<json_rpc.Parameters>();
+    controller.server.registerMethod('foo', (json_rpc.Parameters params) {
+      completer.complete(params);
+    });
+
+    unawaited(controller.handleRequest({
+      'jsonrpc': '2.0',
+      'method': 'foo',
+      'params': {'param': 'value'}
+    }));
+
+    var params = await completer.future;
+    expect(params.id, isNull);
+    expect(params.isNotification, isTrue);
+    expect(params['param'].isNotification, isTrue);
   });
 
   test('calls a method that takes no parameters', () {


### PR DESCRIPTION
A `registerMethod` callback is handed a `Parameters` object that already names the
method it is answering, but not the id. Anything keyed by that id has to come from
somewhere else. In `package:dart_mcp` a transport sets a field on the server before
delivering a `subscriptions/listen` request, and the handler reads it back,
the workaround noted in https://github.com/dart-lang/ai/pull/636#discussion_r3897914670.

That object now carries the id alongside `method`. Callback shapes are untouched,
though a class that implements `Parameters` picks up two more members.
I left the bump at 4.2.0, and `dart_apitool` reads the change as minor.

Notifications carry no id, and `_validateRequest` also admits an explicit `null` id
on a request that does get a response. Both of those reach a handler as `null`, so
`isNotification` tells them apart.

Part of https://github.com/dart-lang/tools/issues/2086. That issue asks for the
outgoing id, the one `sendRequest` picks. This is the incoming half.
