### PR TITLE
[yaml_edit] Harden getListIndentation and getContentSensitiveEnd

### DIFF
--- a/pkgs/yaml_edit/CHANGELOG.md
+++ b/pkgs/yaml_edit/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.5-wip
 
 - Fix `YamlEditor.appendToList` and map updates when adding to flow collections with a trailing comma.
+- Harden `getListIndentation` to gracefully fall back to `list.span.start.column` when no list-internal hyphen is found.
 
 ## 2.2.4
 

--- a/pkgs/yaml_edit/lib/src/utils.dart
+++ b/pkgs/yaml_edit/lib/src/utils.dart
@@ -95,13 +95,13 @@ bool isBlockNode(YamlNode node) {
 /// last meaningful content happens)
 int getContentSensitiveEnd(YamlNode yamlNode) {
   if (yamlNode is YamlList) {
-    if (yamlNode.style == CollectionStyle.FLOW) {
+    if (yamlNode.style == CollectionStyle.FLOW || yamlNode.isEmpty) {
       return yamlNode.span.end.offset;
     } else {
       return getContentSensitiveEnd(yamlNode.nodes.last);
     }
   } else if (yamlNode is YamlMap) {
-    if (yamlNode.style == CollectionStyle.FLOW) {
+    if (yamlNode.style == CollectionStyle.FLOW || yamlNode.isEmpty) {
       return yamlNode.span.end.offset;
     } else {
       return getContentSensitiveEnd(yamlNode.nodes.values.last);
@@ -203,24 +203,39 @@ int getIndentation(YamlEditor editor) {
 /// but returns the number of spaces before the hyphen of elements for
 /// block lists.
 ///
-/// Throws [UnsupportedError] if an empty block map is passed in.
+/// It is an error if [list] is an empty block list.
+///
+/// Throws [UnsupportedError] if [list] is an empty block list.
 int getListIndentation(String yaml, YamlList list) {
   if (list.style == CollectionStyle.FLOW) return 0;
 
-  /// An empty block map doesn't really exist.
+  /// An empty block list doesn't really exist.
   if (list.isEmpty) {
     throw UnsupportedError('Unable to get indentation for empty block list');
   }
 
-  final lastSpanOffset = list.nodes.last.span.start.offset;
-  final lastHyphen = yaml.lastIndexOf('-', lastSpanOffset - 1);
+  // Iterate backwards to find a node with a valid hyphen in the source text.
+  // We cannot rely solely on the last node because if it has an invalid or
+  // external span, its offsets will fall outside list.span.
+  final listStart = list.span.start.offset;
+  final listEnd = list.span.end.offset;
 
-  if (lastHyphen == 0) return lastHyphen;
+  for (final node in list.nodes.reversed) {
+    final nodeStart = node.span.start.offset;
+    final nodeEnd = node.span.end.offset;
+    if (nodeStart < listStart || nodeEnd > listEnd) continue;
+    if (nodeStart <= 0) continue;
 
-  // Look for '\n' that's before hyphen
-  final lastNewLine = yaml.lastIndexOf('\n', lastHyphen - 1);
+    final hyphen = yaml.lastIndexOf('-', nodeStart - 1);
+    if (hyphen < listStart) continue;
+    if (hyphen == 0) return 0;
 
-  return lastHyphen - lastNewLine - 1;
+    final newLine = yaml.lastIndexOf('\n', hyphen - 1);
+    if (newLine < 0) return hyphen;
+    return hyphen - newLine - 1;
+  }
+
+  return list.span.start.column;
 }
 
 /// Gets the indentation level of [map]. This is 0 if it is a flow map,

--- a/pkgs/yaml_edit/test/utils_test.dart
+++ b/pkgs/yaml_edit/test/utils_test.dart
@@ -624,4 +624,75 @@ a:
       );
     });
   });
+
+  group('getContentSensitiveEnd', () {
+    test('getContentSensitiveEnd with empty list and empty map', () {
+      final emptyList =
+          YamlList.internal([], shellSpan(null), CollectionStyle.BLOCK);
+      expect(getContentSensitiveEnd(emptyList), equals(0));
+      final emptyMap =
+          YamlMap.internal({}, shellSpan(null), CollectionStyle.BLOCK);
+      expect(getContentSensitiveEnd(emptyMap), equals(0));
+    });
+  });
+
+  group('getListIndentation', () {
+    test('block list with only aliases falls back to list.span.start.column',
+        () {
+      final yaml = '''
+anchors:
+  a: &item1 10
+  b: &item2 20
+list:
+  - *item1
+  - *item2
+''';
+      final doc = YamlEditor(yaml);
+      final list = doc.parseAt(['list']) as YamlList;
+      final indent = getListIndentation(yaml, list);
+      expect(indent, equals(2));
+    });
+
+    test('nested block list with only aliases preserves indent column', () {
+      final yaml = '''
+anchors:
+  val: &v 1
+data:
+  nested:
+    - *v
+''';
+      final doc = YamlEditor(yaml);
+      final list = doc.parseAt(['data', 'nested']) as YamlList;
+      final indent = getListIndentation(yaml, list);
+      expect(indent, equals(4));
+    });
+
+    test('nested block list preserves indent column', () {
+      final yaml = '''
+data:
+  nested:
+    - a
+''';
+      final doc = YamlEditor(yaml);
+      final list = doc.parseAt(['data', 'nested']) as YamlList;
+      final indent = getListIndentation(yaml, list);
+      expect(indent, equals(4));
+    });
+
+    test('flow list returns 0', () {
+      final yaml = '[1, 2, 3]';
+      final doc = YamlEditor(yaml);
+      final list = doc.parseAt([]) as YamlList;
+      expect(getListIndentation(yaml, list), equals(0));
+    });
+
+    test('empty block list throws UnsupportedError', () {
+      final emptyBlockList =
+          YamlList.internal([], shellSpan(null), CollectionStyle.BLOCK);
+      expect(
+        () => getListIndentation('', emptyBlockList),
+        throwsUnsupportedError,
+      );
+    });
+  });
 }


### PR DESCRIPTION
This PR hardens `getListIndentation` against out-of-span AST nodes and empty collections in `package:yaml_edit`.

### Changes

- In `getListIndentation` in `lib/src/utils.dart`, search backward through `list.nodes` for an element whose span falls within `list.span` and has a preceding hyphen, falling back to `list.span.start.column`.
- In `getContentSensitiveEnd` in `lib/src/utils.dart`, add `isEmpty` guards to prevent out-of-bounds indexing on empty block lists or maps.
- Fix doc comment in `getListIndentation` to refer to empty block list rather than empty block map.
- Add unit tests in `test/utils_test.dart`.
