### PR TITLE
[yaml_edit] Fix block list append after keep-chomping scalar

### DIFF
--- a/pkgs/yaml_edit/CHANGELOG.md
+++ b/pkgs/yaml_edit/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.5-wip
 
 - Fix `YamlEditor.appendToList` and map updates when adding to flow collections with a trailing comma.
+- Fix appending to block lists ending with keep-chomping block scalars (`|+`).
 
 ## 2.2.4
 

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -161,9 +161,24 @@ SourceEdit _appendToBlockList(
     if (nextNewLineIndex == -1) {
       formattedValue = getLineEnding(yaml) + formattedValue;
     } else {
-      if (lastNode is YamlScalar &&
-          (lastNode.style == ScalarStyle.LITERAL ||
-              lastNode.style == ScalarStyle.FOLDED)) {
+      var deepestNode = lastNode;
+      while (true) {
+        if (deepestNode is YamlList &&
+            deepestNode.style == CollectionStyle.BLOCK &&
+            deepestNode.isNotEmpty) {
+          deepestNode = deepestNode.nodes.last;
+        } else if (deepestNode is YamlMap &&
+            deepestNode.style == CollectionStyle.BLOCK &&
+            deepestNode.isNotEmpty) {
+          deepestNode = deepestNode.nodes.values.last;
+        } else {
+          break;
+        }
+      }
+
+      if (deepestNode is YamlScalar &&
+          (deepestNode.style == ScalarStyle.LITERAL ||
+              deepestNode.style == ScalarStyle.FOLDED)) {
         while (nextNewLineIndex + 1 < yaml.length) {
           final nextLineEnd = yaml.indexOf('\n', nextNewLineIndex + 1);
           final lineSlice = nextLineEnd == -1

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -155,11 +155,27 @@ SourceEdit _appendToBlockList(
   // Adjusts offset to after the trailing newline of the last entry, if it
   // exists
   if (list.isNotEmpty) {
-    final lastValueSpanEnd = list.nodes.last.span.end.offset;
-    final nextNewLineIndex = yaml.indexOf('\n', lastValueSpanEnd - 1);
+    final lastNode = list.nodes.last;
+    final lastValueSpanEnd = getContentSensitiveEnd(lastNode);
+    var nextNewLineIndex = yaml.indexOf('\n', lastValueSpanEnd);
     if (nextNewLineIndex == -1) {
       formattedValue = getLineEnding(yaml) + formattedValue;
     } else {
+      if (lastNode is YamlScalar &&
+          (lastNode.style == ScalarStyle.LITERAL ||
+              lastNode.style == ScalarStyle.FOLDED)) {
+        while (nextNewLineIndex + 1 < yaml.length) {
+          final nextLineEnd = yaml.indexOf('\n', nextNewLineIndex + 1);
+          final lineSlice = nextLineEnd == -1
+              ? yaml.substring(nextNewLineIndex + 1)
+              : yaml.substring(nextNewLineIndex + 1, nextLineEnd);
+          if (lineSlice.trim().isEmpty && nextLineEnd != -1) {
+            nextNewLineIndex = nextLineEnd;
+          } else {
+            break;
+          }
+        }
+      }
       offset = nextNewLineIndex + 1;
     }
   }

--- a/pkgs/yaml_edit/test/append_test.dart
+++ b/pkgs/yaml_edit/test/append_test.dart
@@ -242,6 +242,31 @@ a:
               }),
           returnsNormally);
     });
+
+    test('preserves trailing newlines of |+ when appending', () {
+      final doc = YamlEditor('list:\n  - |+\n    hello\n');
+      doc.appendToList(['list'], 'next');
+      final result = doc.toString();
+      expect(result, equals('list:\n  - |+\n    hello\n  - next\n'));
+      expect(doc.parseAt(['list', 0]).value, equals('hello\n'));
+      expect(doc.parseAt(['list', 1]).value, equals('next'));
+    });
+
+    test('preserves multiple trailing newlines of |+ when appending', () {
+      final doc = YamlEditor('list:\n  - |+\n    hello\n\n\n');
+      doc.appendToList(['list'], 'next');
+      final result = doc.toString();
+      expect(result, equals('list:\n  - |+\n    hello\n\n\n  - next\n'));
+      expect(doc.parseAt(['list', 0]).value, equals('hello\n\n\n'));
+      expect(doc.parseAt(['list', 1]).value, equals('next'));
+    });
+
+    test('appends to list ending with single-line scalar without newlines', () {
+      final doc = YamlEditor('list:\n  - item');
+      doc.appendToList(['list'], 'item2');
+      expect(doc.parseAt(['list', 0]).value, equals('item'));
+      expect(doc.parseAt(['list', 1]).value, equals('item2'));
+    });
   });
 
   group('flow list', () {

--- a/pkgs/yaml_edit/test/append_test.dart
+++ b/pkgs/yaml_edit/test/append_test.dart
@@ -261,6 +261,39 @@ a:
       expect(doc.parseAt(['list', 1]).value, equals('next'));
     });
 
+    test('preserves multiple trailing newlines of nested |+ when appending',
+        () {
+      final doc = YamlEditor('list:\n  - map_key: |+\n      hello\n\n\n');
+      doc.appendToList(['list'], 'next');
+      final result = doc.toString();
+      expect(result,
+          equals('list:\n  - map_key: |+\n      hello\n\n\n  - next\n'));
+      expect(doc.parseAt(['list', 0, 'map_key']).value, equals('hello\n\n\n'));
+      expect(doc.parseAt(['list', 1]).value, equals('next'));
+    });
+
+    test(
+        'preserves multiple trailing newlines of nested list |+ when appending',
+        () {
+      final doc = YamlEditor('list:\n  - - |+\n      hello\n\n\n');
+      doc.appendToList(['list'], 'next');
+      final result = doc.toString();
+      expect(result, equals('list:\n  - - |+\n      hello\n\n\n  - next\n'));
+      expect(doc.parseAt(['list', 0, 0]).value, equals('hello\n\n\n'));
+      expect(doc.parseAt(['list', 1]).value, equals('next'));
+    });
+
+    test('preserves multiple trailing newlines of nested >+ when appending',
+        () {
+      final doc = YamlEditor('list:\n  - map_key: >+\n      hello\n\n\n');
+      doc.appendToList(['list'], 'next');
+      final result = doc.toString();
+      expect(result,
+          equals('list:\n  - map_key: >+\n      hello\n\n\n  - next\n'));
+      expect(doc.parseAt(['list', 0, 'map_key']).value, equals('hello\n\n\n'));
+      expect(doc.parseAt(['list', 1]).value, equals('next'));
+    });
+
     test('appends to list ending with single-line scalar without newlines', () {
       final doc = YamlEditor('list:\n  - item');
       doc.appendToList(['list'], 'item2');


### PR DESCRIPTION
This PR fixes appending to block lists when the previous last entry ends with a keep-chomping scalar (`|+` or `>+`), including when nested inside block maps or lists, in `package:yaml_edit`.

### Changes

- In `_appendToBlockList` in `lib/src/list_mutations.dart`, resolve the deepest last block node to scan past trailing blank lines of keep-chomping block scalars (`|+` / `>+`) when locating the insertion offset. Previously, `_appendToBlockList` stopped at the first newline after the scalar's content span (and only checked immediate scalar items), placing appended items inside the scalar's trailing blank lines.
- Add regression tests in `test/append_test.dart` covering top-level and nested keep-chomping scalars in maps and lists.
