### PR TITLE
fix(benchmark_harness): migrate subprocess spawning to package:cli_util

### DIFF
--- a/pkgs/benchmark_harness/CHANGELOG.md
+++ b/pkgs/benchmark_harness/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1-wip
+
+- Migrate `bench` command Dart subprocess spawning to `package:cli_util` (`dartExecutable ?? 'dart'`) to support AOT-compiled executables (`dart compile exe` / `dart install`).
+
 ## 2.4.0
 
 - Added a `bench` command.

--- a/pkgs/benchmark_harness/lib/src/bench_command/compile_and_run.dart
+++ b/pkgs/benchmark_harness/lib/src/bench_command/compile_and_run.dart
@@ -4,7 +4,11 @@
 
 import 'dart:io';
 
+import 'package:cli_util/cli_util.dart';
+
 import 'bench_options.dart';
+
+String get _dartExecutable => dartExecutable ?? 'dart';
 
 // TODO(kevmoo): allow the user to specify custom flags – for compile and/or run
 
@@ -107,7 +111,7 @@ class _JITRunner extends _Runner {
 
   @override
   Future<void> _runImpl() async {
-    await _runProc(_Stage.run, Platform.executable, [target]);
+    await _runProc(_Stage.run, _dartExecutable, [target]);
   }
 }
 
@@ -117,7 +121,7 @@ class _AOTRunner extends _Runner {
   @override
   Future<void> _runImpl() async {
     final outFile = _outputFile('exe');
-    await _runProc(_Stage.compile, Platform.executable, [
+    await _runProc(_Stage.compile, _dartExecutable, [
       'compile',
       'exe',
       target,
@@ -135,7 +139,7 @@ class _JSRunner extends _Runner {
   @override
   Future<void> _runImpl() async {
     final outFile = _outputFile('js');
-    await _runProc(_Stage.compile, Platform.executable, [
+    await _runProc(_Stage.compile, _dartExecutable, [
       'compile',
       'js',
       target,
@@ -154,7 +158,7 @@ class _WasmRunner extends _Runner {
   @override
   Future<void> _runImpl() async {
     final outFile = _outputFile('wasm');
-    await _runProc(_Stage.compile, Platform.executable, [
+    await _runProc(_Stage.compile, _dartExecutable, [
       'compile',
       'wasm',
       target,

--- a/pkgs/benchmark_harness/pubspec.yaml
+++ b/pkgs/benchmark_harness/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
-  path: ^1.9.0
   test: ^1.25.7
 
 executables:

--- a/pkgs/benchmark_harness/pubspec.yaml
+++ b/pkgs/benchmark_harness/pubspec.yaml
@@ -1,5 +1,5 @@
 name: benchmark_harness
-version: 2.4.0
+version: 2.4.1-wip
 description: The official Dart project benchmark harness.
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/benchmark_harness
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Abenchmark_harness
@@ -12,6 +12,7 @@ environment:
 
 dependencies:
   args: ^2.5.0
+  cli_util: ^0.6.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0

--- a/pkgs/benchmark_harness/test/bench_command_test.dart
+++ b/pkgs/benchmark_harness/test/bench_command_test.dart
@@ -10,11 +10,12 @@ import 'dart:io';
 
 import 'package:benchmark_harness/src/bench_command/bench_options.dart';
 import 'package:benchmark_harness/src/bench_command/compile_and_run.dart';
+import 'package:cli_util/cli_util.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('readme', () async {
-    final output = await Process.run(Platform.executable, [
+    final output = await Process.run(dartExecutable ?? 'dart', [
       'bin/bench.dart',
       '--help',
     ]);
@@ -45,6 +46,27 @@ void main() {
 
     tearDownAll(() {
       tempDir.deleteSync(recursive: true);
+    });
+
+    test('AOT compiled bench executable can compile and run target', () async {
+      final benchExe = tempDir.uri.resolve('bench.exe').toFilePath();
+      final compileResult = await Process.run(dartExecutable ?? 'dart', [
+        'compile',
+        'exe',
+        'bin/bench.dart',
+        '-o',
+        benchExe,
+      ]);
+      expect(compileResult.exitCode, 0, reason: '${compileResult.stderr}');
+
+      final runResult = await Process.run(benchExe, [
+        '--flavor',
+        'jit',
+        '--target',
+        testFilePath,
+      ]);
+      expect(runResult.exitCode, 0, reason: '${runResult.stderr}');
+      expect(runResult.stdout, contains('8589934592'));
     });
 
     group('BenchOptions.fromArgs', () {


### PR DESCRIPTION
- Replace Platform.executable in lib/src/bench_command/compile_and_run.dart with package:cli_util (dartExecutable ?? 'dart') to support AOT-compiled executables (dart compile exe / dart install).
- Bump version to 2.4.1-wip, add cli_util: ^0.6.0 dependency to pubspec.yaml, and update CHANGELOG.md.
