### PR TITLE
[yaml_edit] Support comment-aware flow delimiter scanning and empty flow map values

### DIFF
--- a/pkgs/yaml_edit/CHANGELOG.md
+++ b/pkgs/yaml_edit/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.2.5-wip
 
 - Fix `YamlEditor.appendToList` and map updates when adding to flow collections with a trailing comma.
+- Fix flow list and flow map mutations when comments contain delimiter characters.
+- Support updating empty values in flow maps without whitespace after the colon.
 
 ## 2.2.4
 

--- a/pkgs/yaml_edit/lib/src/char_codes.dart
+++ b/pkgs/yaml_edit/lib/src/char_codes.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Character code constants and character classification predicates for
+/// YAML 1.2 parsing and source modification.
+///
+/// Constants and predicates adhere to the [YAML 1.2 specification](https://yaml.org/spec/1.2.2/).
+abstract final class YamlChar {
+  /// Character code for horizontal tab (`\t`).
+  static const int tab = 0x09;
+
+  /// Character code for line feed (`\n`).
+  static const int lineFeed = 0x0A;
+
+  /// Character code for carriage return (`\r`).
+  static const int carriageReturn = 0x0D;
+
+  /// Character code for space (` `).
+  static const int space = 0x20;
+
+  /// Character code for number sign / hash (`#`).
+  static const int hash = 0x23;
+
+  /// Character code for asterisk (`*`).
+  static const int asterisk = 0x2A;
+
+  /// Character code for comma (`,`).
+  static const int comma = 0x2C;
+
+  /// Character code for hyphen-minus (`-`).
+  static const int hyphen = 0x2D;
+
+  /// Character code for colon (`:`).
+  static const int colon = 0x3A;
+
+  /// Character code for question mark (`?`).
+  static const int question = 0x3F;
+
+  /// Character code for left square bracket (`[`).
+  static const int leftSquare = 0x5B;
+
+  /// Character code for right square bracket (`]`).
+  static const int rightSquare = 0x5D;
+
+  /// Character code for left curly brace (`{`).
+  static const int leftCurly = 0x7B;
+
+  /// Character code for right curly brace (`}`).
+  static const int rightCurly = 0x7D;
+
+  /// Returns `true` if [codeUnit] represents YAML whitespace (`space`
+  /// or `tab`).
+  ///
+  /// See [YAML 1.2 rule 26 (s-white)](https://yaml.org/spec/1.2.2/#rule-s-white).
+  ///
+  /// Runs in O(1) constant time.
+  static bool isWhitespace(int codeUnit) =>
+      codeUnit == space || codeUnit == tab;
+
+  /// Returns `true` if [codeUnit] represents a YAML line break (`LF` or `CR`).
+  ///
+  /// See [YAML 1.2 rule 29 (b-char)](https://yaml.org/spec/1.2.2/#rule-b-char).
+  ///
+  /// Runs in O(1) constant time.
+  static bool isLineBreak(int codeUnit) =>
+      codeUnit == lineFeed || codeUnit == carriageReturn;
+
+  /// Returns `true` if [codeUnit] represents a YAML flow indicator
+  /// (`,`, `[`, `]`, `{`, or `}`).
+  ///
+  /// See [YAML 1.2 rule 23 (c-flow-indicator)](https://yaml.org/spec/1.2.2/#rule-c-flow-indicator).
+  ///
+  /// Runs in O(1) constant time.
+  static bool isFlowIndicator(int codeUnit) =>
+      codeUnit == comma ||
+      codeUnit == leftSquare ||
+      codeUnit == rightSquare ||
+      codeUnit == leftCurly ||
+      codeUnit == rightCurly;
+
+  /// Returns `true` if [codeUnit] can be part of a YAML anchor or alias name.
+  ///
+  /// Anchor characters cannot be whitespace, line breaks, or flow indicators.
+  /// See [YAML 1.2 rule 102 (ns-anchor-char)](https://yaml.org/spec/1.2.2/#rule-ns-anchor-char).
+  ///
+  /// Runs in O(1) constant time.
+  static bool isAnchorChar(int codeUnit) =>
+      !isWhitespace(codeUnit) &&
+      !isLineBreak(codeUnit) &&
+      !isFlowIndicator(codeUnit);
+}

--- a/pkgs/yaml_edit/lib/src/char_codes.dart
+++ b/pkgs/yaml_edit/lib/src/char_codes.dart
@@ -19,8 +19,14 @@ abstract final class YamlChar {
   /// Character code for space (` `).
   static const int space = 0x20;
 
+  /// Character code for quotation mark / double quote (`"`).
+  static const int doubleQuote = 0x22;
+
   /// Character code for number sign / hash (`#`).
   static const int hash = 0x23;
+
+  /// Character code for apostrophe / single quote (`'`).
+  static const int singleQuote = 0x27;
 
   /// Character code for asterisk (`*`).
   static const int asterisk = 0x2A;
@@ -36,6 +42,9 @@ abstract final class YamlChar {
 
   /// Character code for question mark (`?`).
   static const int question = 0x3F;
+
+  /// Character code for reverse solidus / backslash (`\`).
+  static const int backslash = 0x5C;
 
   /// Character code for left square bracket (`[`).
   static const int leftSquare = 0x5B;

--- a/pkgs/yaml_edit/lib/src/list_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/list_mutations.dart
@@ -4,6 +4,7 @@
 
 import 'package:yaml/yaml.dart';
 
+import 'char_codes.dart';
 import 'editor.dart';
 import 'source_edit.dart';
 import 'strings.dart';
@@ -327,8 +328,13 @@ SourceEdit _insertInFlowList(
   final yaml = yamlEdit.toString();
   final currNode = list.nodes[index];
   final currNodeStart = currNode.span.start.offset;
-  var start = yaml.lastIndexOf(RegExp(r',|\['), currNodeStart - 1) + 1;
-  if (yaml[start] == ' ') start++;
+  var start = findPreviousFlowDelimiter(
+        yaml,
+        currNodeStart - 1,
+        delimiters: {YamlChar.comma, YamlChar.leftSquare},
+      ) +
+      1;
+  if (start < yaml.length && yaml[start] == ' ') start++;
 
   return SourceEdit(start, 0, formattedValue);
 }
@@ -399,14 +405,32 @@ SourceEdit _removeFromFlowList(
   var end = span.end.offset;
 
   if (index == 0) {
-    start = yaml.lastIndexOf('[', start - 1) + 1;
+    start = findPreviousFlowDelimiter(
+          yaml,
+          start - 1,
+          delimiters: {YamlChar.leftSquare},
+        ) +
+        1;
     if (index == list.length - 1) {
-      end = yaml.indexOf(']', end);
+      end = findNextFlowDelimiter(
+        yaml,
+        end,
+        delimiters: {YamlChar.rightSquare},
+      );
     } else {
-      end = yaml.indexOf(',', end) + 1;
+      end = findNextFlowDelimiter(
+            yaml,
+            end,
+            delimiters: {YamlChar.comma},
+          ) +
+          1;
     }
   } else {
-    start = yaml.lastIndexOf(',', start - 1);
+    start = findPreviousFlowDelimiter(
+      yaml,
+      start - 1,
+      delimiters: {YamlChar.comma},
+    );
   }
 
   return SourceEdit(start, end - start, '');

--- a/pkgs/yaml_edit/lib/src/map_mutations.dart
+++ b/pkgs/yaml_edit/lib/src/map_mutations.dart
@@ -4,6 +4,7 @@
 
 import 'package:yaml/yaml.dart';
 
+import 'char_codes.dart';
 import 'editor.dart';
 import 'equality.dart';
 import 'source_edit.dart';
@@ -192,9 +193,30 @@ SourceEdit _replaceInBlockMap(
 SourceEdit _replaceInFlowMap(
     YamlEditor yamlEdit, YamlMap map, Object? key, YamlNode newValue) {
   final valueSpan = map.nodes[key]!.span;
-  final valueString = yamlEncodeFlow(newValue);
+  var valueString = yamlEncodeFlow(newValue);
 
-  return SourceEdit(valueSpan.start.offset, valueSpan.length, valueString);
+  final yaml = yamlEdit.toString();
+  final keyNode = getKeyNode(map, key);
+  final colonIndex = findNextFlowDelimiter(
+    yaml,
+    keyNode.span.end.offset,
+    delimiters: {YamlChar.colon, YamlChar.comma, YamlChar.rightCurly},
+  );
+  if (colonIndex == -1 || yaml.codeUnitAt(colonIndex) != YamlChar.colon) {
+    return SourceEdit(keyNode.span.end.offset, 0, ': $valueString');
+  }
+
+  var start = valueSpan.start.offset;
+  if (valueSpan.length == 0) {
+    if (start < colonIndex + 1) {
+      start = colonIndex + 1;
+    }
+    if (start <= colonIndex + 1) {
+      valueString = ' $valueString';
+    }
+  }
+
+  return SourceEdit(start, valueSpan.length, valueString);
 }
 
 /// Performs the string operation on [yamlEdit] to achieve the effect of
@@ -246,15 +268,33 @@ SourceEdit _removeFromFlowMap(YamlEditor yamlEdit, YamlMap map, Object? key) {
   final yaml = yamlEdit.toString();
 
   if (deepEquals(keyNode, map.keys.first)) {
-    start = yaml.lastIndexOf('{', start - 1) + 1;
+    start = findPreviousFlowDelimiter(
+          yaml,
+          start - 1,
+          delimiters: {YamlChar.leftCurly},
+        ) +
+        1;
 
     if (deepEquals(keyNode, map.keys.last)) {
-      end = yaml.indexOf('}', end);
+      end = findNextFlowDelimiter(
+        yaml,
+        end,
+        delimiters: {YamlChar.rightCurly},
+      );
     } else {
-      end = yaml.indexOf(',', end) + 1;
+      end = findNextFlowDelimiter(
+            yaml,
+            end,
+            delimiters: {YamlChar.comma},
+          ) +
+          1;
     }
   } else {
-    start = yaml.lastIndexOf(',', start - 1);
+    start = findPreviousFlowDelimiter(
+      yaml,
+      start - 1,
+      delimiters: {YamlChar.comma},
+    );
   }
 
   return SourceEdit(start, end - start, '');

--- a/pkgs/yaml_edit/lib/src/utils.dart
+++ b/pkgs/yaml_edit/lib/src/utils.dart
@@ -596,17 +596,17 @@ int _findCommentStartOnLine(String yaml, int lineStart, int lineEnd) {
     final prev = i > lineStart ? yaml.codeUnitAt(i - 1) : YamlChar.space;
 
     if (inSingleQuote) {
-      if (c == 0x27 /* ' */) {
-        if (i + 1 < lineEnd && yaml.codeUnitAt(i + 1) == 0x27) {
+      if (c == YamlChar.singleQuote) {
+        if (i + 1 < lineEnd && yaml.codeUnitAt(i + 1) == YamlChar.singleQuote) {
           i++;
         } else {
           inSingleQuote = false;
         }
       }
     } else if (inDoubleQuote) {
-      if (c == 0x5C /* \ */) {
+      if (c == YamlChar.backslash) {
         i++;
-      } else if (c == 0x22 /* " */) {
+      } else if (c == YamlChar.doubleQuote) {
         inDoubleQuote = false;
       }
     } else {
@@ -615,9 +615,9 @@ int _findCommentStartOnLine(String yaml, int lineStart, int lineEnd) {
           YamlChar.isFlowIndicator(prev) ||
           prev == YamlChar.colon;
 
-      if (c == 0x27 /* ' */ && isQuoteStart) {
+      if (c == YamlChar.singleQuote && isQuoteStart) {
         inSingleQuote = true;
-      } else if (c == 0x22 /* " */ && isQuoteStart) {
+      } else if (c == YamlChar.doubleQuote && isQuoteStart) {
         inDoubleQuote = true;
       } else if (c == YamlChar.hash) {
         if (i == lineStart ||
@@ -653,8 +653,9 @@ int findNextFlowDelimiter(
     final prev = i > 0 ? yaml.codeUnitAt(i - 1) : YamlChar.space;
 
     if (inSingleQuote) {
-      if (code == 0x27 /* ' */) {
-        if (i + 1 < yaml.length && yaml.codeUnitAt(i + 1) == 0x27) {
+      if (code == YamlChar.singleQuote) {
+        if (i + 1 < yaml.length &&
+            yaml.codeUnitAt(i + 1) == YamlChar.singleQuote) {
           i++;
         } else {
           inSingleQuote = false;
@@ -662,10 +663,10 @@ int findNextFlowDelimiter(
       }
       i++;
     } else if (inDoubleQuote) {
-      if (code == 0x5C /* \ */) {
+      if (code == YamlChar.backslash) {
         i += 2;
         continue;
-      } else if (code == 0x22 /* " */) {
+      } else if (code == YamlChar.doubleQuote) {
         inDoubleQuote = false;
       }
       i++;
@@ -685,10 +686,10 @@ int findNextFlowDelimiter(
         } else {
           i++;
         }
-      } else if (code == 0x27 /* ' */ && isQuoteStart) {
+      } else if (code == YamlChar.singleQuote && isQuoteStart) {
         inSingleQuote = true;
         i++;
-      } else if (code == 0x22 /* " */ && isQuoteStart) {
+      } else if (code == YamlChar.doubleQuote && isQuoteStart) {
         inDoubleQuote = true;
         i++;
       } else if (delimiters.contains(code)) {

--- a/pkgs/yaml_edit/lib/src/utils.dart
+++ b/pkgs/yaml_edit/lib/src/utils.dart
@@ -7,6 +7,7 @@ import 'dart:math';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 
+import 'char_codes.dart';
 import 'editor.dart';
 import 'source_edit.dart';
 import 'wrap.dart';
@@ -585,6 +586,167 @@ extension YamlNodeExtension on YamlNode {
     if (me is YamlList) return me.style;
     return null;
   }
+}
+
+int _findCommentStartOnLine(String yaml, int lineStart, int lineEnd) {
+  var inSingleQuote = false;
+  var inDoubleQuote = false;
+  for (var i = lineStart; i < lineEnd; i++) {
+    final c = yaml.codeUnitAt(i);
+    final prev = i > lineStart ? yaml.codeUnitAt(i - 1) : YamlChar.space;
+
+    if (inSingleQuote) {
+      if (c == 0x27 /* ' */) {
+        if (i + 1 < lineEnd && yaml.codeUnitAt(i + 1) == 0x27) {
+          i++;
+        } else {
+          inSingleQuote = false;
+        }
+      }
+    } else if (inDoubleQuote) {
+      if (c == 0x5C /* \ */) {
+        i++;
+      } else if (c == 0x22 /* " */) {
+        inDoubleQuote = false;
+      }
+    } else {
+      final isQuoteStart = i == lineStart ||
+          YamlChar.isWhitespace(prev) ||
+          YamlChar.isFlowIndicator(prev) ||
+          prev == YamlChar.colon;
+
+      if (c == 0x27 /* ' */ && isQuoteStart) {
+        inSingleQuote = true;
+      } else if (c == 0x22 /* " */ && isQuoteStart) {
+        inDoubleQuote = true;
+      } else if (c == YamlChar.hash) {
+        if (i == lineStart ||
+            YamlChar.isWhitespace(prev) ||
+            YamlChar.isLineBreak(prev)) {
+          return i;
+        }
+      }
+    }
+  }
+  return -1;
+}
+
+/// Searches forward from [offset] in [yaml] to find the index of the next
+/// character matching any of the specified [delimiters], skipping `# ...`
+/// comments.
+///
+/// Returns `-1` if no matching delimiter is found, or if [yaml] is empty or
+/// [offset] is greater than or equal to `yaml.length`.
+///
+/// Runs in O(N) where N is the length of [yaml] from [offset].
+int findNextFlowDelimiter(
+  String yaml,
+  int offset, {
+  required Set<int> delimiters,
+}) {
+  if (yaml.isEmpty || offset >= yaml.length) return -1;
+  var inSingleQuote = false;
+  var inDoubleQuote = false;
+  var i = max(0, offset);
+  while (i < yaml.length) {
+    final code = yaml.codeUnitAt(i);
+    final prev = i > 0 ? yaml.codeUnitAt(i - 1) : YamlChar.space;
+
+    if (inSingleQuote) {
+      if (code == 0x27 /* ' */) {
+        if (i + 1 < yaml.length && yaml.codeUnitAt(i + 1) == 0x27) {
+          i++;
+        } else {
+          inSingleQuote = false;
+        }
+      }
+      i++;
+    } else if (inDoubleQuote) {
+      if (code == 0x5C /* \ */) {
+        i += 2;
+        continue;
+      } else if (code == 0x22 /* " */) {
+        inDoubleQuote = false;
+      }
+      i++;
+    } else {
+      final isQuoteStart = i == 0 ||
+          YamlChar.isWhitespace(prev) ||
+          YamlChar.isFlowIndicator(prev) ||
+          prev == YamlChar.colon;
+
+      if (code == YamlChar.hash) {
+        final isComment =
+            i == 0 || YamlChar.isWhitespace(prev) || YamlChar.isLineBreak(prev);
+        if (isComment) {
+          while (i < yaml.length && !YamlChar.isLineBreak(yaml.codeUnitAt(i))) {
+            i++;
+          }
+        } else {
+          i++;
+        }
+      } else if (code == 0x27 /* ' */ && isQuoteStart) {
+        inSingleQuote = true;
+        i++;
+      } else if (code == 0x22 /* " */ && isQuoteStart) {
+        inDoubleQuote = true;
+        i++;
+      } else if (delimiters.contains(code)) {
+        return i;
+      } else {
+        i++;
+      }
+    }
+  }
+  return -1;
+}
+
+/// Searches backward from [offset] in [yaml] to find the index of the previous
+/// character matching any of the specified [delimiters], skipping `# ...`
+/// comments.
+///
+/// Returns `-1` if no matching delimiter is found, or if [yaml] is empty or
+/// [offset] is less than `0`.
+///
+/// Runs in O(N) where N is the length of [yaml] up to [offset].
+int findPreviousFlowDelimiter(
+  String yaml,
+  int offset, {
+  required Set<int> delimiters,
+}) {
+  if (yaml.isEmpty || offset < 0) return -1;
+  var i = min(offset, yaml.length - 1);
+  while (i >= 0) {
+    final prevLf = i > 0 ? yaml.lastIndexOf('\n', i - 1) : -1;
+    final prevCr = i > 0 ? yaml.lastIndexOf('\r', i - 1) : -1;
+    final lineStart = max(prevLf, prevCr) + 1;
+
+    final nextLf = yaml.indexOf('\n', lineStart);
+    final nextCr = yaml.indexOf('\r', lineStart);
+    final int lineEnd;
+    if (nextLf == -1 && nextCr == -1) {
+      lineEnd = yaml.length;
+    } else if (nextLf == -1) {
+      lineEnd = nextCr;
+    } else if (nextCr == -1) {
+      lineEnd = nextLf;
+    } else {
+      lineEnd = min(nextLf, nextCr);
+    }
+
+    final commentStart = _findCommentStartOnLine(yaml, lineStart, lineEnd);
+    if (commentStart != -1 && i >= commentStart) {
+      i = commentStart - 1;
+    }
+
+    while (i >= lineStart) {
+      if (delimiters.contains(yaml.codeUnitAt(i))) {
+        return i;
+      }
+      i--;
+    }
+  }
+  return -1;
 }
 
 /// Checks if [between] contains a comma that is not part of a comment.

--- a/pkgs/yaml_edit/test/insert_test.dart
+++ b/pkgs/yaml_edit/test/insert_test.dart
@@ -203,5 +203,13 @@ a:
       expect(doc.toString(), equals('["[],", test, "[],"]'));
       expectYamlBuilderValue(doc, ['[],', 'test', '[],']);
     });
+
+    test('insert with comment containing comma and brackets', () {
+      final doc = YamlEditor('[1, # comment with , and [ and ]\n 2]');
+      doc.insertIntoList([], 1, 'inserted');
+      expect(doc.parseAt([0]).value, equals(1));
+      expect(doc.parseAt([1]).value, equals('inserted'));
+      expect(doc.parseAt([2]).value, equals(2));
+    });
   });
 }

--- a/pkgs/yaml_edit/test/remove_test.dart
+++ b/pkgs/yaml_edit/test/remove_test.dart
@@ -311,6 +311,25 @@ next: value
       ]);
       expect(doc.toString(), equals('{a: { b: 2}}'));
     });
+
+    test('remove first entry with comment containing comma and brace', () {
+      final doc1 = YamlEditor('{a: 1 # comment with , and }\n, b: 2}');
+      doc1.remove(['a']);
+      expect(doc1.parseAt(['b']).value, equals(2));
+    });
+
+    test('remove non-first entry with comment preceding it', () {
+      final doc2 = YamlEditor('{b: 2, # comment with , and }\n a: 1}');
+      doc2.remove(['a']);
+      expect(doc2.parseAt(['b']).value, equals(2));
+    });
+
+    test('remove single entry with comment', () {
+      final doc3 = YamlEditor('{a: 1 # comment with }\n}');
+      doc3.remove(['a']);
+      expect(doc3.toString(), equals('{}'));
+      expect(doc3.parseAt([]).value, equals({}));
+    });
   });
 
   group('block list', () {
@@ -675,6 +694,25 @@ b:
       final doc = YamlEditor('["{}[],", [test, "{}[],", "{}[],"], "{}[],"]');
       doc.remove([1, 0]);
       expect(doc.toString(), equals('["{}[],", [ "{}[],", "{}[],"], "{}[],"]'));
+    });
+
+    test('remove first element with comment containing comma and bracket', () {
+      final doc1 = YamlEditor('[1 # comment with , and ]\n, 2]');
+      doc1.remove([0]);
+      expect(doc1.parseAt([0]).value, equals(2));
+    });
+
+    test('remove last element with comment containing comma and bracket', () {
+      final doc2 = YamlEditor('[1, # comment with , and ]\n 2]');
+      doc2.remove([1]);
+      expect(doc2.parseAt([0]).value, equals(1));
+    });
+
+    test('remove single element with comment', () {
+      final doc3 = YamlEditor('[ 1 # comment with ]\n]');
+      doc3.remove([0]);
+      expect(doc3.toString(), equals('[]'));
+      expect(doc3.parseAt([]).value, equals([]));
     });
   });
 }

--- a/pkgs/yaml_edit/test/update_test.dart
+++ b/pkgs/yaml_edit/test/update_test.dart
@@ -816,6 +816,25 @@ analyzer:
         expect(doc.toString(), equals('{a: 1, b: 2, c: 3,}'));
         expectYamlBuilderValue(doc, {'a': 1, 'b': 2, 'c': 3});
       });
+
+      test('updating explicit key without colon succeeds', () {
+        final doc = YamlEditor('{? key}');
+        doc.update(['key'], 'value');
+        expect(doc.toString(), equals('{? key: value}'));
+        expectYamlBuilderValue(doc, {'key': 'value'});
+
+        final doc2 = YamlEditor('{? key, foo: bar}');
+        doc2.update(['key'], 'value');
+        expect(doc2.toString(), equals('{? key: value, foo: bar}'));
+        expectYamlBuilderValue(doc2, {'key': 'value', 'foo': 'bar'});
+      });
+
+      test('updating explicit key with colon succeeds', () {
+        final doc = YamlEditor('{? key: old}');
+        doc.update(['key'], 'new');
+        expect(doc.toString(), equals('{? key: new}'));
+        expectYamlBuilderValue(doc, {'key': 'new'});
+      });
     });
 
     group('block map', () {
@@ -1104,6 +1123,47 @@ d: 4
         );
         expectYamlBuilderValue(doc, []);
       });
+    });
+  });
+
+  group('flow collections with comments or empty values', () {
+    test('update flow list with comment containing comma and bracket', () {
+      final doc = YamlEditor('[1 # comment with , and ]\n, 2]');
+      doc.update([0], 'updated');
+      expect(doc.parseAt([0]).value, equals('updated'));
+      expect(doc.parseAt([1]).value, equals(2));
+    });
+
+    test('flow map update with comment containing comma and braces', () {
+      final doc = YamlEditor('{a: 1 # comment with , and { and }\n, b: 2}');
+      doc.update(['a'], 99);
+      expect(doc.parseAt(['a']).value, equals(99));
+      expect(doc.parseAt(['b']).value, equals(2));
+
+      doc.update(['b'], 88);
+      expect(doc.parseAt(['b']).value, equals(88));
+    });
+
+    test('flow map insert with comment containing delimiters', () {
+      final doc = YamlEditor('{a: 1 # comment with , and }\n, b: 2}');
+      doc.update(['c'], 3);
+      expect(doc.parseAt(['a']).value, equals(1));
+      expect(doc.parseAt(['b']).value, equals(2));
+      expect(doc.parseAt(['c']).value, equals(3));
+    });
+
+    test('flow map update empty value without space after colon', () {
+      final doc = YamlEditor('{a:}');
+      doc.update(['a'], 'hello');
+      expect(doc.toString(), equals('{a: hello}'));
+      expect(doc.parseAt(['a']).value, equals('hello'));
+    });
+
+    test('flow map update empty value with comment', () {
+      final doc = YamlEditor('{a: # comment\n, b: 1}');
+      doc.update(['a'], 'hello');
+      expect(doc.parseAt(['a']).value, equals('hello'));
+      expect(doc.parseAt(['b']).value, equals(1));
     });
   });
 }

--- a/pkgs/yaml_edit/test/utils_test.dart
+++ b/pkgs/yaml_edit/test/utils_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/src/char_codes.dart';
 import 'package:yaml_edit/src/utils.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
@@ -622,6 +623,224 @@ a:
           ),
         ),
       );
+    });
+  });
+
+  group('YamlChar constants and predicates', () {
+    test('constants have correct ASCII code units', () {
+      expect(YamlChar.tab, equals(0x09));
+      expect(YamlChar.lineFeed, equals(0x0A));
+      expect(YamlChar.carriageReturn, equals(0x0D));
+      expect(YamlChar.space, equals(0x20));
+      expect(YamlChar.hash, equals(0x23));
+      expect(YamlChar.asterisk, equals(0x2A));
+      expect(YamlChar.comma, equals(0x2C));
+      expect(YamlChar.hyphen, equals(0x2D));
+      expect(YamlChar.colon, equals(0x3A));
+      expect(YamlChar.question, equals(0x3F));
+      expect(YamlChar.leftSquare, equals(0x5B));
+      expect(YamlChar.rightSquare, equals(0x5D));
+      expect(YamlChar.leftCurly, equals(0x7B));
+      expect(YamlChar.rightCurly, equals(0x7D));
+    });
+
+    test('isWhitespace', () {
+      expect(YamlChar.isWhitespace(0x20), isTrue);
+      expect(YamlChar.isWhitespace(0x09), isTrue);
+      expect(YamlChar.isWhitespace(0x0A), isFalse);
+      expect(YamlChar.isWhitespace(0x0D), isFalse);
+      expect(YamlChar.isWhitespace(0x61), isFalse); // 'a'
+      expect(YamlChar.isWhitespace(-1), isFalse);
+    });
+
+    test('isLineBreak', () {
+      expect(YamlChar.isLineBreak(0x0A), isTrue);
+      expect(YamlChar.isLineBreak(0x0D), isTrue);
+      expect(YamlChar.isLineBreak(0x20), isFalse);
+      expect(YamlChar.isLineBreak(0x09), isFalse);
+      expect(YamlChar.isLineBreak(0x61), isFalse);
+      expect(YamlChar.isLineBreak(-1), isFalse);
+    });
+
+    test('isFlowIndicator', () {
+      expect(YamlChar.isFlowIndicator(0x2C), isTrue); // ','
+      expect(YamlChar.isFlowIndicator(0x5B), isTrue); // '['
+      expect(YamlChar.isFlowIndicator(0x5D), isTrue); // ']'
+      expect(YamlChar.isFlowIndicator(0x7B), isTrue); // '{'
+      expect(YamlChar.isFlowIndicator(0x7D), isTrue); // '}'
+      expect(YamlChar.isFlowIndicator(0x20), isFalse);
+      expect(YamlChar.isFlowIndicator(0x3A), isFalse); // ':'
+      expect(YamlChar.isFlowIndicator(0x2D), isFalse); // '-'
+      expect(YamlChar.isFlowIndicator(-1), isFalse);
+    });
+
+    test('isAnchorChar', () {
+      // Valid anchor chars
+      expect(YamlChar.isAnchorChar(0x61), isTrue); // 'a'
+      expect(YamlChar.isAnchorChar(0x30), isTrue); // '0'
+      expect(YamlChar.isAnchorChar(0x2E), isTrue); // '.'
+      expect(YamlChar.isAnchorChar(0x2F), isTrue); // '/'
+      expect(YamlChar.isAnchorChar(0x40), isTrue); // '@'
+      expect(YamlChar.isAnchorChar(0x2B), isTrue); // '+'
+      expect(YamlChar.isAnchorChar(0x5F), isTrue); // '_'
+      expect(YamlChar.isAnchorChar(0x2D), isTrue); // '-'
+
+      // Invalid anchor chars: whitespace, line breaks, flow indicators
+      expect(YamlChar.isAnchorChar(0x20), isFalse); // space
+      expect(YamlChar.isAnchorChar(0x09), isFalse); // tab
+      expect(YamlChar.isAnchorChar(0x0A), isFalse); // LF
+      expect(YamlChar.isAnchorChar(0x0D), isFalse); // CR
+      expect(YamlChar.isAnchorChar(0x2C), isFalse); // ','
+      expect(YamlChar.isAnchorChar(0x5B), isFalse); // '['
+      expect(YamlChar.isAnchorChar(0x5D), isFalse); // ']'
+      expect(YamlChar.isAnchorChar(0x7B), isFalse); // '{'
+      expect(YamlChar.isAnchorChar(0x7D), isFalse); // '}'
+    });
+  });
+
+  group('findNextFlowDelimiter and findPreviousFlowDelimiter', () {
+    test('returns -1 on empty yaml or out-of-bounds offsets', () {
+      expect(
+        findNextFlowDelimiter('', 0, delimiters: {YamlChar.comma}),
+        equals(-1),
+      );
+      expect(
+        findNextFlowDelimiter('abc', 5, delimiters: {YamlChar.comma}),
+        equals(-1),
+      );
+      expect(
+        findNextFlowDelimiter('abc', -2, delimiters: {YamlChar.comma}),
+        equals(-1),
+      );
+
+      expect(
+        findPreviousFlowDelimiter('', 0, delimiters: {YamlChar.comma}),
+        equals(-1),
+      );
+      expect(
+        findPreviousFlowDelimiter('abc', -1, delimiters: {YamlChar.comma}),
+        equals(-1),
+      );
+      expect(
+        findPreviousFlowDelimiter('a,b', 10, delimiters: {YamlChar.comma}),
+        equals(1),
+      );
+    });
+
+    test('findNextFlowDelimiter finds delimiter without comments', () {
+      final yaml = '[1, 2, 3]';
+      expect(
+        findNextFlowDelimiter(yaml, 0, delimiters: {YamlChar.comma}),
+        equals(2),
+      );
+      expect(
+        findNextFlowDelimiter(yaml, 3, delimiters: {YamlChar.comma}),
+        equals(5),
+      );
+      expect(
+        findNextFlowDelimiter(yaml, 6, delimiters: {YamlChar.rightSquare}),
+        equals(8),
+      );
+      expect(
+        findNextFlowDelimiter(yaml, 6, delimiters: {YamlChar.colon}),
+        equals(-1),
+      );
+    });
+
+    test('findNextFlowDelimiter skips comments containing delimiters', () {
+      final yaml = '[1, # comment with , and ] and }\n 2]';
+      expect(
+        findNextFlowDelimiter(yaml, 3, delimiters: {YamlChar.comma}),
+        equals(-1),
+      );
+      expect(
+        findNextFlowDelimiter(yaml, 3, delimiters: {YamlChar.rightSquare}),
+        equals(35),
+      );
+    });
+
+    test('findPreviousFlowDelimiter finds delimiter without comments', () {
+      final yaml = '{a: 1, b: 2}';
+      expect(
+        findPreviousFlowDelimiter(yaml, 10, delimiters: {YamlChar.comma}),
+        equals(5),
+      );
+      expect(
+        findPreviousFlowDelimiter(yaml, 4, delimiters: {YamlChar.leftCurly}),
+        equals(0),
+      );
+      expect(
+        findPreviousFlowDelimiter(yaml, 4, delimiters: {YamlChar.rightCurly}),
+        equals(-1),
+      );
+    });
+
+    test('findPreviousFlowDelimiter skips comments containing delimiters', () {
+      final yaml = '{\n  a: 1, # comment with , and { and }\n  b: 2\n}';
+      final bOffset = yaml.indexOf('b:');
+      final found = findPreviousFlowDelimiter(
+        yaml,
+        bOffset,
+        delimiters: {YamlChar.comma},
+      );
+      expect(found, equals(yaml.indexOf(',')));
+    });
+
+    test('findPreviousFlowDelimiter with multiple comment lines', () {
+      final yaml = '[\n'
+          '  1,\n'
+          '  # comment line 1 with ,\n'
+          '  # comment line 2 with ,\n'
+          '  2\n'
+          ']';
+      final twoOffset = yaml.indexOf('2');
+      final found = findPreviousFlowDelimiter(
+        yaml,
+        twoOffset,
+        delimiters: {YamlChar.comma},
+      );
+      expect(found, equals(yaml.indexOf(',')));
+    });
+
+    test('findPreviousFlowDelimiter with CR and CRLF line endings', () {
+      final yamlCr = '[\r  1,\r  # comment with ,\r  2\r]';
+      final twoCr = yamlCr.indexOf('2');
+      expect(
+        findPreviousFlowDelimiter(yamlCr, twoCr, delimiters: {YamlChar.comma}),
+        equals(yamlCr.indexOf(',')),
+      );
+
+      final yamlCrlf = '[\r\n  1,\r\n  # comment with ,\r\n  2\r\n]';
+      final twoCrlf = yamlCrlf.indexOf('2');
+      expect(
+        findPreviousFlowDelimiter(
+          yamlCrlf,
+          twoCrlf,
+          delimiters: {YamlChar.comma},
+        ),
+        equals(yamlCrlf.indexOf(',')),
+      );
+    });
+
+    test('findPreviousFlowDelimiter when search starts inside comment', () {
+      final yaml = '[ 1, # inside comment with , here ]';
+      final insideComment = yaml.indexOf('here');
+      final found = findPreviousFlowDelimiter(
+        yaml,
+        insideComment,
+        delimiters: {YamlChar.comma},
+      );
+      expect(found, equals(yaml.indexOf(',')));
+    });
+
+    test('findPreviousFlowDelimiter when comment is at start of line', () {
+      final yaml = '1,\n# comment with ,\n2';
+      final found = findPreviousFlowDelimiter(
+        yaml,
+        yaml.indexOf('2'),
+        delimiters: {YamlChar.comma},
+      );
+      expect(found, equals(yaml.indexOf(',')));
     });
   });
 }


### PR DESCRIPTION
This PR adds comment-aware flow delimiter scanning and fixes updating empty values in flow maps in `package:yaml_edit`.

### Changes

- Add `YamlChar` constants and helper predicates in `lib/src/char_codes.dart`.
- Add `findNextFlowDelimiter` and `findPreviousFlowDelimiter` in `lib/src/utils.dart` that skip `# ...` comments when searching for flow delimiters (`,`, `]`, `}`).
- Use comment-aware delimiter searching in flow list insertions (`_insertInFlowList`), flow list removals (`_removeFromFlowList`), and flow map removals (`_removeFromFlowMap`).
- In `_replaceInFlowMap`, handle empty flow map values (`{a:}`) without leaving syntax errors when replacing with a value.
- Add unit tests in `test/insert_test.dart`, `test/remove_test.dart`, `test/update_test.dart`, and `test/utils_test.dart`.
