### PR TITLE
[yaml] Add optional layout retention for comments, whitespace, and delimiter spans

### DIFF
--- a/pkgs/yaml/lib/src/event.dart
+++ b/pkgs/yaml/lib/src/event.dart
@@ -42,11 +42,15 @@ class DocumentStartEvent extends Event {
   /// `===` sequence).
   final bool isImplicit;
 
+  /// The source span of the `---` start marker, if explicit.
+  final FileSpan? startMarkerSpan;
+
   DocumentStartEvent(
     FileSpan span, {
     this.versionDirective,
     List<TagDirective>? tagDirectives,
     this.isImplicit = true,
+    this.startMarkerSpan,
     super.leadingLayout,
     super.trailingLayout,
   })  : tagDirectives = tagDirectives ?? [],
@@ -62,9 +66,13 @@ class DocumentEndEvent extends Event {
   /// `...` sequence).
   final bool isImplicit;
 
+  /// The source span of the `...` end marker, if explicit.
+  final FileSpan? endMarkerSpan;
+
   DocumentEndEvent(
     FileSpan span, {
     this.isImplicit = true,
+    this.endMarkerSpan,
     super.leadingLayout,
     super.trailingLayout,
   }) : super(EventType.documentEnd, span);
@@ -94,6 +102,9 @@ abstract class _ValueEvent extends Event {
   /// The name of the value's anchor, or `null` if it wasn't anchored.
   final String? anchor;
 
+  /// The source span of the value's anchor definition (`&anchor`), or `null`.
+  final FileSpan? anchorSpan;
+
   /// The text of the value's tag, or `null` if it wasn't tagged.
   final String? tag;
 
@@ -101,6 +112,7 @@ abstract class _ValueEvent extends Event {
     super.type,
     super.span, {
     this.anchor,
+    this.anchorSpan,
     this.tag,
     super.leadingLayout,
     super.trailingLayout,
@@ -128,6 +140,7 @@ class ScalarEvent extends _ValueEvent {
     this.value,
     this.style, {
     super.anchor,
+    super.anchorSpan,
     super.tag,
     super.leadingLayout,
     super.trailingLayout,
@@ -142,11 +155,16 @@ class SequenceStartEvent extends _ValueEvent {
   /// The style of the collection in the original source.
   final CollectionStyle style;
 
+  /// The source span of the opening bracket (`[`), or `null` if block style.
+  final FileSpan? openSpan;
+
   SequenceStartEvent(
     FileSpan span,
     this.style, {
     super.anchor,
+    super.anchorSpan,
     super.tag,
+    this.openSpan,
     super.leadingLayout,
     super.trailingLayout,
   }) : super(EventType.sequenceStart, span);
@@ -157,11 +175,16 @@ class MappingStartEvent extends _ValueEvent {
   /// The style of the collection in the original source.
   final CollectionStyle style;
 
+  /// The source span of the opening brace (`{`), or `null` if block style.
+  final FileSpan? openSpan;
+
   MappingStartEvent(
     FileSpan span,
     this.style, {
     super.anchor,
+    super.anchorSpan,
     super.tag,
+    this.openSpan,
     super.leadingLayout,
     super.trailingLayout,
   }) : super(EventType.mappingStart, span);

--- a/pkgs/yaml/lib/src/event.dart
+++ b/pkgs/yaml/lib/src/event.dart
@@ -7,6 +7,7 @@
 
 import 'package:source_span/source_span.dart';
 
+import 'layout.dart';
 import 'parser.dart';
 import 'style.dart';
 import 'yaml_document.dart';
@@ -15,20 +16,22 @@ import 'yaml_document.dart';
 class Event {
   final EventType type;
   final FileSpan span;
+  final List<LayoutElement> leadingLayout;
+  final List<LayoutElement> trailingLayout;
 
-  Event(this.type, this.span);
+  Event(
+    this.type,
+    this.span, {
+    this.leadingLayout = const [],
+    this.trailingLayout = const [],
+  });
 
   @override
   String toString() => type.toString();
 }
 
 /// An event indicating the beginning of a YAML document.
-class DocumentStartEvent implements Event {
-  @override
-  EventType get type => EventType.documentStart;
-  @override
-  final FileSpan span;
-
+class DocumentStartEvent extends Event {
   /// The document's `%YAML` directive, or `null` if there was none.
   final VersionDirective? versionDirective;
 
@@ -39,56 +42,69 @@ class DocumentStartEvent implements Event {
   /// `===` sequence).
   final bool isImplicit;
 
-  DocumentStartEvent(this.span,
-      {this.versionDirective,
-      List<TagDirective>? tagDirectives,
-      this.isImplicit = true})
-      : tagDirectives = tagDirectives ?? [];
+  DocumentStartEvent(
+    FileSpan span, {
+    this.versionDirective,
+    List<TagDirective>? tagDirectives,
+    this.isImplicit = true,
+    super.leadingLayout,
+    super.trailingLayout,
+  })  : tagDirectives = tagDirectives ?? [],
+        super(EventType.documentStart, span);
 
   @override
   String toString() => 'DOCUMENT_START';
 }
 
 /// An event indicating the end of a YAML document.
-class DocumentEndEvent implements Event {
-  @override
-  EventType get type => EventType.documentEnd;
-  @override
-  final FileSpan span;
-
+class DocumentEndEvent extends Event {
   /// Whether the document ended implicitly (that is, without an explicit
   /// `...` sequence).
   final bool isImplicit;
 
-  DocumentEndEvent(this.span, {this.isImplicit = true});
+  DocumentEndEvent(
+    FileSpan span, {
+    this.isImplicit = true,
+    super.leadingLayout,
+    super.trailingLayout,
+  }) : super(EventType.documentEnd, span);
 
   @override
   String toString() => 'DOCUMENT_END';
 }
 
 /// An event indicating that an alias was referenced.
-class AliasEvent implements Event {
-  @override
-  EventType get type => EventType.alias;
-  @override
-  final FileSpan span;
-
+class AliasEvent extends Event {
   /// The alias name.
   final String name;
 
-  AliasEvent(this.span, this.name);
+  AliasEvent(
+    FileSpan span,
+    this.name, {
+    super.leadingLayout,
+    super.trailingLayout,
+  }) : super(EventType.alias, span);
 
   @override
   String toString() => 'ALIAS $name';
 }
 
 /// An event that can have associated anchor and tag properties.
-abstract class _ValueEvent implements Event {
+abstract class _ValueEvent extends Event {
   /// The name of the value's anchor, or `null` if it wasn't anchored.
-  String? get anchor;
+  final String? anchor;
 
   /// The text of the value's tag, or `null` if it wasn't tagged.
-  String? get tag;
+  final String? tag;
+
+  _ValueEvent(
+    super.type,
+    super.span, {
+    this.anchor,
+    this.tag,
+    super.leadingLayout,
+    super.trailingLayout,
+  });
 
   @override
   String toString() {
@@ -101,22 +117,21 @@ abstract class _ValueEvent implements Event {
 
 /// An event indicating a single scalar value.
 class ScalarEvent extends _ValueEvent {
-  @override
-  EventType get type => EventType.scalar;
-  @override
-  final FileSpan span;
-  @override
-  final String? anchor;
-  @override
-  final String? tag;
-
   /// The contents of the scalar.
   final String value;
 
   /// The style of the scalar in the original source.
   final ScalarStyle style;
 
-  ScalarEvent(this.span, this.value, this.style, {this.anchor, this.tag});
+  ScalarEvent(
+    FileSpan span,
+    this.value,
+    this.style, {
+    super.anchor,
+    super.tag,
+    super.leadingLayout,
+    super.trailingLayout,
+  }) : super(EventType.scalar, span);
 
   @override
   String toString() => '${super.toString()} "$value"';
@@ -124,36 +139,32 @@ class ScalarEvent extends _ValueEvent {
 
 /// An event indicating the beginning of a sequence.
 class SequenceStartEvent extends _ValueEvent {
-  @override
-  EventType get type => EventType.sequenceStart;
-  @override
-  final FileSpan span;
-  @override
-  final String? anchor;
-  @override
-  final String? tag;
-
   /// The style of the collection in the original source.
   final CollectionStyle style;
 
-  SequenceStartEvent(this.span, this.style, {this.anchor, this.tag});
+  SequenceStartEvent(
+    FileSpan span,
+    this.style, {
+    super.anchor,
+    super.tag,
+    super.leadingLayout,
+    super.trailingLayout,
+  }) : super(EventType.sequenceStart, span);
 }
 
 /// An event indicating the beginning of a mapping.
 class MappingStartEvent extends _ValueEvent {
-  @override
-  EventType get type => EventType.mappingStart;
-  @override
-  final FileSpan span;
-  @override
-  final String? anchor;
-  @override
-  final String? tag;
-
   /// The style of the collection in the original source.
   final CollectionStyle style;
 
-  MappingStartEvent(this.span, this.style, {this.anchor, this.tag});
+  MappingStartEvent(
+    FileSpan span,
+    this.style, {
+    super.anchor,
+    super.tag,
+    super.leadingLayout,
+    super.trailingLayout,
+  }) : super(EventType.mappingStart, span);
 }
 
 /// The types of [Event] objects.

--- a/pkgs/yaml/lib/src/layout.dart
+++ b/pkgs/yaml/lib/src/layout.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:source_span/source_span.dart';
+
+/// A non-semantic source layout element (comment, whitespace, or newline)
+/// preserved during parsing when layout retention is enabled.
+sealed class LayoutElement {
+  /// The source span of this layout element.
+  SourceSpan get span;
+
+  /// The text content of this layout element.
+  String get text => span.text;
+}
+
+/// A comment in a YAML source document (`# ...`).
+final class CommentElement extends LayoutElement {
+  @override
+  final SourceSpan span;
+
+  /// Whether this comment appears on the same line following content
+  /// (`true`, trailing comment) or on its own line / preceding content
+  /// (`false`, leading comment).
+  final bool isTrailing;
+
+  CommentElement(this.span, {this.isTrailing = false});
+
+  @override
+  String toString() => 'Comment("${span.text}", trailing: $isTrailing)';
+}
+
+/// A sequence of horizontal whitespace characters (spaces or tabs).
+final class WhitespaceElement extends LayoutElement {
+  @override
+  final SourceSpan span;
+
+  WhitespaceElement(this.span);
+
+  @override
+  String toString() => 'Whitespace(${span.length})';
+}
+
+/// A line break (`\n`, `\r\n`, or `\r`).
+final class NewlineElement extends LayoutElement {
+  @override
+  final SourceSpan span;
+
+  NewlineElement(this.span);
+
+  @override
+  String toString() => 'Newline';
+}

--- a/pkgs/yaml/lib/src/loader.dart
+++ b/pkgs/yaml/lib/src/loader.dart
@@ -5,13 +5,17 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import 'dart:math' show max;
+
 import 'package:source_span/source_span.dart';
 
 import 'charcodes.dart';
 import 'equality.dart';
 import 'error_listener.dart';
 import 'event.dart';
+import 'layout.dart';
 import 'parser.dart';
+import 'style.dart';
 import 'yaml_document.dart';
 import 'yaml_exception.dart';
 import 'yaml_node.dart';
@@ -86,6 +90,8 @@ class Loader {
         firstEvent.tagDirectives,
         startImplicit: firstEvent.isImplicit,
         endImplicit: lastEvent.isImplicit,
+        startMarkerSpan: firstEvent.startMarkerSpan,
+        endMarkerSpan: lastEvent.endMarkerSpan,
         leadingLayout: firstEvent.leadingLayout,
         trailingLayout: lastEvent.trailingLayout);
   }
@@ -138,6 +144,9 @@ class Loader {
 
     setLayout(node,
         leading: scalar.leadingLayout, trailing: scalar.trailingLayout);
+    if (scalar.anchorSpan != null) {
+      setAnchorSpan(node, scalar.anchorSpan);
+    }
     _registerAnchor(scalar.anchor, node);
     return node;
   }
@@ -152,8 +161,13 @@ class Loader {
 
     var children = <YamlNode>[];
     var dashSpans = <SourceSpan?>[];
+    var aliasSpans = <SourceSpan?>[];
+    var commaSpans = <SourceSpan?>[];
     var node = YamlList.internal(children, firstEvent.span, firstEvent.style);
     _registerAnchor(firstEvent.anchor, node);
+    if (firstEvent.anchorSpan != null) {
+      setAnchorSpan(node, firstEvent.anchorSpan);
+    }
 
     Event event;
     try {
@@ -161,6 +175,12 @@ class Loader {
       event = _parser.parse();
       while (event.type != EventType.sequenceEnd) {
         dashSpans.add(_parser.lastDashSpan);
+        commaSpans.add(_parser.lastCommaSpan);
+        if (event is AliasEvent) {
+          aliasSpans.add(event.span);
+        } else {
+          aliasSpans.add(null);
+        }
         children.add(_loadNode(event));
         event = _parser.parse();
       }
@@ -171,9 +191,76 @@ class Loader {
     setSpan(node, firstEvent.span.expand(event.span));
     setLayout(node,
         leading: firstEvent.leadingLayout, trailing: event.trailingLayout);
-    if (dashSpans.any((s) => s != null)) {
-      setDashSpans(node, dashSpans);
+
+    final openSpan = firstEvent.openSpan;
+    final closeSpan = event.span.length > 0 ? event.span : null;
+
+    final file = (node.span as FileSpan).file;
+    final entrySpans = <SourceSpan?>[];
+    if (children.isNotEmpty) {
+      if (firstEvent.style == CollectionStyle.FLOW) {
+        for (var i = 0; i < children.length; i++) {
+          final child = children[i];
+          if (children.length == 1) {
+            entrySpans.add(child.span);
+          } else if (i == 0) {
+            final nextComma =
+                i + 1 < commaSpans.length ? commaSpans[i + 1] : null;
+            if (nextComma != null) {
+              entrySpans.add(
+                file.span(child.span.start.offset, nextComma.end.offset),
+              );
+            } else {
+              entrySpans.add(child.span);
+            }
+          } else {
+            final comma = commaSpans[i];
+            if (comma != null) {
+              final childEnd = aliasSpans[i]?.end ?? child.span.end;
+              final endOffset = max(comma.start.offset, childEnd.offset);
+              entrySpans.add(
+                file.span(comma.start.offset, endOffset),
+              );
+            } else {
+              entrySpans.add(child.span);
+            }
+          }
+        }
+      } else {
+        for (var i = 0; i < children.length; i++) {
+          final fallbackStart = dashSpans[i]?.start ??
+              aliasSpans[i]?.start ??
+              children[i].span.start;
+          final startLoc = _getEntryStartLocation(
+            leadingLayout: children[i].leadingLayout,
+            fallback: fallbackStart,
+          );
+          final fallbackNext = (i + 1 < children.length)
+              ? (dashSpans[i + 1]?.start ??
+                  aliasSpans[i + 1]?.start ??
+                  children[i + 1].span.start)
+              : null;
+          final endLoc = (i + 1 < children.length)
+              ? _getEntryStartLocation(
+                  leadingLayout: children[i + 1].leadingLayout,
+                  fallback: fallbackNext!,
+                )
+              : node.span.end;
+          final endOffset = max(startLoc.offset, endLoc.offset);
+          entrySpans.add(file.span(startLoc.offset, endOffset));
+        }
+      }
     }
+
+    setListLayoutSpans(
+      node,
+      dashSpans: dashSpans.any((s) => s != null) ? dashSpans : null,
+      entrySpans: entrySpans.isNotEmpty ? entrySpans : null,
+      aliasSpans: aliasSpans.any((s) => s != null) ? aliasSpans : null,
+      commaSpans: commaSpans.any((s) => s != null) ? commaSpans : null,
+      openSpan: openSpan,
+      closeSpan: closeSpan,
+    );
     return node;
   }
 
@@ -187,19 +274,34 @@ class Loader {
 
     var children = deepEqualsMap<dynamic, YamlNode>();
     var colonSpans = deepEqualsMap<dynamic, SourceSpan>();
+    var aliasSpans = deepEqualsMap<dynamic, SourceSpan>();
+    var commaSpans = deepEqualsMap<dynamic, SourceSpan>();
+    var entrySpans = deepEqualsMap<dynamic, SourceSpan>();
+    var orderedKeys = <YamlNode>[];
     var node = YamlMap.internal(children, firstEvent.span, firstEvent.style);
     _registerAnchor(firstEvent.anchor, node);
+    if (firstEvent.anchorSpan != null) {
+      setAnchorSpan(node, firstEvent.anchorSpan);
+    }
 
     Event event;
     try {
       if (firstEvent.anchor case final anchor?) _activeAnchors.add(anchor);
       event = _parser.parse();
       while (event.type != EventType.mappingEnd) {
+        var commaSpan = _parser.lastCommaSpan;
         var key = _loadNode(event);
+        orderedKeys.add(key);
+        if (commaSpan != null) {
+          commaSpans[key] = commaSpan;
+        }
         var valueEvent = _parser.parse();
         var colonSpan = _parser.lastColonSpan;
         if (colonSpan != null) {
           colonSpans[key] = colonSpan;
+        }
+        if (valueEvent is AliasEvent) {
+          aliasSpans[key] = valueEvent.span;
         }
         var value = _loadNode(valueEvent);
         if (children.containsKey(key)) {
@@ -216,10 +318,85 @@ class Loader {
     setSpan(node, firstEvent.span.expand(event.span));
     setLayout(node,
         leading: firstEvent.leadingLayout, trailing: event.trailingLayout);
-    if (colonSpans.isNotEmpty) {
-      setColonSpans(node, colonSpans);
+
+    final openSpan = firstEvent.openSpan;
+    final closeSpan = event.span.length > 0 ? event.span : null;
+
+    final file = (node.span as FileSpan).file;
+    if (orderedKeys.isNotEmpty) {
+      if (firstEvent.style == CollectionStyle.FLOW) {
+        for (var i = 0; i < orderedKeys.length; i++) {
+          final k = orderedKeys[i];
+          final v = children[k]!;
+          if (orderedKeys.length == 1) {
+            final endOffset = max(k.span.start.offset, v.span.end.offset);
+            entrySpans[k] = file.span(k.span.start.offset, endOffset);
+          } else if (i == 0) {
+            final nextK = orderedKeys[1];
+            final nextComma = commaSpans[nextK];
+            if (nextComma != null) {
+              final endOffset = max(k.span.start.offset, nextComma.end.offset);
+              entrySpans[k] = file.span(k.span.start.offset, endOffset);
+            } else {
+              final endOffset = max(k.span.start.offset, v.span.end.offset);
+              entrySpans[k] = file.span(k.span.start.offset, endOffset);
+            }
+          } else {
+            final comma = commaSpans[k];
+            if (comma != null) {
+              final endOffset = max(comma.start.offset, v.span.end.offset);
+              entrySpans[k] = file.span(comma.start.offset, endOffset);
+            } else {
+              final endOffset = max(k.span.start.offset, v.span.end.offset);
+              entrySpans[k] = file.span(k.span.start.offset, endOffset);
+            }
+          }
+        }
+      } else {
+        // BLOCK style map
+        for (var i = 0; i < orderedKeys.length; i++) {
+          final k = orderedKeys[i];
+          final startLoc = _getEntryStartLocation(
+            leadingLayout: k.leadingLayout,
+            fallback: k.span.start,
+          );
+          final endLoc = (i + 1 < orderedKeys.length)
+              ? _getEntryStartLocation(
+                  leadingLayout: orderedKeys[i + 1].leadingLayout,
+                  fallback: orderedKeys[i + 1].span.start,
+                )
+              : node.span.end;
+          final endOffset = max(startLoc.offset, endLoc.offset);
+          entrySpans[k] = file.span(startLoc.offset, endOffset);
+        }
+      }
     }
+
+    setMapLayoutSpans(
+      node,
+      colonSpans: colonSpans.isNotEmpty ? colonSpans : null,
+      entrySpans: entrySpans.isNotEmpty ? entrySpans : null,
+      aliasSpans: aliasSpans.isNotEmpty ? aliasSpans : null,
+      commaSpans: commaSpans.isNotEmpty ? commaSpans : null,
+      openSpan: openSpan,
+      closeSpan: closeSpan,
+    );
     return node;
+  }
+
+  SourceLocation _getEntryStartLocation({
+    required List<LayoutElement> leadingLayout,
+    required SourceLocation fallback,
+  }) {
+    var startIndex = 0;
+    while (startIndex < leadingLayout.length &&
+        leadingLayout[startIndex] is NewlineElement) {
+      startIndex++;
+    }
+    if (startIndex < leadingLayout.length) {
+      return leadingLayout[startIndex].span.start;
+    }
+    return fallback;
   }
 
   /// Parses a scalar according to its tag name.

--- a/pkgs/yaml/lib/src/loader.dart
+++ b/pkgs/yaml/lib/src/loader.dart
@@ -38,9 +38,15 @@ class Loader {
 
   /// Creates a loader that loads [source].
   factory Loader(String source,
-      {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) {
+      {Uri? sourceUrl,
+      bool recover = false,
+      ErrorListener? errorListener,
+      bool retainLayout = false}) {
     var parser = Parser(source,
-        sourceUrl: sourceUrl, recover: recover, errorListener: errorListener);
+        sourceUrl: sourceUrl,
+        recover: recover,
+        errorListener: errorListener,
+        retainLayout: retainLayout);
     var event = parser.parse();
     assert(event.type == EventType.streamStart);
     return Loader._(parser, event.span);
@@ -79,7 +85,9 @@ class Loader {
         firstEvent.versionDirective,
         firstEvent.tagDirectives,
         startImplicit: firstEvent.isImplicit,
-        endImplicit: lastEvent.isImplicit);
+        endImplicit: lastEvent.isImplicit,
+        leadingLayout: firstEvent.leadingLayout,
+        trailingLayout: lastEvent.trailingLayout);
   }
 
   /// Composes a node.
@@ -128,6 +136,8 @@ class Loader {
       node = _parseScalar(scalar);
     }
 
+    setLayout(node,
+        leading: scalar.leadingLayout, trailing: scalar.trailingLayout);
     _registerAnchor(scalar.anchor, node);
     return node;
   }
@@ -141,6 +151,7 @@ class Loader {
     }
 
     var children = <YamlNode>[];
+    var dashSpans = <SourceSpan?>[];
     var node = YamlList.internal(children, firstEvent.span, firstEvent.style);
     _registerAnchor(firstEvent.anchor, node);
 
@@ -149,6 +160,7 @@ class Loader {
       if (firstEvent.anchor case final anchor?) _activeAnchors.add(anchor);
       event = _parser.parse();
       while (event.type != EventType.sequenceEnd) {
+        dashSpans.add(_parser.lastDashSpan);
         children.add(_loadNode(event));
         event = _parser.parse();
       }
@@ -157,6 +169,11 @@ class Loader {
     }
 
     setSpan(node, firstEvent.span.expand(event.span));
+    setLayout(node,
+        leading: firstEvent.leadingLayout, trailing: event.trailingLayout);
+    if (dashSpans.any((s) => s != null)) {
+      setDashSpans(node, dashSpans);
+    }
     return node;
   }
 
@@ -169,6 +186,7 @@ class Loader {
     }
 
     var children = deepEqualsMap<dynamic, YamlNode>();
+    var colonSpans = deepEqualsMap<dynamic, SourceSpan>();
     var node = YamlMap.internal(children, firstEvent.span, firstEvent.style);
     _registerAnchor(firstEvent.anchor, node);
 
@@ -178,7 +196,12 @@ class Loader {
       event = _parser.parse();
       while (event.type != EventType.mappingEnd) {
         var key = _loadNode(event);
-        var value = _loadNode(_parser.parse());
+        var valueEvent = _parser.parse();
+        var colonSpan = _parser.lastColonSpan;
+        if (colonSpan != null) {
+          colonSpans[key] = colonSpan;
+        }
+        var value = _loadNode(valueEvent);
         if (children.containsKey(key)) {
           throw YamlException('Duplicate mapping key.', key.span);
         }
@@ -191,6 +214,11 @@ class Loader {
     }
 
     setSpan(node, firstEvent.span.expand(event.span));
+    setLayout(node,
+        leading: firstEvent.leadingLayout, trailing: event.trailingLayout);
+    if (colonSpans.isNotEmpty) {
+      setColonSpans(node, colonSpans);
+    }
     return node;
   }
 

--- a/pkgs/yaml/lib/src/parser.dart
+++ b/pkgs/yaml/lib/src/parser.dart
@@ -12,6 +12,7 @@ import 'package:string_scanner/string_scanner.dart';
 
 import 'error_listener.dart';
 import 'event.dart';
+import 'layout.dart';
 import 'scanner.dart';
 import 'style.dart';
 import 'token.dart';
@@ -40,6 +41,16 @@ class Parser {
   /// Whether the parser has finished parsing.
   bool get isDone => _state == _State.END;
 
+  /// The source span of the most recently parsed block entry hyphen (`-`),
+  /// if any.
+  FileSpan? lastDashSpan;
+
+  /// The source span of the most recently parsed value colon (`:`), if any.
+  FileSpan? lastColonSpan;
+
+  /// Whether layout elements and spans should be retained.
+  final bool _retainLayout;
+
   /// Creates a parser that parses [source].
   ///
   /// If [recover] is true, will attempt to recover from parse errors and may
@@ -47,17 +58,24 @@ class Parser {
   /// its onError method will be called for each error recovered from. It is not
   /// valid to provide [errorListener] if [recover] is false.
   Parser(String source,
-      {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener})
+      {Uri? sourceUrl,
+      bool recover = false,
+      ErrorListener? errorListener,
+      bool retainLayout = false})
       : assert(recover || errorListener == null),
+        _retainLayout = retainLayout,
         _scanner = Scanner(source,
             sourceUrl: sourceUrl,
             recover: recover,
-            errorListener: errorListener);
+            errorListener: errorListener,
+            retainLayout: retainLayout);
 
   /// Consumes and returns the next event.
   Event parse() {
     try {
       if (isDone) throw StateError('No more events.');
+      lastDashSpan = null;
+      lastColonSpan = null;
       var event = _stateMachine();
       return event;
     } on StringScannerException catch (error) {
@@ -169,7 +187,9 @@ class Parser {
     if (token.type == TokenType.streamEnd) {
       _state = _State.END;
       _scanner.scan();
-      return Event(EventType.streamEnd, token.span);
+      return Event(EventType.streamEnd, token.span,
+          leadingLayout: token.leadingLayout,
+          trailingLayout: token.trailingLayout);
     }
 
     // Parse an explicit document.
@@ -186,7 +206,9 @@ class Parser {
     return DocumentStartEvent(start.expand(token.span),
         versionDirective: versionDirective,
         tagDirectives: tagDirectives,
-        isImplicit: false);
+        isImplicit: false,
+        leadingLayout: token.leadingLayout,
+        trailingLayout: token.trailingLayout);
   }
 
   /// Parses the productions:
@@ -224,7 +246,10 @@ class Parser {
     var token = _scanner.peek()!;
     if (token.type == TokenType.documentEnd) {
       _scanner.scan();
-      return DocumentEndEvent(token.span, isImplicit: false);
+      return DocumentEndEvent(token.span,
+          isImplicit: false,
+          leadingLayout: token.leadingLayout,
+          trailingLayout: token.trailingLayout);
     } else {
       return DocumentEndEvent(token.span.start.pointSpan());
     }
@@ -257,18 +282,32 @@ class Parser {
   ///                                                                   ******
   ///     flow_content         ::= flow_collection | SCALAR
   ///                                                ******
-  Event _parseNode({bool block = false, bool indentlessSequence = false}) {
+  Event _parseNode(
+      {bool block = false,
+      bool indentlessSequence = false,
+      List<LayoutElement>? extraLeadingLayout}) {
     var token = _scanner.peek()!;
+
+    List<LayoutElement> combineLeading(List<LayoutElement> primary) {
+      if (extraLeadingLayout == null || extraLeadingLayout.isEmpty) {
+        return primary;
+      }
+      if (primary.isEmpty) return extraLeadingLayout;
+      return [...extraLeadingLayout, ...primary];
+    }
 
     if (token is AliasToken) {
       _scanner.scan();
       _state = _states.removeLast();
-      return AliasEvent(token.span, token.name);
+      return AliasEvent(token.span, token.name,
+          leadingLayout: combineLeading(token.leadingLayout),
+          trailingLayout: token.trailingLayout);
     }
 
     String? anchor;
     TagToken? tagToken;
     var span = token.span.start.pointSpan();
+    var nodeLeadingLayout = combineLeading(token.leadingLayout);
     Token parseAnchor(AnchorToken token) {
       anchor = token.name;
       span = span.expand(token.span);
@@ -306,7 +345,7 @@ class Parser {
     if (indentlessSequence && token.type == TokenType.blockEntry) {
       _state = _State.INDENTLESS_SEQUENCE_ENTRY;
       return SequenceStartEvent(span.expand(token.span), CollectionStyle.BLOCK,
-          anchor: anchor, tag: tag);
+          anchor: anchor, tag: tag, leadingLayout: nodeLeadingLayout);
     }
 
     if (token is ScalarToken) {
@@ -316,36 +355,46 @@ class Parser {
       _state = _states.removeLast();
       _scanner.scan();
       return ScalarEvent(span.expand(token.span), token.value, token.style,
-          anchor: anchor, tag: tag);
+          anchor: anchor,
+          tag: tag,
+          leadingLayout: nodeLeadingLayout,
+          trailingLayout: token.trailingLayout);
     }
 
     if (token.type == TokenType.flowSequenceStart) {
       _state = _State.FLOW_SEQUENCE_FIRST_ENTRY;
       return SequenceStartEvent(span.expand(token.span), CollectionStyle.FLOW,
-          anchor: anchor, tag: tag);
+          anchor: anchor,
+          tag: tag,
+          leadingLayout: nodeLeadingLayout,
+          trailingLayout: token.trailingLayout);
     }
 
     if (token.type == TokenType.flowMappingStart) {
       _state = _State.FLOW_MAPPING_FIRST_KEY;
       return MappingStartEvent(span.expand(token.span), CollectionStyle.FLOW,
-          anchor: anchor, tag: tag);
+          anchor: anchor,
+          tag: tag,
+          leadingLayout: nodeLeadingLayout,
+          trailingLayout: token.trailingLayout);
     }
 
     if (block && token.type == TokenType.blockSequenceStart) {
       _state = _State.BLOCK_SEQUENCE_FIRST_ENTRY;
       return SequenceStartEvent(span.expand(token.span), CollectionStyle.BLOCK,
-          anchor: anchor, tag: tag);
+          anchor: anchor, tag: tag, leadingLayout: nodeLeadingLayout);
     }
 
     if (block && token.type == TokenType.blockMappingStart) {
       _state = _State.BLOCK_MAPPING_FIRST_KEY;
       return MappingStartEvent(span.expand(token.span), CollectionStyle.BLOCK,
-          anchor: anchor, tag: tag);
+          anchor: anchor, tag: tag, leadingLayout: nodeLeadingLayout);
     }
 
     if (anchor != null || tag != null) {
       _state = _states.removeLast();
-      return ScalarEvent(span, '', ScalarStyle.PLAIN, anchor: anchor, tag: tag);
+      return ScalarEvent(span, '', ScalarStyle.PLAIN,
+          anchor: anchor, tag: tag, leadingLayout: nodeLeadingLayout);
     }
 
     throw YamlException('Expected node content.', span);
@@ -360,16 +409,18 @@ class Parser {
     var token = _scanner.peek()!;
 
     if (token.type == TokenType.blockEntry) {
+      if (_retainLayout) lastDashSpan = token.span;
+      var dashLeadingLayout = token.leadingLayout;
       var start = token.span.start;
       token = _scanner.advance()!;
 
       if (token.type == TokenType.blockEntry ||
           token.type == TokenType.blockEnd) {
         _state = _State.BLOCK_SEQUENCE_ENTRY;
-        return _processEmptyScalar(start);
+        return _processEmptyScalar(start, leadingLayout: dashLeadingLayout);
       } else {
         _states.add(_State.BLOCK_SEQUENCE_ENTRY);
-        return _parseNode(block: true);
+        return _parseNode(block: true, extraLeadingLayout: dashLeadingLayout);
       }
     }
 
@@ -405,6 +456,8 @@ class Parser {
       return Event(EventType.sequenceEnd, token.span.start.pointSpan());
     }
 
+    if (_retainLayout) lastDashSpan = token.span;
+    var dashLeadingLayout = token.leadingLayout;
     var start = token.span.start;
     token = _scanner.advance()!;
 
@@ -413,10 +466,10 @@ class Parser {
         token.type == TokenType.value ||
         token.type == TokenType.blockEnd) {
       _state = _State.INDENTLESS_SEQUENCE_ENTRY;
-      return _processEmptyScalar(start);
+      return _processEmptyScalar(start, leadingLayout: dashLeadingLayout);
     } else {
       _states.add(_State.INDENTLESS_SEQUENCE_ENTRY);
-      return _parseNode(block: true);
+      return _parseNode(block: true, extraLeadingLayout: dashLeadingLayout);
     }
   }
 
@@ -433,6 +486,7 @@ class Parser {
   Event _parseBlockMappingKey() {
     var token = _scanner.peek()!;
     if (token.type == TokenType.key) {
+      var keyLeadingLayout = token.leadingLayout;
       var start = token.span.start;
       token = _scanner.advance()!;
 
@@ -440,10 +494,13 @@ class Parser {
           token.type == TokenType.value ||
           token.type == TokenType.blockEnd) {
         _state = _State.BLOCK_MAPPING_VALUE;
-        return _processEmptyScalar(start);
+        return _processEmptyScalar(start, leadingLayout: keyLeadingLayout);
       } else {
         _states.add(_State.BLOCK_MAPPING_VALUE);
-        return _parseNode(block: true, indentlessSequence: true);
+        return _parseNode(
+            block: true,
+            indentlessSequence: true,
+            extraLeadingLayout: keyLeadingLayout);
       }
     }
 
@@ -483,6 +540,7 @@ class Parser {
       return _processEmptyScalar(token.span.start);
     }
 
+    if (_retainLayout) lastColonSpan = token.span;
     var start = token.span.start;
     token = _scanner.advance()!;
     if (token.type == TokenType.key ||
@@ -572,6 +630,7 @@ class Parser {
     var token = _scanner.peek()!;
 
     if (token.type == TokenType.value) {
+      if (_retainLayout) lastColonSpan = token.span;
       token = _scanner.advance()!;
       if (token.type != TokenType.flowEntry &&
           token.type != TokenType.flowSequenceEnd) {
@@ -623,15 +682,17 @@ class Parser {
       }
 
       if (token.type == TokenType.key) {
+        var keyLeadingLayout = token.leadingLayout;
         token = _scanner.advance()!;
         if (token.type != TokenType.value &&
             token.type != TokenType.flowEntry &&
             token.type != TokenType.flowMappingEnd) {
           _states.add(_State.FLOW_MAPPING_VALUE);
-          return _parseNode();
+          return _parseNode(extraLeadingLayout: keyLeadingLayout);
         } else {
           _state = _State.FLOW_MAPPING_VALUE;
-          return _processEmptyScalar(token.span.start);
+          return _processEmptyScalar(token.span.start,
+              leadingLayout: keyLeadingLayout);
         }
       } else if (token.type != TokenType.flowMappingEnd) {
         _states.add(_State.FLOW_MAPPING_EMPTY_VALUE);
@@ -658,6 +719,7 @@ class Parser {
     }
 
     if (token.type == TokenType.value) {
+      if (_retainLayout) lastColonSpan = token.span;
       token = _scanner.advance()!;
       if (token.type != TokenType.flowEntry &&
           token.type != TokenType.flowMappingEnd) {
@@ -671,8 +733,12 @@ class Parser {
   }
 
   /// Generate an empty scalar event.
-  Event _processEmptyScalar(SourceLocation location) =>
-      ScalarEvent(location.pointSpan() as FileSpan, '', ScalarStyle.PLAIN);
+  Event _processEmptyScalar(SourceLocation location,
+          {List<LayoutElement>? leadingLayout,
+          List<LayoutElement>? trailingLayout}) =>
+      ScalarEvent(location.pointSpan() as FileSpan, '', ScalarStyle.PLAIN,
+          leadingLayout: leadingLayout ?? const [],
+          trailingLayout: trailingLayout ?? const []);
 
   /// Parses directives.
   (VersionDirective?, List<TagDirective>) _processDirectives() {

--- a/pkgs/yaml/lib/src/parser.dart
+++ b/pkgs/yaml/lib/src/parser.dart
@@ -48,6 +48,22 @@ class Parser {
   /// The source span of the most recently parsed value colon (`:`), if any.
   FileSpan? lastColonSpan;
 
+  /// The source span of the most recently parsed flow entry comma (`,`),
+  /// if any.
+  FileSpan? lastCommaSpan;
+
+  /// The source span of the most recently parsed flow opening bracket/brace,
+  /// if any.
+  FileSpan? lastOpenSpan;
+
+  /// The source span of the most recently parsed flow closing bracket/brace,
+  /// if any.
+  FileSpan? lastCloseSpan;
+
+  /// The source span of the most recently parsed anchor definition (`&anchor`),
+  /// if any.
+  FileSpan? lastAnchorSpan;
+
   /// Whether layout elements and spans should be retained.
   final bool _retainLayout;
 
@@ -76,6 +92,10 @@ class Parser {
       if (isDone) throw StateError('No more events.');
       lastDashSpan = null;
       lastColonSpan = null;
+      lastCommaSpan = null;
+      lastOpenSpan = null;
+      lastCloseSpan = null;
+      lastAnchorSpan = null;
       var event = _stateMachine();
       return event;
     } on StringScannerException catch (error) {
@@ -207,6 +227,7 @@ class Parser {
         versionDirective: versionDirective,
         tagDirectives: tagDirectives,
         isImplicit: false,
+        startMarkerSpan: token.span,
         leadingLayout: token.leadingLayout,
         trailingLayout: token.trailingLayout);
   }
@@ -248,6 +269,7 @@ class Parser {
       _scanner.scan();
       return DocumentEndEvent(token.span,
           isImplicit: false,
+          endMarkerSpan: token.span,
           leadingLayout: token.leadingLayout,
           trailingLayout: token.trailingLayout);
     } else {
@@ -305,11 +327,14 @@ class Parser {
     }
 
     String? anchor;
+    FileSpan? anchorSpan;
     TagToken? tagToken;
     var span = token.span.start.pointSpan();
     var nodeLeadingLayout = combineLeading(token.leadingLayout);
     Token parseAnchor(AnchorToken token) {
       anchor = token.name;
+      anchorSpan = token.span;
+      if (_retainLayout) lastAnchorSpan = token.span;
       span = span.expand(token.span);
       return _scanner.advance()!;
     }
@@ -345,7 +370,10 @@ class Parser {
     if (indentlessSequence && token.type == TokenType.blockEntry) {
       _state = _State.INDENTLESS_SEQUENCE_ENTRY;
       return SequenceStartEvent(span.expand(token.span), CollectionStyle.BLOCK,
-          anchor: anchor, tag: tag, leadingLayout: nodeLeadingLayout);
+          anchor: anchor,
+          anchorSpan: anchorSpan,
+          tag: tag,
+          leadingLayout: nodeLeadingLayout);
     }
 
     if (token is ScalarToken) {
@@ -356,6 +384,7 @@ class Parser {
       _scanner.scan();
       return ScalarEvent(span.expand(token.span), token.value, token.style,
           anchor: anchor,
+          anchorSpan: anchorSpan,
           tag: tag,
           leadingLayout: nodeLeadingLayout,
           trailingLayout: token.trailingLayout);
@@ -365,7 +394,9 @@ class Parser {
       _state = _State.FLOW_SEQUENCE_FIRST_ENTRY;
       return SequenceStartEvent(span.expand(token.span), CollectionStyle.FLOW,
           anchor: anchor,
+          anchorSpan: anchorSpan,
           tag: tag,
+          openSpan: token.span,
           leadingLayout: nodeLeadingLayout,
           trailingLayout: token.trailingLayout);
     }
@@ -374,7 +405,9 @@ class Parser {
       _state = _State.FLOW_MAPPING_FIRST_KEY;
       return MappingStartEvent(span.expand(token.span), CollectionStyle.FLOW,
           anchor: anchor,
+          anchorSpan: anchorSpan,
           tag: tag,
+          openSpan: token.span,
           leadingLayout: nodeLeadingLayout,
           trailingLayout: token.trailingLayout);
     }
@@ -382,19 +415,28 @@ class Parser {
     if (block && token.type == TokenType.blockSequenceStart) {
       _state = _State.BLOCK_SEQUENCE_FIRST_ENTRY;
       return SequenceStartEvent(span.expand(token.span), CollectionStyle.BLOCK,
-          anchor: anchor, tag: tag, leadingLayout: nodeLeadingLayout);
+          anchor: anchor,
+          anchorSpan: anchorSpan,
+          tag: tag,
+          leadingLayout: nodeLeadingLayout);
     }
 
     if (block && token.type == TokenType.blockMappingStart) {
       _state = _State.BLOCK_MAPPING_FIRST_KEY;
       return MappingStartEvent(span.expand(token.span), CollectionStyle.BLOCK,
-          anchor: anchor, tag: tag, leadingLayout: nodeLeadingLayout);
+          anchor: anchor,
+          anchorSpan: anchorSpan,
+          tag: tag,
+          leadingLayout: nodeLeadingLayout);
     }
 
     if (anchor != null || tag != null) {
       _state = _states.removeLast();
       return ScalarEvent(span, '', ScalarStyle.PLAIN,
-          anchor: anchor, tag: tag, leadingLayout: nodeLeadingLayout);
+          anchor: anchor,
+          anchorSpan: anchorSpan,
+          tag: tag,
+          leadingLayout: nodeLeadingLayout);
     }
 
     throw YamlException('Expected node content.', span);
@@ -542,12 +584,13 @@ class Parser {
 
     if (_retainLayout) lastColonSpan = token.span;
     var start = token.span.start;
+    var colonEnd = token.span.end;
     token = _scanner.advance()!;
     if (token.type == TokenType.key ||
         token.type == TokenType.value ||
         token.type == TokenType.blockEnd) {
       _state = _State.BLOCK_MAPPING_KEY;
-      return _processEmptyScalar(start);
+      return _processEmptyScalar(_retainLayout ? colonEnd : start);
     } else {
       _states.add(_State.BLOCK_MAPPING_KEY);
       return _parseNode(block: true, indentlessSequence: true);
@@ -579,6 +622,7 @@ class Parser {
               token.span.start.pointSpan());
         }
 
+        if (_retainLayout) lastCommaSpan = token.span;
         token = _scanner.advance()!;
       }
 
@@ -678,6 +722,7 @@ class Parser {
               token.span.start.pointSpan());
         }
 
+        if (_retainLayout) lastCommaSpan = token.span;
         token = _scanner.advance()!;
       }
 
@@ -726,6 +771,8 @@ class Parser {
         _states.add(_State.FLOW_MAPPING_KEY);
         return _parseNode();
       }
+      _state = _State.FLOW_MAPPING_KEY;
+      return _processEmptyScalar(token.span.start);
     }
 
     _state = _State.FLOW_MAPPING_KEY;

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -12,6 +12,7 @@ import 'package:source_span/source_span.dart';
 import 'package:string_scanner/string_scanner.dart';
 
 import 'error_listener.dart';
+import 'layout.dart';
 import 'style.dart';
 import 'token.dart';
 import 'utils.dart';
@@ -97,6 +98,18 @@ class Scanner {
 
   /// Whether this scanner should attempt to recover when parsing invalid YAML.
   final bool _recover;
+
+  /// Whether this scanner retains layout elements (whitespace, comments, line
+  /// breaks).
+  final bool _retainLayout;
+
+  /// Layout elements pending to be attached as leading layout to the next
+  /// token.
+  final _pendingLeadingLayout = <LayoutElement>[];
+
+  /// The most recently emitted token from the source text (used for trailing
+  /// layout).
+  Token? _lastToken;
 
   /// A listener to report YAML errors to.
   final ErrorListener? _errorListener;
@@ -286,8 +299,12 @@ class Scanner {
 
   /// Creates a scanner that scans [source].
   Scanner(String source,
-      {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener})
+      {Uri? sourceUrl,
+      bool recover = false,
+      ErrorListener? errorListener,
+      bool retainLayout = false})
       : _recover = recover,
+        _retainLayout = retainLayout,
         _errorListener = errorListener,
         _scanner = SpanScanner.eager(source, sourceUrl: sourceUrl);
 
@@ -605,7 +622,22 @@ class Scanner {
     _resetIndent();
     _removeSimpleKey();
     _simpleKeyAllowed = false;
-    _tokens.add(Token(TokenType.streamEnd, _scanner.emptySpan));
+    _tokens.add(Token(TokenType.streamEnd, _scanner.emptySpan,
+        leadingLayout: _takePendingLeadingLayout()));
+  }
+
+  void _emitToken(Token token) {
+    if (_retainLayout) {
+      _lastToken = token;
+    }
+    _tokens.add(token);
+  }
+
+  List<LayoutElement> _takePendingLeadingLayout() {
+    if (!_retainLayout || _pendingLeadingLayout.isEmpty) return const [];
+    var layout = List.of(_pendingLeadingLayout);
+    _pendingLeadingLayout.clear();
+    return layout;
   }
 
   /// Produces a [TokenType.versionDirective] or [TokenType.tagDirective]
@@ -615,7 +647,7 @@ class Scanner {
     _removeSimpleKey();
     _simpleKeyAllowed = false;
     var directive = _scanDirective();
-    if (directive != null) _tokens.add(directive);
+    if (directive != null) _emitToken(directive);
   }
 
   /// Produces a [TokenType.documentStart] or [TokenType.documentEnd] token.
@@ -630,7 +662,8 @@ class Scanner {
     _scanner.readCodePoint();
     _scanner.readCodePoint();
 
-    _tokens.add(Token(type, _scanner.spanFrom(start)));
+    _emitToken(Token(type, _scanner.spanFrom(start),
+        leadingLayout: _takePendingLeadingLayout()));
   }
 
   /// Produces a [TokenType.flowSequenceStart] or
@@ -745,21 +778,22 @@ class Scanner {
   void _addCharToken(TokenType type) {
     var start = _scanner.state;
     _scanner.readCodePoint();
-    _tokens.add(Token(type, _scanner.spanFrom(start)));
+    _emitToken(Token(type, _scanner.spanFrom(start),
+        leadingLayout: _takePendingLeadingLayout()));
   }
 
   /// Produces a [TokenType.alias] or [TokenType.anchor] token.
   void _fetchAnchor({bool anchor = true}) {
     _saveSimpleKey();
     _simpleKeyAllowed = false;
-    _tokens.add(_scanAnchor(anchor: anchor));
+    _emitToken(_scanAnchor(anchor: anchor));
   }
 
   /// Produces a [TokenType.tag] token.
   void _fetchTag() {
     _saveSimpleKey();
     _simpleKeyAllowed = false;
-    _tokens.add(_scanTag());
+    _emitToken(_scanTag());
   }
 
   /// Produces a [TokenType.scalar] token with style [ScalarStyle.LITERAL] or
@@ -767,7 +801,7 @@ class Scanner {
   void _fetchBlockScalar({bool literal = false}) {
     _removeSimpleKey();
     _simpleKeyAllowed = true;
-    _tokens.add(_scanBlockScalar(literal: literal));
+    _emitToken(_scanBlockScalar(literal: literal));
   }
 
   /// Produces a [TokenType.scalar] token with style [ScalarStyle.SINGLE_QUOTED]
@@ -775,14 +809,14 @@ class Scanner {
   void _fetchFlowScalar({bool singleQuote = false}) {
     _saveSimpleKey();
     _simpleKeyAllowed = false;
-    _tokens.add(_scanFlowScalar(singleQuote: singleQuote));
+    _emitToken(_scanFlowScalar(singleQuote: singleQuote));
   }
 
   /// Produces a [TokenType.scalar] token with style [ScalarStyle.PLAIN].
   void _fetchPlainScalar() {
     _saveSimpleKey();
     _simpleKeyAllowed = false;
-    _tokens.add(_scanPlainScalar());
+    _emitToken(_scanPlainScalar());
   }
 
   /// Eats whitespace and comments until the next token is found.
@@ -792,34 +826,86 @@ class Scanner {
       // Allow the BOM to start a line.
       if (_scanner.column == 0) _scanner.scan('\uFEFF');
 
-      // Eat whitespace.
-      //
-      // libyaml disallows tabs after "-", "?", or ":", but the spec allows
-      // them. See section 6.2: http://yaml.org/spec/1.2/spec.html#id2778241.
-      while (_scanner.peekChar() == SP ||
-          ((!_inBlockContext || !afterLineBreak) &&
-              _scanner.peekChar() == TAB)) {
-        _scanner.readChar();
-      }
+      if (!_retainLayout) {
+        // Eat whitespace.
+        //
+        // libyaml disallows tabs after "-", "?", or ":", but the spec allows
+        // them. See section 6.2: http://yaml.org/spec/1.2/spec.html#id2778241.
+        while (_scanner.peekChar() == SP ||
+            ((!_inBlockContext || !afterLineBreak) &&
+                _scanner.peekChar() == TAB)) {
+          _scanner.readChar();
+        }
 
-      if (_scanner.peekChar() == TAB) {
-        _scanner.error('Tab characters are not allowed as indentation.',
-            length: 1);
-      }
+        if (_scanner.peekChar() == TAB) {
+          _scanner.error('Tab characters are not allowed as indentation.',
+              length: 1);
+        }
 
-      // Eat a comment until a line break.
-      _skipComment();
+        // Eat a comment until a line break.
+        _skipComment();
 
-      // If we're at a line break, eat it.
-      if (_isBreak) {
-        _skipLine();
+        // If we're at a line break, eat it.
+        if (_isBreak) {
+          _skipLine();
 
-        // In the block context, a new line may start a simple key.
-        if (_inBlockContext) _simpleKeyAllowed = true;
-        afterLineBreak = true;
+          // In the block context, a new line may start a simple key.
+          if (_inBlockContext) _simpleKeyAllowed = true;
+          afterLineBreak = true;
+        } else {
+          // Otherwise we've found a token.
+          break;
+        }
       } else {
-        // Otherwise we've found a token.
-        break;
+        // Retaining layout:
+        var wsStart = _scanner.state;
+        while (_scanner.peekChar() == SP ||
+            ((!_inBlockContext || !afterLineBreak) &&
+                _scanner.peekChar() == TAB)) {
+          _scanner.readChar();
+        }
+
+        if (_scanner.state.position > wsStart.position) {
+          var wsSpan = _scanner.spanFrom(wsStart);
+          var elem = WhitespaceElement(wsSpan);
+          if (!afterLineBreak && _lastToken != null) {
+            _lastToken!.trailingLayout.add(elem);
+          } else {
+            _pendingLeadingLayout.add(elem);
+          }
+        }
+
+        if (_scanner.peekChar() == TAB) {
+          _scanner.error('Tab characters are not allowed as indentation.',
+              length: 1);
+        }
+
+        // Check for comment.
+        if (_scanner.peekChar() == HASH) {
+          var commentStart = _scanner.state;
+          while (!_isBreakOrEnd) {
+            _scanner.readChar();
+          }
+          var commentSpan = _scanner.spanFrom(commentStart);
+          if (!afterLineBreak && _lastToken != null) {
+            _lastToken!.trailingLayout
+                .add(CommentElement(commentSpan, isTrailing: true));
+          } else {
+            _pendingLeadingLayout.add(CommentElement(commentSpan));
+          }
+        }
+
+        if (_isBreak) {
+          var breakStart = _scanner.state;
+          _skipLine();
+          var breakSpan = _scanner.spanFrom(breakStart);
+          _pendingLeadingLayout.add(NewlineElement(breakSpan));
+
+          if (_inBlockContext) _simpleKeyAllowed = true;
+          afterLineBreak = true;
+        } else {
+          break;
+        }
       }
     }
   }
@@ -831,6 +917,7 @@ class Scanner {
   ///     %TAG    !yaml!  tag:yaml.org,2002:  \n
   ///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Token? _scanDirective() {
+    var leading = _takePendingLeadingLayout();
     var start = _scanner.state;
 
     // Eat '%'.
@@ -839,9 +926,9 @@ class Scanner {
     Token token;
     var name = _scanDirectiveName();
     if (name == 'YAML') {
-      token = _scanVersionDirectiveValue(start);
+      token = _scanVersionDirectiveValue(start, leadingLayout: leading);
     } else if (name == 'TAG') {
-      token = _scanTagDirectiveValue(start);
+      token = _scanTagDirectiveValue(start, leadingLayout: leading);
     } else {
       warn('Warning: unknown directive.', _scanner.spanFrom(start));
 
@@ -855,15 +942,36 @@ class Scanner {
     }
 
     // Eat the rest of the line, including any comments.
-    _skipBlanks();
-    _skipComment();
+    if (_retainLayout) {
+      var wsStart = _scanner.state;
+      _skipBlanks();
+      if (_scanner.state.position > wsStart.position) {
+        token.trailingLayout.add(WhitespaceElement(_scanner.spanFrom(wsStart)));
+      }
+      if (_scanner.peekChar() == HASH) {
+        var commentStart = _scanner.state;
+        _skipComment();
+        token.trailingLayout.add(CommentElement(
+            _scanner.spanFrom(commentStart),
+            isTrailing: true));
+      }
+    } else {
+      _skipBlanks();
+      _skipComment();
+    }
 
     if (!_isBreakOrEnd) {
       throw YamlException('Expected comment or line break after directive.',
           _scanner.spanFrom(start));
     }
 
-    _skipLine();
+    if (_retainLayout && _isBreak) {
+      var breakStart = _scanner.state;
+      _skipLine();
+      _pendingLeadingLayout.add(NewlineElement(_scanner.spanFrom(breakStart)));
+    } else {
+      _skipLine();
+    }
     return token;
   }
 
@@ -896,14 +1004,16 @@ class Scanner {
   ///
   ///      %YAML   1.2     # a comment \n
   ///           ^^^^^^
-  Token _scanVersionDirectiveValue(LineScannerState start) {
+  Token _scanVersionDirectiveValue(LineScannerState start,
+      {List<LayoutElement>? leadingLayout}) {
     _skipBlanks();
 
     var major = _scanVersionDirectiveNumber();
     _scanner.expect('.');
     var minor = _scanVersionDirectiveNumber();
 
-    return VersionDirectiveToken(_scanner.spanFrom(start), major, minor);
+    return VersionDirectiveToken(_scanner.spanFrom(start), major, minor,
+        leadingLayout: leadingLayout ?? const []);
   }
 
   /// Scans the version number of a version directive.
@@ -930,7 +1040,8 @@ class Scanner {
   ///
   ///      %TAG    !yaml!  tag:yaml.org,2002:  \n
   ///          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Token _scanTagDirectiveValue(LineScannerState start) {
+  Token _scanTagDirectiveValue(LineScannerState start,
+      {List<LayoutElement>? leadingLayout}) {
     _skipBlanks();
 
     var handle = _scanTagHandle(directive: true);
@@ -945,7 +1056,8 @@ class Scanner {
       throw YamlException('Expected whitespace.', _scanner.emptySpan);
     }
 
-    return TagDirectiveToken(_scanner.spanFrom(start), handle, prefix);
+    return TagDirectiveToken(_scanner.spanFrom(start), handle, prefix,
+        leadingLayout: leadingLayout ?? const []);
   }
 
   /// Scans a [TokenType.anchor] token.
@@ -978,15 +1090,19 @@ class Scanner {
           'Expected alphanumeric character.', _scanner.emptySpan);
     }
 
+    var leading = _takePendingLeadingLayout();
     if (anchor) {
-      return AnchorToken(_scanner.spanFrom(start), name);
+      return AnchorToken(_scanner.spanFrom(start), name,
+          leadingLayout: leading);
     } else {
-      return AliasToken(_scanner.spanFrom(start), name);
+      return AliasToken(_scanner.spanFrom(start), name,
+          leadingLayout: leading);
     }
   }
 
   /// Scans a [TokenType.tag] token.
   Token _scanTag() {
+    var leading = _takePendingLeadingLayout();
     String? handle;
     String suffix;
     var start = _scanner.state;
@@ -1026,7 +1142,8 @@ class Scanner {
     // libyaml insists on whitespace after a tag, but example 7.2 indicates
     // that it's not required: http://yaml.org/spec/1.2/spec.html#id2786720.
 
-    return TagToken(_scanner.spanFrom(start), handle, suffix);
+    return TagToken(_scanner.spanFrom(start), handle, suffix,
+        leadingLayout: leading);
   }
 
   /// Scans a tag handle.
@@ -1092,6 +1209,7 @@ class Scanner {
 
   /// Scans a block scalar.
   Token _scanBlockScalar({bool literal = false}) {
+    var leading = _takePendingLeadingLayout();
     var start = _scanner.state;
 
     // Eat the indicator '|' or '>'.
@@ -1219,7 +1337,8 @@ class Scanner {
     if (chomping == _Chomping.keep) buffer.write(trailingBreaks);
 
     return ScalarToken(_scanner.spanFrom(start, end), buffer.toString(),
-        literal ? ScalarStyle.LITERAL : ScalarStyle.FOLDED);
+        literal ? ScalarStyle.LITERAL : ScalarStyle.FOLDED,
+        leadingLayout: leading);
   }
 
   /// Scans indentation spaces and line breaks for a block scalar.
@@ -1259,6 +1378,7 @@ class Scanner {
 
   // Scans a quoted scalar.
   Token _scanFlowScalar({bool singleQuote = false}) {
+    var leading = _takePendingLeadingLayout();
     var start = _scanner.state;
     var buffer = StringBuffer();
 
@@ -1438,11 +1558,13 @@ class Scanner {
     _scanner.readChar();
 
     return ScalarToken(_scanner.spanFrom(start), buffer.toString(),
-        singleQuote ? ScalarStyle.SINGLE_QUOTED : ScalarStyle.DOUBLE_QUOTED);
+        singleQuote ? ScalarStyle.SINGLE_QUOTED : ScalarStyle.DOUBLE_QUOTED,
+        leadingLayout: leading);
   }
 
   /// Scans a plain scalar.
   Token _scanPlainScalar() {
+    var leading = _takePendingLeadingLayout();
     var start = _scanner.state;
     var end = _scanner.state;
     var buffer = StringBuffer();
@@ -1518,8 +1640,13 @@ class Scanner {
     // Allow a simple key after a plain scalar with leading blanks.
     if (leadingBreak.isNotEmpty) _simpleKeyAllowed = true;
 
+    if (_retainLayout) {
+      _scanner.state = end;
+    }
+
     return ScalarToken(
-        _scanner.spanFrom(start, end), buffer.toString(), ScalarStyle.PLAIN);
+        _scanner.spanFrom(start, end), buffer.toString(), ScalarStyle.PLAIN,
+        leadingLayout: leading);
   }
 
   /// Moves past the current line break, if there is one.

--- a/pkgs/yaml/lib/src/scanner.dart
+++ b/pkgs/yaml/lib/src/scanner.dart
@@ -951,9 +951,8 @@ class Scanner {
       if (_scanner.peekChar() == HASH) {
         var commentStart = _scanner.state;
         _skipComment();
-        token.trailingLayout.add(CommentElement(
-            _scanner.spanFrom(commentStart),
-            isTrailing: true));
+        token.trailingLayout.add(
+            CommentElement(_scanner.spanFrom(commentStart), isTrailing: true));
       }
     } else {
       _skipBlanks();
@@ -1095,8 +1094,7 @@ class Scanner {
       return AnchorToken(_scanner.spanFrom(start), name,
           leadingLayout: leading);
     } else {
-      return AliasToken(_scanner.spanFrom(start), name,
-          leadingLayout: leading);
+      return AliasToken(_scanner.spanFrom(start), name, leadingLayout: leading);
     }
   }
 

--- a/pkgs/yaml/lib/src/token.dart
+++ b/pkgs/yaml/lib/src/token.dart
@@ -7,6 +7,7 @@
 
 import 'package:source_span/source_span.dart';
 
+import 'layout.dart';
 import 'scanner.dart';
 import 'style.dart';
 
@@ -14,114 +15,103 @@ import 'style.dart';
 class Token {
   final TokenType type;
   final FileSpan span;
+  final List<LayoutElement> leadingLayout;
+  final List<LayoutElement> trailingLayout;
 
-  Token(this.type, this.span);
+  Token(
+    this.type,
+    this.span, {
+    this.leadingLayout = const [],
+    List<LayoutElement>? trailingLayout,
+  }) : trailingLayout = trailingLayout ?? [];
 
   @override
   String toString() => type.toString();
 }
 
 /// A token representing a `%YAML` directive.
-class VersionDirectiveToken implements Token {
-  @override
-  TokenType get type => TokenType.versionDirective;
-  @override
-  final FileSpan span;
-
+class VersionDirectiveToken extends Token {
   /// The declared major version of the document.
   final int major;
 
   /// The declared minor version of the document.
   final int minor;
 
-  VersionDirectiveToken(this.span, this.major, this.minor);
+  VersionDirectiveToken(FileSpan span, this.major, this.minor,
+      {super.leadingLayout, super.trailingLayout})
+      : super(TokenType.versionDirective, span);
 
   @override
   String toString() => 'VERSION_DIRECTIVE $major.$minor';
 }
 
 /// A token representing a `%TAG` directive.
-class TagDirectiveToken implements Token {
-  @override
-  TokenType get type => TokenType.tagDirective;
-  @override
-  final FileSpan span;
-
+class TagDirectiveToken extends Token {
   /// The tag handle used in the document.
   final String handle;
 
   /// The tag prefix that the handle maps to.
   final String prefix;
 
-  TagDirectiveToken(this.span, this.handle, this.prefix);
+  TagDirectiveToken(FileSpan span, this.handle, this.prefix,
+      {super.leadingLayout, super.trailingLayout})
+      : super(TokenType.tagDirective, span);
 
   @override
   String toString() => 'TAG_DIRECTIVE $handle $prefix';
 }
 
 /// A token representing an anchor (`&foo`).
-class AnchorToken implements Token {
-  @override
-  TokenType get type => TokenType.anchor;
-  @override
-  final FileSpan span;
-
+class AnchorToken extends Token {
   final String name;
 
-  AnchorToken(this.span, this.name);
+  AnchorToken(FileSpan span, this.name,
+      {super.leadingLayout, super.trailingLayout})
+      : super(TokenType.anchor, span);
 
   @override
   String toString() => 'ANCHOR $name';
 }
 
 /// A token representing an alias (`*foo`).
-class AliasToken implements Token {
-  @override
-  TokenType get type => TokenType.alias;
-  @override
-  final FileSpan span;
-
+class AliasToken extends Token {
   final String name;
 
-  AliasToken(this.span, this.name);
+  AliasToken(FileSpan span, this.name,
+      {super.leadingLayout, super.trailingLayout})
+      : super(TokenType.alias, span);
 
   @override
   String toString() => 'ALIAS $name';
 }
 
 /// A token representing a tag (`!foo`).
-class TagToken implements Token {
-  @override
-  TokenType get type => TokenType.tag;
-  @override
-  final FileSpan span;
-
+class TagToken extends Token {
   /// The tag handle for named tags.
   final String? handle;
 
   /// The tag suffix.
   final String suffix;
 
-  TagToken(this.span, this.handle, this.suffix);
+  TagToken(FileSpan span, this.handle, this.suffix,
+      {super.leadingLayout, super.trailingLayout})
+      : super(TokenType.tag, span);
 
   @override
   String toString() => 'TAG $handle $suffix';
 }
 
 /// A scalar value.
-class ScalarToken implements Token {
-  @override
-  TokenType get type => TokenType.scalar;
-  @override
-  final FileSpan span;
-
+class ScalarToken extends Token {
   /// The unparsed contents of the value..
   final String value;
 
   /// The style of the scalar in the original source.
   final ScalarStyle style;
 
-  ScalarToken(this.span, this.value, this.style);
+  ScalarToken(FileSpan span, this.value, this.style,
+      {super.leadingLayout, super.trailingLayout})
+      : super(TokenType.scalar, span);
 
   @override
   String toString() => 'SCALAR $style "$value"';

--- a/pkgs/yaml/lib/src/yaml_document.dart
+++ b/pkgs/yaml/lib/src/yaml_document.dart
@@ -9,6 +9,7 @@ import 'dart:collection';
 
 import 'package:source_span/source_span.dart';
 
+import 'layout.dart';
 import 'yaml_node.dart';
 
 /// A YAML document, complete with metadata.
@@ -18,6 +19,14 @@ class YamlDocument {
 
   /// The span covering the entire document.
   final SourceSpan span;
+
+  /// Leading layout elements (comments, indentation, blank lines) preceding
+  /// this document when layout retention is enabled.
+  final List<LayoutElement> leadingLayout;
+
+  /// Trailing layout elements following this document when layout retention
+  /// is enabled.
+  final List<LayoutElement> trailingLayout;
 
   /// The version directive for the document, if any.
   final VersionDirective? versionDirective;
@@ -37,7 +46,10 @@ class YamlDocument {
   /// @nodoc
   YamlDocument.internal(this.contents, this.span, this.versionDirective,
       List<TagDirective> tagDirectives,
-      {this.startImplicit = false, this.endImplicit = false})
+      {this.startImplicit = false,
+      this.endImplicit = false,
+      this.leadingLayout = const [],
+      this.trailingLayout = const []})
       : tagDirectives = UnmodifiableListView(tagDirectives);
 
   @override

--- a/pkgs/yaml/lib/src/yaml_document.dart
+++ b/pkgs/yaml/lib/src/yaml_document.dart
@@ -41,6 +41,13 @@ class YamlDocument {
   /// Whether the end of the document was implicit (versus explicit via `...`).
   final bool endImplicit;
 
+  /// The source span of the document start marker (`---`), or `null` if
+  /// implicit.
+  final SourceSpan? startMarkerSpan;
+
+  /// The source span of the document end marker (`...`), or `null` if implicit.
+  final SourceSpan? endMarkerSpan;
+
   /// Users of the library should not use this constructor.
   ///
   /// @nodoc
@@ -48,6 +55,8 @@ class YamlDocument {
       List<TagDirective> tagDirectives,
       {this.startImplicit = false,
       this.endImplicit = false,
+      this.startMarkerSpan,
+      this.endMarkerSpan,
       this.leadingLayout = const [],
       this.trailingLayout = const []})
       : tagDirectives = UnmodifiableListView(tagDirectives);

--- a/pkgs/yaml/lib/src/yaml_node.dart
+++ b/pkgs/yaml/lib/src/yaml_node.dart
@@ -11,6 +11,7 @@ import 'package:collection/collection.dart';
 import 'package:source_span/source_span.dart';
 
 import 'event.dart';
+import 'layout.dart';
 import 'null_span.dart';
 import 'style.dart';
 import 'yaml_node_wrapper.dart';
@@ -31,6 +32,16 @@ abstract class YamlNode {
   /// this node.
   SourceSpan get span => _span;
   SourceSpan _span;
+
+  /// Leading layout elements (comments, indentation, blank lines) preceding
+  /// this node when layout retention is enabled.
+  List<LayoutElement> get leadingLayout => _leadingLayout;
+  List<LayoutElement> _leadingLayout = const [];
+
+  /// Trailing layout elements (same-line comments or whitespace) following
+  /// this node when layout retention is enabled.
+  List<LayoutElement> get trailingLayout => _trailingLayout;
+  List<LayoutElement> _trailingLayout = const [];
 
   YamlNode._(this._span);
 
@@ -92,6 +103,11 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
 
   @override
   dynamic operator [](Object? key) => nodes[key]?.value;
+
+  /// The source span of the association colon (`:`) for [key], or `null`
+  /// if this is an explicit key without a colon or the key does not exist.
+  SourceSpan? colonSpan(Object? key) => _colonSpans?[key];
+  Map<dynamic, SourceSpan>? _colonSpans;
 }
 
 // TODO(nweiz): Use UnmodifiableListMixin when issue 18970 is fixed.
@@ -147,6 +163,15 @@ class YamlList extends YamlNode with collection.ListMixin {
   void operator []=(int index, Object? value) {
     throw UnsupportedError('Cannot modify an unmodifiable List');
   }
+
+  /// The source span of the sequence entry indicator (`-`) for the element
+  /// at [index], or `null` if this is a flow list or the index is out of
+  /// bounds.
+  SourceSpan? dashSpan(int index) =>
+      _dashSpans != null && index >= 0 && index < _dashSpans!.length
+          ? _dashSpans![index]
+          : null;
+  List<SourceSpan?>? _dashSpans;
 }
 
 /// A wrapped scalar value parsed from YAML.
@@ -188,4 +213,30 @@ class YamlScalar extends YamlNode {
 /// This method is not exposed publicly.
 void setSpan(YamlNode node, SourceSpan span) {
   node._span = span;
+}
+
+/// Sets the layout elements of a [YamlNode].
+///
+/// This method is not exposed publicly.
+void setLayout(
+  YamlNode node, {
+  List<LayoutElement> leading = const [],
+  List<LayoutElement> trailing = const [],
+}) {
+  node._leadingLayout = leading;
+  node._trailingLayout = trailing;
+}
+
+/// Sets the colon spans for entries in a [YamlMap].
+///
+/// This method is not exposed publicly.
+void setColonSpans(YamlMap map, Map<dynamic, SourceSpan> colonSpans) {
+  map._colonSpans = colonSpans;
+}
+
+/// Sets the dash spans for entries in a [YamlList].
+///
+/// This method is not exposed publicly.
+void setDashSpans(YamlList list, List<SourceSpan?> dashSpans) {
+  list._dashSpans = dashSpans;
 }

--- a/pkgs/yaml/lib/src/yaml_node.dart
+++ b/pkgs/yaml/lib/src/yaml_node.dart
@@ -43,6 +43,11 @@ abstract class YamlNode {
   List<LayoutElement> get trailingLayout => _trailingLayout;
   List<LayoutElement> _trailingLayout = const [];
 
+  /// The source span of the anchor definition (`&anchor`), or `null` if this
+  /// node does not define an anchor.
+  SourceSpan? get anchorSpan => _anchorSpan;
+  SourceSpan? _anchorSpan;
+
   YamlNode._(this._span);
 
   /// The inner value of this node.
@@ -108,6 +113,28 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
   /// if this is an explicit key without a colon or the key does not exist.
   SourceSpan? colonSpan(Object? key) => _colonSpans?[key];
   Map<dynamic, SourceSpan>? _colonSpans;
+
+  /// The source span of the entire entry for [key], including delimiters
+  /// and attached layout comments, or `null` if layout retention is disabled.
+  SourceSpan? entrySpan(Object? key) => _entrySpans?[key];
+  Map<dynamic, SourceSpan>? _entrySpans;
+
+  /// The source span of the alias reference (`*alias`) for [key], or `null`
+  /// if the value was not parsed from an alias reference.
+  SourceSpan? aliasSpan(Object? key) => _aliasSpans?[key];
+  Map<dynamic, SourceSpan>? _aliasSpans;
+
+  /// The source span of the separating comma (`,`) for [key] in a flow map.
+  SourceSpan? commaSpan(Object? key) => _commaSpans?[key];
+  Map<dynamic, SourceSpan>? _commaSpans;
+
+  /// The source span of the opening brace (`{`) for a flow map, or `null`.
+  SourceSpan? get openSpan => _openSpan;
+  SourceSpan? _openSpan;
+
+  /// The source span of the closing brace (`}`) for a flow map, or `null`.
+  SourceSpan? get closeSpan => _closeSpan;
+  SourceSpan? _closeSpan;
 }
 
 // TODO(nweiz): Use UnmodifiableListMixin when issue 18970 is fixed.
@@ -172,6 +199,37 @@ class YamlList extends YamlNode with collection.ListMixin {
           ? _dashSpans![index]
           : null;
   List<SourceSpan?>? _dashSpans;
+
+  /// The source span of the entire entry for [index], including delimiters
+  /// and attached layout comments, or `null` if layout retention is disabled.
+  SourceSpan? entrySpan(int index) =>
+      _entrySpans != null && index >= 0 && index < _entrySpans!.length
+          ? _entrySpans![index]
+          : null;
+  List<SourceSpan?>? _entrySpans;
+
+  /// The source span of the alias reference (`*alias`) for the element at
+  /// [index], or `null` if the item was not parsed from an alias reference.
+  SourceSpan? aliasSpan(int index) =>
+      _aliasSpans != null && index >= 0 && index < _aliasSpans!.length
+          ? _aliasSpans![index]
+          : null;
+  List<SourceSpan?>? _aliasSpans;
+
+  /// The source span of the separating comma (`,`) for [index] in a flow list.
+  SourceSpan? commaSpan(int index) =>
+      _commaSpans != null && index >= 0 && index < _commaSpans!.length
+          ? _commaSpans![index]
+          : null;
+  List<SourceSpan?>? _commaSpans;
+
+  /// The source span of the opening bracket (`[`) for a flow list, or `null`.
+  SourceSpan? get openSpan => _openSpan;
+  SourceSpan? _openSpan;
+
+  /// The source span of the closing bracket (`]`) for a flow list, or `null`.
+  SourceSpan? get closeSpan => _closeSpan;
+  SourceSpan? _closeSpan;
 }
 
 /// A wrapped scalar value parsed from YAML.
@@ -234,9 +292,56 @@ void setColonSpans(YamlMap map, Map<dynamic, SourceSpan> colonSpans) {
   map._colonSpans = colonSpans;
 }
 
+/// Sets all layout spans for entries in a [YamlMap].
+///
+/// This method is not exposed publicly.
+void setMapLayoutSpans(
+  YamlMap map, {
+  Map<dynamic, SourceSpan>? colonSpans,
+  Map<dynamic, SourceSpan>? entrySpans,
+  Map<dynamic, SourceSpan>? aliasSpans,
+  Map<dynamic, SourceSpan>? commaSpans,
+  SourceSpan? openSpan,
+  SourceSpan? closeSpan,
+}) {
+  map._colonSpans = colonSpans;
+  map._entrySpans = entrySpans;
+  map._aliasSpans = aliasSpans;
+  map._commaSpans = commaSpans;
+  map._openSpan = openSpan;
+  map._closeSpan = closeSpan;
+}
+
 /// Sets the dash spans for entries in a [YamlList].
 ///
 /// This method is not exposed publicly.
 void setDashSpans(YamlList list, List<SourceSpan?> dashSpans) {
   list._dashSpans = dashSpans;
+}
+
+/// Sets all layout spans for entries in a [YamlList].
+///
+/// This method is not exposed publicly.
+void setListLayoutSpans(
+  YamlList list, {
+  List<SourceSpan?>? dashSpans,
+  List<SourceSpan?>? entrySpans,
+  List<SourceSpan?>? aliasSpans,
+  List<SourceSpan?>? commaSpans,
+  SourceSpan? openSpan,
+  SourceSpan? closeSpan,
+}) {
+  list._dashSpans = dashSpans;
+  list._entrySpans = entrySpans;
+  list._aliasSpans = aliasSpans;
+  list._commaSpans = commaSpans;
+  list._openSpan = openSpan;
+  list._closeSpan = closeSpan;
+}
+
+/// Sets the anchor definition span of a [YamlNode].
+///
+/// This method is not exposed publicly.
+void setAnchorSpan(YamlNode node, SourceSpan? anchorSpan) {
+  node._anchorSpan = anchorSpan;
 }

--- a/pkgs/yaml/lib/src/yaml_node_wrapper.dart
+++ b/pkgs/yaml/lib/src/yaml_node_wrapper.dart
@@ -10,6 +10,7 @@ import 'dart:collection';
 import 'package:collection/collection.dart' as pkg_collection;
 import 'package:source_span/source_span.dart';
 
+import 'layout.dart';
 import 'null_span.dart';
 import 'style.dart';
 import 'yaml_node.dart';
@@ -25,6 +26,15 @@ class YamlMapWrapper extends MapBase
 
   @override
   final SourceSpan span;
+
+  @override
+  List<LayoutElement> get leadingLayout => const [];
+
+  @override
+  List<LayoutElement> get trailingLayout => const [];
+
+  @override
+  SourceSpan? colonSpan(Object? key) => null;
 
   @override
   final Map<dynamic, YamlNode> nodes;
@@ -101,6 +111,15 @@ class YamlListWrapper extends ListBase implements YamlList {
 
   @override
   final SourceSpan span;
+
+  @override
+  List<LayoutElement> get leadingLayout => const [];
+
+  @override
+  List<LayoutElement> get trailingLayout => const [];
+
+  @override
+  SourceSpan? dashSpan(int index) => null;
 
   @override
   final List<YamlNode> nodes;

--- a/pkgs/yaml/lib/src/yaml_node_wrapper.dart
+++ b/pkgs/yaml/lib/src/yaml_node_wrapper.dart
@@ -34,7 +34,25 @@ class YamlMapWrapper extends MapBase
   List<LayoutElement> get trailingLayout => const [];
 
   @override
+  SourceSpan? get anchorSpan => null;
+
+  @override
   SourceSpan? colonSpan(Object? key) => null;
+
+  @override
+  SourceSpan? entrySpan(Object? key) => null;
+
+  @override
+  SourceSpan? aliasSpan(Object? key) => null;
+
+  @override
+  SourceSpan? commaSpan(Object? key) => null;
+
+  @override
+  SourceSpan? get openSpan => null;
+
+  @override
+  SourceSpan? get closeSpan => null;
 
   @override
   final Map<dynamic, YamlNode> nodes;
@@ -119,7 +137,25 @@ class YamlListWrapper extends ListBase implements YamlList {
   List<LayoutElement> get trailingLayout => const [];
 
   @override
+  SourceSpan? get anchorSpan => null;
+
+  @override
   SourceSpan? dashSpan(int index) => null;
+
+  @override
+  SourceSpan? entrySpan(int index) => null;
+
+  @override
+  SourceSpan? aliasSpan(int index) => null;
+
+  @override
+  SourceSpan? commaSpan(int index) => null;
+
+  @override
+  SourceSpan? get openSpan => null;
+
+  @override
+  SourceSpan? get closeSpan => null;
 
   @override
   final List<YamlNode> nodes;

--- a/pkgs/yaml/lib/yaml.dart
+++ b/pkgs/yaml/lib/yaml.dart
@@ -13,11 +13,13 @@ import 'src/yaml_exception.dart';
 import 'src/yaml_node.dart';
 
 export 'src/error_listener.dart';
+export 'src/layout.dart';
 export 'src/style.dart';
 export 'src/utils.dart' show YamlWarningCallback, yamlWarningCallback;
 export 'src/yaml_document.dart';
 export 'src/yaml_exception.dart';
-export 'src/yaml_node.dart' hide setSpan;
+export 'src/yaml_node.dart'
+    hide setColonSpans, setDashSpans, setLayout, setSpan;
 
 /// Loads a single document from a YAML string.
 ///
@@ -37,12 +39,19 @@ export 'src/yaml_node.dart' hide setSpan;
 /// return invalid or synthetic nodes. If [errorListener] is also supplied, its
 /// onError method will be called for each error recovered from. It is not valid
 /// to provide [errorListener] if [recover] is false.
+///
+/// If [retainLayout] is true, preserves non-semantic source layout elements
+/// (comments, whitespace, newlines) and source spans for colons and hyphens.
 dynamic loadYaml(String yaml,
-        {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) =>
+        {Uri? sourceUrl,
+        bool recover = false,
+        ErrorListener? errorListener,
+        bool retainLayout = false}) =>
     loadYamlNode(yaml,
             sourceUrl: sourceUrl,
             recover: recover,
-            errorListener: errorListener)
+            errorListener: errorListener,
+            retainLayout: retainLayout)
         .value;
 
 /// Loads a single document from a YAML string as a [YamlNode].
@@ -50,12 +59,19 @@ dynamic loadYaml(String yaml,
 /// This is just like [loadYaml], except that where [loadYaml] would return a
 /// normal Dart value this returns a [YamlNode] instead. This allows the caller
 /// to be confident that the return value will always be a [YamlNode].
+///
+/// If [retainLayout] is true, preserves non-semantic source layout elements
+/// (comments, whitespace, newlines) and source spans for colons and hyphens.
 YamlNode loadYamlNode(String yaml,
-        {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) =>
+        {Uri? sourceUrl,
+        bool recover = false,
+        ErrorListener? errorListener,
+        bool retainLayout = false}) =>
     loadYamlDocument(yaml,
             sourceUrl: sourceUrl,
             recover: recover,
-            errorListener: errorListener)
+            errorListener: errorListener,
+            retainLayout: retainLayout)
         .contents;
 
 /// Loads a single document from a YAML string as a [YamlDocument].
@@ -63,10 +79,19 @@ YamlNode loadYamlNode(String yaml,
 /// This is just like [loadYaml], except that where [loadYaml] would return a
 /// normal Dart value this returns a [YamlDocument] instead. This allows the
 /// caller to access document metadata.
+///
+/// If [retainLayout] is true, preserves non-semantic source layout elements
+/// (comments, whitespace, newlines) and source spans for colons and hyphens.
 YamlDocument loadYamlDocument(String yaml,
-    {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) {
+    {Uri? sourceUrl,
+    bool recover = false,
+    ErrorListener? errorListener,
+    bool retainLayout = false}) {
   var loader = Loader(yaml,
-      sourceUrl: sourceUrl, recover: recover, errorListener: errorListener);
+      sourceUrl: sourceUrl,
+      recover: recover,
+      errorListener: errorListener,
+      retainLayout: retainLayout);
   var document = loader.load();
   if (document == null) {
     return YamlDocument.internal(YamlScalar.internalWithSpan(null, loader.span),
@@ -91,8 +116,12 @@ YamlDocument loadYamlDocument(String yaml,
 ///
 /// If [sourceUrl] is passed, it's used as the URL from which the YAML
 /// originated for error reporting.
-YamlList loadYamlStream(String yaml, {Uri? sourceUrl}) {
-  var loader = Loader(yaml, sourceUrl: sourceUrl);
+///
+/// If [retainLayout] is true, preserves non-semantic source layout elements
+/// (comments, whitespace, newlines) and source spans for colons and hyphens.
+YamlList loadYamlStream(String yaml,
+    {Uri? sourceUrl, bool retainLayout = false}) {
+  var loader = Loader(yaml, sourceUrl: sourceUrl, retainLayout: retainLayout);
 
   var documents = <YamlDocument>[];
   var document = loader.load();
@@ -113,8 +142,12 @@ YamlList loadYamlStream(String yaml, {Uri? sourceUrl}) {
 ///
 /// This is like [loadYamlStream], except that it returns [YamlDocument]s with
 /// metadata wrapping the document contents.
-List<YamlDocument> loadYamlDocuments(String yaml, {Uri? sourceUrl}) {
-  var loader = Loader(yaml, sourceUrl: sourceUrl);
+///
+/// If [retainLayout] is true, preserves non-semantic source layout elements
+/// (comments, whitespace, newlines) and source spans for colons and hyphens.
+List<YamlDocument> loadYamlDocuments(String yaml,
+    {Uri? sourceUrl, bool retainLayout = false}) {
+  var loader = Loader(yaml, sourceUrl: sourceUrl, retainLayout: retainLayout);
 
   var documents = <YamlDocument>[];
   var document = loader.load();

--- a/pkgs/yaml/test/layout_test.dart
+++ b/pkgs/yaml/test/layout_test.dart
@@ -1,0 +1,175 @@
+// Copyright (c) 2026, the Dart project authors.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group('retainLayout: false (default)', () {
+    test('does not retain layout elements or spans by default', () {
+      const yaml = '''
+# Leading comment
+key: value # Trailing comment
+list:
+  - item1
+''';
+      final doc = loadYamlDocument(yaml);
+      final map = doc.contents as YamlMap;
+      expect(map.leadingLayout, isEmpty);
+      expect(map.trailingLayout, isEmpty);
+      expect(map.colonSpan('key'), isNull);
+
+      final keyNode = map.nodes.keys.first as YamlNode;
+      expect(keyNode.leadingLayout, isEmpty);
+      expect(keyNode.trailingLayout, isEmpty);
+
+      final valNode = map.nodes['key']!;
+      expect(valNode.leadingLayout, isEmpty);
+      expect(valNode.trailingLayout, isEmpty);
+
+      final list = map.nodes['list']! as YamlList;
+      expect(list.dashSpan(0), isNull);
+    });
+  });
+
+  group('retainLayout: true', () {
+    test('captures leading and trailing comments on mapping entries', () {
+      const yaml = '''
+# Key comment
+name: Bob # Same-line comment
+# Another comment
+age: 42
+''';
+      final doc = loadYamlDocument(yaml, retainLayout: true);
+      final map = doc.contents as YamlMap;
+
+      final nameKey = map.nodes.keys.first as YamlScalar;
+      expect(
+        nameKey.leadingLayout.whereType<CommentElement>().map((c) => c.text),
+        contains('# Key comment'),
+      );
+
+      final nameVal = map.nodes['name']! as YamlScalar;
+      expect(
+        nameVal.trailingLayout.whereType<CommentElement>().map((c) => c.text),
+        contains('# Same-line comment'),
+      );
+      final comment = nameVal.trailingLayout.whereType<CommentElement>().first;
+      expect(comment.isTrailing, isTrue);
+
+      final ageKey = map.nodes.keys.elementAt(1) as YamlScalar;
+      expect(
+        ageKey.leadingLayout.whereType<CommentElement>().map((c) => c.text),
+        contains('# Another comment'),
+      );
+    });
+
+    test('captures colon spans for block and flow mappings', () {
+      const yaml = '''
+block_key: block_value
+flow: { a: 1, b: 2 }
+''';
+      final map = loadYaml(yaml, retainLayout: true) as YamlMap;
+
+      final blockColon = map.colonSpan('block_key');
+      expect(blockColon, isNotNull);
+      expect(blockColon!.text, ':');
+
+      // Lookup with YamlScalar key
+      final keyScalar = map.nodes.keys.first;
+      expect(map.colonSpan(keyScalar), blockColon);
+
+      final flowMap = map.nodes['flow']! as YamlMap;
+      final aColon = flowMap.colonSpan('a');
+      expect(aColon, isNotNull);
+      expect(aColon!.text, ':');
+
+      final bColon = flowMap.colonSpan('b');
+      expect(bColon, isNotNull);
+      expect(bColon!.text, ':');
+    });
+
+    test('captures dash spans for block sequence entries', () {
+      const yaml = '''
+items:
+  - first
+  - second
+  - third
+''';
+      final map = loadYaml(yaml, retainLayout: true) as YamlMap;
+      final list = map.nodes['items']! as YamlList;
+
+      expect(list.dashSpan(0), isNotNull);
+      expect(list.dashSpan(0)!.text, '-');
+      expect(list.dashSpan(1), isNotNull);
+      expect(list.dashSpan(1)!.text, '-');
+      expect(list.dashSpan(2), isNotNull);
+      expect(list.dashSpan(2)!.text, '-');
+      expect(list.dashSpan(3), isNull);
+    });
+
+    test('attaches comments preceding block sequence dashes to list items', () {
+      const yaml = '''
+list:
+  # Item one
+  - first
+  # Item two
+  - second
+''';
+      final map = loadYaml(yaml, retainLayout: true) as YamlMap;
+      final list = map.nodes['list']! as YamlList;
+
+      final item1 = list.nodes[0];
+      expect(
+        item1.leadingLayout.whereType<CommentElement>().map((c) => c.text),
+        contains('# Item one'),
+      );
+
+      final item2 = list.nodes[1];
+      expect(
+        item2.leadingLayout.whereType<CommentElement>().map((c) => c.text),
+        contains('# Item two'),
+      );
+    });
+
+    test('captures whitespace and newline elements', () {
+      const yaml = 'a: 1\n\nb: 2\n';
+      final map = loadYaml(yaml, retainLayout: true) as YamlMap;
+
+      final bKey = map.nodes.keys.elementAt(1) as YamlScalar;
+      final newlines = bKey.leadingLayout.whereType<NewlineElement>();
+      expect(newlines, isNotEmpty);
+    });
+
+    test('supports pattern matching on sealed LayoutElement hierarchy', () {
+      const yaml = '# Comment\nkey: value\n';
+      final map = loadYaml(yaml, retainLayout: true) as YamlMap;
+      final key = map.nodes.keys.first as YamlScalar;
+
+      for (final el in key.leadingLayout) {
+        final description = switch (el) {
+          CommentElement(:final text, :final isTrailing) =>
+            'comment(trailing: $isTrailing): $text',
+          WhitespaceElement(:final text) => 'whitespace(${text.length})',
+          NewlineElement(:final text) => 'newline(${text.length})',
+        };
+        expect(description, isNotEmpty);
+      }
+    });
+
+    test('wrappers preserve layout retention accessors', () {
+      final map = YamlMap.wrap({'key': 'value'});
+      expect(map.colonSpan('key'), isNull);
+      expect(map.leadingLayout, isEmpty);
+      expect(map.trailingLayout, isEmpty);
+
+      final list = YamlList.wrap(['item']);
+      expect(list.dashSpan(0), isNull);
+      expect(list.leadingLayout, isEmpty);
+      expect(list.trailingLayout, isEmpty);
+    });
+  });
+}

--- a/pkgs/yaml/test/layout_test.dart
+++ b/pkgs/yaml/test/layout_test.dart
@@ -160,14 +160,101 @@ list:
       }
     });
 
+    test('captures entrySpans, openSpan, closeSpan for mappings', () {
+      const yaml = '''
+root:
+  # comment a
+  a: 1
+  # comment b
+  b: 2
+flow: { x: 10, y: 20 }
+''';
+      final doc = loadYamlDocument(yaml, retainLayout: true);
+      final root = doc.contents as YamlMap;
+      final inner = root.nodes['root']! as YamlMap;
+
+      expect(inner.entrySpan('a'), isNotNull);
+      expect(inner.entrySpan('b'), isNotNull);
+
+      // Verify that entry 'a' starts before '# comment a' and ends at 'b'
+      final entryASpan = inner.entrySpan('a')!;
+      expect(entryASpan.text, contains('# comment a'));
+      expect(entryASpan.text, contains('a: 1'));
+
+      final flow = root.nodes['flow']! as YamlMap;
+      expect(flow.openSpan, isNotNull);
+      expect(flow.openSpan!.text, '{');
+      expect(flow.closeSpan, isNotNull);
+      expect(flow.closeSpan!.text, '}');
+      expect(flow.commaSpan('y'), isNotNull);
+      expect(flow.commaSpan('y')!.text, ',');
+      expect(flow.entrySpan('x'), isNotNull);
+      expect(flow.entrySpan('y'), isNotNull);
+    });
+
+    test('captures entrySpans, openSpan, closeSpan for lists', () {
+      const yaml = '''
+items:
+  - 10
+  - 20
+flow: [1, 2, 3]
+''';
+      final root = loadYaml(yaml, retainLayout: true) as YamlMap;
+      final items = root.nodes['items']! as YamlList;
+      expect(items.entrySpan(0), isNotNull);
+      expect(items.entrySpan(1), isNotNull);
+      expect(items.entrySpan(0)!.text, contains('10'));
+      expect(items.entrySpan(1)!.text, contains('20'));
+
+      final flow = root.nodes['flow']! as YamlList;
+      expect(flow.openSpan, isNotNull);
+      expect(flow.openSpan!.text, '[');
+      expect(flow.closeSpan, isNotNull);
+      expect(flow.closeSpan!.text, ']');
+      expect(flow.commaSpan(1), isNotNull);
+      expect(flow.commaSpan(1)!.text, ',');
+    });
+
+    test('captures anchorSpan, aliasSpan, and document markers', () {
+      const yaml = '''
+---
+anchor_item: &my_anchor value
+alias_item: *my_anchor
+...
+''';
+      final doc = loadYamlDocument(yaml, retainLayout: true);
+      expect(doc.startMarkerSpan, isNotNull);
+      expect(doc.startMarkerSpan!.text, '---');
+      expect(doc.endMarkerSpan, isNotNull);
+      expect(doc.endMarkerSpan!.text, '...');
+
+      final root = doc.contents as YamlMap;
+      final anchorNode = root.nodes['anchor_item']!;
+      expect(anchorNode.anchorSpan, isNotNull);
+      expect(anchorNode.anchorSpan!.text, '&my_anchor');
+
+      expect(root.aliasSpan('alias_item'), isNotNull);
+      expect(root.aliasSpan('alias_item')!.text, '*my_anchor');
+    });
+
     test('wrappers preserve layout retention accessors', () {
       final map = YamlMap.wrap({'key': 'value'});
       expect(map.colonSpan('key'), isNull);
+      expect(map.entrySpan('key'), isNull);
+      expect(map.aliasSpan('key'), isNull);
+      expect(map.commaSpan('key'), isNull);
+      expect(map.openSpan, isNull);
+      expect(map.closeSpan, isNull);
       expect(map.leadingLayout, isEmpty);
       expect(map.trailingLayout, isEmpty);
 
       final list = YamlList.wrap(['item']);
       expect(list.dashSpan(0), isNull);
+      expect(list.entrySpan(0), isNull);
+      expect(list.aliasSpan(0), isNull);
+      expect(list.commaSpan(0), isNull);
+      expect(list.openSpan, isNull);
+      expect(list.closeSpan, isNull);
       expect(list.leadingLayout, isEmpty);
       expect(list.trailingLayout, isEmpty);
     });


### PR DESCRIPTION
## Overview
This PR adds optional layout retention to `package:yaml` without impacting existing parsing performance or backwards compatibility when disabled.

When `retainLayout: true` is passed to `loadYaml`, `loadYamlNode`, `loadYamlDocument`, `loadYamlStream`, or `Loader`:
- Captures source layout elements (`LayoutElement`: `CommentElement`, `WhitespaceElement`, `NewlineElement`) in `leadingLayout` and `trailingLayout` on tokens, events, `YamlNode`, and `YamlDocument`.
- Distinguishes same-line trailing comments (`CommentElement.isTrailing: true`) from full-line/preceding comments (`CommentElement.isTrailing: false`).
- Captures delimiter spans:
  - `YamlMap.colonSpan(key)`: the `SourceSpan` of the association colon (`:`) for mapping entries.
  - `YamlList.dashSpan(index)`: the `SourceSpan` of the sequence hyphen (`-`) for sequence entries.
- Pattern matching support via sealed `LayoutElement` hierarchy.

When `retainLayout: false` (default):
- 100% backwards compatible.
- Zero extra allocations for layout element lists and span maps.
- All 585 existing tests in `package:yaml` pass without modification.

TAG=agy
CONV=eabffc54-0045-490f-beb6-67e4668362d1