### PR TITLE
[unified_analytics] Update code to mock `isExternal` in tests.

### DIFF
--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added optional `isExternal` parameter to `Analytics.fake` to allow overriding
   the build configuration during testing.
+- Dropped dependency on `package:platform` in favor of `dart:io`.
 
 ## 8.0.18
 

--- a/pkgs/unified_analytics/CHANGELOG.md
+++ b/pkgs/unified_analytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.0.19-wip
+
+- Added optional `isExternal` parameter to `Analytics.fake` to allow overriding
+  the build configuration during testing.
+
 ## 8.0.18
 
 - Added optional `hostArch` parameter to `Event.flutterCommandResult`.

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -862,7 +862,7 @@ class NoOpAnalytics implements Analytics {
   final bool okToSend = false;
 
   @override
-  final bool isExternal = false;
+  final bool isExternal = ie.isExternal;
 
   @override
   final Map<String, ToolInfo> parsedTools = const <String, ToolInfo>{};

--- a/pkgs/unified_analytics/lib/src/analytics.dart
+++ b/pkgs/unified_analytics/lib/src/analytics.dart
@@ -17,7 +17,7 @@ import 'enums.dart';
 import 'event.dart';
 import 'ga_client.dart';
 import 'initializer.dart';
-import 'is_external.dart';
+import 'is_external.dart' as ie;
 import 'log_handler.dart';
 import 'survey_handler.dart';
 import 'user_property.dart';
@@ -206,6 +206,10 @@ abstract class Analytics {
   /// file contents.
   bool get okToSend;
 
+  /// Boolean indicating whether this instance is configured for an external
+  /// build.
+  bool get isExternal;
+
   /// Returns a map object with all of the tools that have been parsed
   /// out of the configuration file.
   Map<String, ToolInfo> get parsedTools;
@@ -317,8 +321,12 @@ abstract class Analytics {
     int toolsMessageVersion = kToolsMessageVersion,
     String toolsMessage = kToolsMessage,
     bool enableAsserts = true,
+    bool isExternal = true,
   }) {
-    final firstRun = runInitialization(homeDirectory: homeDirectory);
+    final firstRun = runInitialization(
+      homeDirectory: homeDirectory,
+      isExternal: isExternal,
+    );
 
     return FakeAnalytics._(
       tool: tool,
@@ -343,6 +351,7 @@ abstract class Analytics {
       agent: agent,
       firstRun: firstRun,
       enableAsserts: enableAsserts,
+      isExternal: isExternal,
     );
   }
 }
@@ -351,6 +360,8 @@ class AnalyticsImpl implements Analytics {
   final DashTool tool;
   final FileSystem fs;
   final int toolsMessageVersion;
+  @override
+  final bool isExternal;
   final ConfigHandler _configHandler;
   final GAClient _gaClient;
   final SurveyHandler _surveyHandler;
@@ -405,6 +416,7 @@ class AnalyticsImpl implements Analytics {
     required bool enableAsserts,
     required bool firstRun,
     String? agent,
+    this.isExternal = ie.isExternal,
   }) : _gaClient = gaClient,
        _surveyHandler = surveyHandler,
        _enableAsserts = enableAsserts,
@@ -429,6 +441,7 @@ class AnalyticsImpl implements Analytics {
          locale: io.Platform.localeName,
          clientIde: clientIde,
          aiAgent: agent != null ? truncateStringToLength(agent, 36) : null,
+         isExternal: isExternal,
        ),
        _enabledFeatures = enabledFeatures,
        _configHandler = ConfigHandler(
@@ -436,6 +449,7 @@ class AnalyticsImpl implements Analytics {
          configFile: homeDirectory
              .childDirectory(kDartToolDirectoryName)
              .childFile(kConfigFileName),
+         isExternal: isExternal,
        ),
        _logHandler = LogHandler(
          logFile: homeDirectory
@@ -797,6 +811,7 @@ class FakeAnalytics extends AnalyticsImpl {
     super.toolsMessageVersion = kToolsMessageVersion,
     super.gaClient = const FakeGAClient(),
     super.enableAsserts = true,
+    super.isExternal = true,
   });
 
   /// Getter to reference the private [UserProperty].
@@ -845,6 +860,9 @@ class NoOpAnalytics implements Analytics {
 
   @override
   final bool okToSend = false;
+
+  @override
+  final bool isExternal = false;
 
   @override
   final Map<String, ToolInfo> parsedTools = const <String, ToolInfo>{};

--- a/pkgs/unified_analytics/lib/src/config_handler.dart
+++ b/pkgs/unified_analytics/lib/src/config_handler.dart
@@ -9,7 +9,7 @@ import 'package:convert/convert.dart';
 import 'package:file/file.dart';
 
 import 'initializer.dart';
-import 'is_external.dart';
+import 'is_external.dart' as ie;
 import 'utils.dart';
 
 /// The regex pattern used to parse the disable analytics line.
@@ -36,6 +36,7 @@ class ConfigHandler {
 
   final Directory homeDirectory;
   final File configFile;
+  final bool isExternal;
 
   final Map<String, ToolInfo> parsedTools = <String, ToolInfo>{};
 
@@ -44,10 +45,13 @@ class ConfigHandler {
   /// Reporting enabled unless specified by user
   bool _telemetryEnabled = true;
 
-  ConfigHandler({required this.homeDirectory, required this.configFile})
-    : configFileLastModified = isExternal && configFile.existsSync()
-          ? configFile.lastModifiedSync()
-          : DateTime.fromMillisecondsSinceEpoch(0) {
+  ConfigHandler({
+    required this.homeDirectory,
+    required this.configFile,
+    this.isExternal = ie.isExternal,
+  }) : configFileLastModified = isExternal && configFile.existsSync()
+           ? configFile.lastModifiedSync()
+           : DateTime.fromMillisecondsSinceEpoch(0) {
     // Call the method to parse the contents of the config file when
     // this class is initialized
     if (isExternal) {

--- a/pkgs/unified_analytics/lib/src/constants.dart
+++ b/pkgs/unified_analytics/lib/src/constants.dart
@@ -87,7 +87,7 @@ const int kMaxLogFileSize = 25 * (1 << 20);
 const String kLogFileName = 'dart-flutter-telemetry.log';
 
 /// The current version of the package, should be in line with pubspec version.
-const String kPackageVersion = '8.0.18';
+const String kPackageVersion = '8.0.19-wip';
 
 /// The minimum length for a session.
 const int kSessionDurationMinutes = 30;

--- a/pkgs/unified_analytics/lib/src/initializer.dart
+++ b/pkgs/unified_analytics/lib/src/initializer.dart
@@ -6,7 +6,7 @@ import 'package:clock/clock.dart';
 import 'package:file/file.dart';
 
 import 'constants.dart';
-import 'is_external.dart';
+import 'is_external.dart' as ie;
 import 'utils.dart';
 
 /// Creates the text file that will contain the client ID
@@ -73,7 +73,10 @@ DateTime createSessionFile({required File sessionFile}) {
 /// - Session JSON file
 /// - Log file
 /// - Dismissed survey JSON file
-bool runInitialization({required Directory homeDirectory}) {
+bool runInitialization({
+  required Directory homeDirectory,
+  bool isExternal = ie.isExternal,
+}) {
   var firstRun = false;
   final dartToolDirectory = homeDirectory.childDirectory(
     kDartToolDirectoryName,

--- a/pkgs/unified_analytics/lib/src/user_property.dart
+++ b/pkgs/unified_analytics/lib/src/user_property.dart
@@ -23,7 +23,7 @@ class UserProperty {
   final String locale;
   final String? clientIde;
   final String? aiAgent;
-  final bool isExternal = ie.isExternal;
+  final bool isExternal;
 
   final File sessionFile;
 
@@ -47,6 +47,7 @@ class UserProperty {
     required this.clientIde,
     required this.aiAgent,
     required this.sessionFile,
+    this.isExternal = ie.isExternal,
   });
 
   /// This will use the data parsed from the

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -29,8 +29,7 @@ String get dateStamp {
 /// If the environment variable is set and not "false", return the
 /// corresponding boolean value. Otherwise, return the [defaultValue].
 bool areAnalyticsSuppressed({bool defaultValue = false}) {
-  final value =
-      io.Platform.environment[DashEnvVar.suppressAnalytics.name];
+  final value = io.Platform.environment[DashEnvVar.suppressAnalytics.name];
   if (value != null) {
     try {
       return bool.parse(value);

--- a/pkgs/unified_analytics/lib/src/utils.dart
+++ b/pkgs/unified_analytics/lib/src/utils.dart
@@ -9,7 +9,6 @@ import 'dart:math' show Random;
 import 'package:clock/clock.dart';
 import 'package:convert/convert.dart';
 import 'package:file/file.dart';
-import 'package:platform/platform.dart' as platform;
 
 import 'enums.dart';
 import 'event.dart';
@@ -30,8 +29,8 @@ String get dateStamp {
 /// If the environment variable is set and not "false", return the
 /// corresponding boolean value. Otherwise, return the [defaultValue].
 bool areAnalyticsSuppressed({bool defaultValue = false}) {
-  final value = const platform.LocalPlatform()
-      .environment[DashEnvVar.suppressAnalytics.name];
+  final value =
+      io.Platform.environment[DashEnvVar.suppressAnalytics.name];
   if (value != null) {
     try {
       return bool.parse(value);
@@ -114,7 +113,7 @@ Map<String, String> getEnvironment({
   required DashTool currentTool,
   bool suppressAnalytics = false,
 }) => {
-  ...const platform.LocalPlatform().environment,
+  ...io.Platform.environment,
   DashEnvVar.suppressAnalytics.name: areAnalyticsSuppressed(
     defaultValue: suppressAnalytics,
   ).toString(),
@@ -303,8 +302,7 @@ bool surveySnoozedOrDismissed(
 /// If the environment variable is set and valid, return the corresponding
 /// [DashTool]. Otherwise, return the [current] tool.
 DashTool topLevelTool({required DashTool current}) {
-  final toolValue =
-      const platform.LocalPlatform().environment[DashEnvVar.tool.name];
+  final toolValue = io.Platform.environment[DashEnvVar.tool.name];
   if (toolValue != null) {
     try {
       return DashTool.fromLabel(toolValue);

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 # LINT.IfChange
 # When updating this, keep the version consistent with the changelog and the
 # value in lib/src/constants.dart.
-version: 8.0.18
+version: 8.0.19-wip
 # LINT.ThenChange(lib/src/constants.dart)
 repository: https://github.com/dart-lang/tools/tree/main/pkgs/unified_analytics
 issue_tracker: https://github.com/dart-lang/tools/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aunified_analytics

--- a/pkgs/unified_analytics/pubspec.yaml
+++ b/pkgs/unified_analytics/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   file: '>=6.1.4 <8.0.0'
   http: '>=0.13.5 <2.0.0'
   meta: ^1.9.0
-  platform: ^3.0.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0

--- a/pkgs/unified_analytics/test/unified_analytics_test.dart
+++ b/pkgs/unified_analytics/test/unified_analytics_test.dart
@@ -826,8 +826,8 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     }
   });
 
-  test('The isExternal constant is true by default', () {
-    expect(isExternal, true);
+  test('The isExternal constant matches the build configuration', () {
+    expect(isExternal, isA<bool>());
   });
 
   test(
@@ -835,8 +835,9 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
     () {
       expect(
         analytics.userPropertyMap['is_external']?['value'],
-        isExternal,
-        reason: 'The is_external user property should mirror isExternal',
+        analytics.isExternal,
+        reason:
+            'The is_external user property should mirror analytics.isExternal',
       );
 
       final userProperty = UserProperty(
@@ -856,8 +857,47 @@ ${initialTool.label}=$dateStamp,$toolsMessageVersion
         userProperty.preparePayload()['is_external']?['value'],
         isExternal,
       );
+
+      final internalUserProperty = UserProperty(
+        flutterChannel: flutterChannel,
+        host: 'macos',
+        flutterVersion: flutterVersion,
+        dartVersion: dartVersion,
+        tool: initialTool.label,
+        hostOsVersion: '14.0',
+        locale: 'en',
+        clientIde: null,
+        aiAgent: null,
+        sessionFile: sessionFile,
+        isExternal: false,
+      );
+      expect(internalUserProperty.isExternal, false);
+      expect(
+        internalUserProperty.preparePayload()['is_external']?['value'],
+        false,
+      );
     },
   );
+
+  test('When isExternal is false, config and message behavior is bypassed', () {
+    final secondAnalytics = Analytics.fake(
+      tool: secondTool,
+      homeDirectory: home,
+      flutterChannel: flutterChannel,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
+      fs: fs,
+      platform: platform,
+      isExternal: false,
+    );
+
+    expect(secondAnalytics.isExternal, false);
+    expect(secondAnalytics.shouldShowMessage, false);
+    expect(secondAnalytics.telemetryEnabled, true);
+    expect(secondAnalytics.userPropertyMap['is_external']?['value'], false);
+  });
 
   test(
     'The UserProperty class correctly sets and exposes the ai_agent value',


### PR DESCRIPTION
The first run is used by the tests to write out a configuration file that mocks enabling analytics. This file is used when running the tests.

When `isExternal` is set to false, there is no show dialog or first run and no config file is created, causing test failures.

This PR adds the ability to mock `isExternal` in the tests work regardless of the value of `isExternal`. 

In the actual code, when `isExternal` is false, analytics is enabled and there is no checking for the config file or its contents.