### PR TITLE
fix(coverage): migrate subprocess spawning to package:cli_util

### DIFF
--- a/pkgs/coverage/CHANGELOG.md
+++ b/pkgs/coverage/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.16.0-wip
 
+- Migrate Dart subprocess spawning to `package:cli_util` (`dartExecutable ?? 'dart'`) to support AOT-compiled executables (`dart compile exe` / `dart install`).
 - Require Dart 3.9.
 - Fixed a race condition in isolate teardown: ignore the benign errors
   produced when an isolate exits between its pause-on-exit callback

--- a/pkgs/coverage/bin/test_with_coverage.dart
+++ b/pkgs/coverage/bin/test_with_coverage.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:cli_util/cli_util.dart';
 import 'package:coverage/src/coverage_options.dart';
 import 'package:coverage/src/util.dart';
 import 'package:meta/meta.dart';
@@ -15,13 +16,14 @@ import 'collect_coverage.dart' as collect_coverage;
 import 'format_coverage.dart' as format_coverage;
 
 final _allProcesses = <Process>[];
+final _dartExecutable = dartExecutable ?? 'dart';
 
 Future<void> _dartRun(
   List<String> args, {
   required void Function(String) onStdout,
   required void Function(String) onStderr,
 }) async {
-  final process = await Process.start(Platform.executable, args);
+  final process = await Process.start(_dartExecutable, args);
   _allProcesses.add(process);
 
   void listen(
@@ -39,7 +41,7 @@ Future<void> _dartRun(
 
   final result = await process.exitCode;
   if (result != 0) {
-    throw ProcessException(Platform.executable, args, '', result);
+    throw ProcessException(_dartExecutable, args, '', result);
   }
 }
 

--- a/pkgs/coverage/bin/test_with_coverage.dart
+++ b/pkgs/coverage/bin/test_with_coverage.dart
@@ -16,7 +16,7 @@ import 'collect_coverage.dart' as collect_coverage;
 import 'format_coverage.dart' as format_coverage;
 
 final _allProcesses = <Process>[];
-final _dartExecutable = dartExecutable ?? 'dart';
+String get _dartExecutable => dartExecutable ?? 'dart';
 
 Future<void> _dartRun(
   List<String> args, {

--- a/pkgs/coverage/lib/src/run_and_collect.dart
+++ b/pkgs/coverage/lib/src/run_and_collect.dart
@@ -5,8 +5,12 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:cli_util/cli_util.dart';
+
 import 'collect.dart';
 import 'util.dart';
+
+final _dartExecutable = dartExecutable ?? 'dart';
 
 Future<Map<String, dynamic>> runAndCollect(
   String scriptPath, {
@@ -23,7 +27,7 @@ Future<Map<String, dynamic>> runAndCollect(
     ...?scriptArgs,
   ];
 
-  final process = await Process.start(Platform.executable, dartArgs);
+  final process = await Process.start(_dartExecutable, dartArgs);
 
   final serviceUri = await serviceUriFromProcess(process.stdout.lines());
   Map<String, dynamic> coverage;
@@ -42,7 +46,7 @@ Future<Map<String, dynamic>> runAndCollect(
   final exitStatus = await process.exitCode;
   if (exitStatus != 0) {
     throw ProcessException(
-      Platform.executable,
+      _dartExecutable,
       dartArgs,
       'Process failed.',
       exitStatus,

--- a/pkgs/coverage/lib/src/run_and_collect.dart
+++ b/pkgs/coverage/lib/src/run_and_collect.dart
@@ -10,7 +10,7 @@ import 'package:cli_util/cli_util.dart';
 import 'collect.dart';
 import 'util.dart';
 
-final _dartExecutable = dartExecutable ?? 'dart';
+String get _dartExecutable => dartExecutable ?? 'dart';
 
 Future<Map<String, dynamic>> runAndCollect(
   String scriptPath, {

--- a/pkgs/coverage/pubspec.yaml
+++ b/pkgs/coverage/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   args: ^2.0.0
   cli_config: ^0.2.0
+  cli_util: ^0.6.0
   glob: ^2.1.2
   logging: ^1.0.0
   meta: ^1.0.2


### PR DESCRIPTION
- Replace Platform.executable in bin/test_with_coverage.dart and lib/src/run_and_collect.dart with package:cli_util (dartExecutable ?? 'dart') to prevent infinite self-invocation loops under AOT compilation (dart compile exe / dart install).
- Add cli_util: ^0.6.0 dependency to pubspec.yaml and update CHANGELOG.md.
