### PR TITLE
[yaml_edit] Fix block scalar encoding with CRLF line endings

### DIFF
--- a/pkgs/yaml_edit/CHANGELOG.md
+++ b/pkgs/yaml_edit/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.5-wip
 
 - Fix `YamlEditor.appendToList` and map updates when adding to flow collections with a trailing comma.
+- Fix literal and folded block scalar encoding with CRLF line endings.
 
 ## 2.2.4
 

--- a/pkgs/yaml_edit/lib/src/strings.dart
+++ b/pkgs/yaml_edit/lib/src/strings.dart
@@ -137,7 +137,7 @@ String? _tryYamlEncodeFolded(String string, int indentSize, String lineEnding) {
     return previous + lineEnding + updated;
   });
 
-  return '>-\n'
+  return '>-$lineEnding'
       '$indent$trimmed'
       '${stripped.replaceAll('\n', lineEnding + indent)}';
 }
@@ -176,7 +176,7 @@ String? _tryYamlEncodeLiteral(
 
   /// Simplest block style.
   /// * https://yaml.org/spec/1.2.2/#812-literal-style
-  return '|-\n$indent${string.replaceAll('\n', lineEnding + indent)}';
+  return '|-$lineEnding$indent${string.replaceAll('\n', lineEnding + indent)}';
 }
 
 /// Encodes a flow [YamlScalar] based on the provided [YamlScalar.style].

--- a/pkgs/yaml_edit/test/windows_test.dart
+++ b/pkgs/yaml_edit/test/windows_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/src/utils.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
@@ -219,6 +220,29 @@ a: 1\r
 '''));
 
       expectDeepEquals(nodes.toList(), [0, 0]);
+    });
+
+    test('literal block scalar encodes with CRLF header', () {
+      final doc = YamlEditor('key: initial\r\nother: 1\r\n');
+      doc.update(
+        ['key'],
+        wrapAsYamlNode('line1\nline2', scalarStyle: ScalarStyle.LITERAL),
+      );
+      final result = doc.toString();
+      expect(result, contains('|-\r\n'));
+      expect(result, isNot(contains('|-\n ')));
+      expect(doc.parseAt(['key']).value, equals('line1\nline2'));
+    });
+
+    test('folded block scalar encodes with CRLF header', () {
+      final doc = YamlEditor('key: initial\r\nother: 1\r\n');
+      doc.update(
+        ['key'],
+        wrapAsYamlNode('line1\nline2', scalarStyle: ScalarStyle.FOLDED),
+      );
+      final result = doc.toString();
+      expect(result, contains('>-\r\n'));
+      expect(doc.parseAt(['key']).value, equals('line1\nline2'));
     });
   });
 }

--- a/pkgs/yaml_edit/test/windows_test.dart
+++ b/pkgs/yaml_edit/test/windows_test.dart
@@ -228,9 +228,10 @@ a: 1\r
         ['key'],
         wrapAsYamlNode('line1\nline2', scalarStyle: ScalarStyle.LITERAL),
       );
-      final result = doc.toString();
-      expect(result, contains('|-\r\n'));
-      expect(result, isNot(contains('|-\n ')));
+      expect(
+        doc.toString(),
+        equals('key: |-\r\n    line1\r\n    line2\r\nother: 1\r\n'),
+      );
       expect(doc.parseAt(['key']).value, equals('line1\nline2'));
     });
 
@@ -240,8 +241,10 @@ a: 1\r
         ['key'],
         wrapAsYamlNode('line1\nline2', scalarStyle: ScalarStyle.FOLDED),
       );
-      final result = doc.toString();
-      expect(result, contains('>-\r\n'));
+      expect(
+        doc.toString(),
+        equals('key: >-\r\n    line1\r\n\r\n    line2\r\nother: 1\r\n'),
+      );
       expect(doc.parseAt(['key']).value, equals('line1\nline2'));
     });
   });


### PR DESCRIPTION
This PR fixes line ending encoding in literal and folded block scalars in `package:yaml_edit`.

### Changes

- Interpolate `$lineEnding` in `_tryYamlEncodeFolded` and `_tryYamlEncodeLiteral` in `lib/src/strings.dart` instead of hardcoding `\n` in the header (`'>-\n'` and `'|-\n'`).
- Add regression tests in `test/windows_test.dart` verifying CRLF line endings are retained in both the header and body of block scalars.
